### PR TITLE
perf: web performance audit fixes

### DIFF
--- a/apps/landing/next.config.mjs
+++ b/apps/landing/next.config.mjs
@@ -6,6 +6,29 @@ const nextConfig = {
   images: {
     qualities: [70, 75, 100]
   },
+  async headers() {
+    return [
+      {
+        // Immutable static assets: screenshots, fonts, images
+        source: '/:path(screenshots|fonts|images)/(.*)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable'
+          }
+        ]
+      },
+      {
+        source: '/favicon.ico',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=86400'
+          }
+        ]
+      }
+    ]
+  },
   async rewrites() {
     return [
       {

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -24,7 +24,6 @@
     "@radix-ui/react-tooltip": "^1.1.6",
     "@remixicon/react": "^4.6.0",
     "@repo/shared": "workspace:*",
-    "@tabler/icons-react": "^3.31.0",
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/postcss": "^4.2.1",
     "@vercel/analytics": "^1.4.1",

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -163,7 +163,7 @@ html[lang="zh"] body {
 @font-face {
   font-family: "NanumPenScript";
   font-weight: 400;
-  font-display: block;
+  font-display: swap;
   font-style: normal;
   font-named-instance: "Regular";
   src: url("/fonts/NanumPenScript.woff2") format("woff2");
@@ -218,8 +218,9 @@ a {
 }
 
 ::view-transition-new(root) {
+  /* GIF is loaded on-demand via JS before triggering the transition, not eagerly via CSS */
   mask:
-    var(--transition-mask, url("/images/i-love-you-love.gif")) center / 0
+    var(--transition-mask, none) center / 0
     no-repeat;
   animation: scale 1.5s;
   animation-fill-mode: both;

--- a/apps/landing/src/components/ui/HeroImage.tsx
+++ b/apps/landing/src/components/ui/HeroImage.tsx
@@ -10,7 +10,7 @@ export default function HeroImage() {
             className="rounded object-contain shadow-2xl md:rounded-xl dark:hidden"
             height={1600}
             priority={true}
-            quality={100}
+            quality={75}
             src="/screenshots/dashboard.png"
             width={2400}
           />
@@ -19,7 +19,7 @@ export default function HeroImage() {
             className="hidden rounded object-contain shadow-2xl md:rounded-xl dark:block dark:shadow-indigo-600/10"
             height={1600}
             priority={true}
-            quality={100}
+            quality={75}
             src="/screenshots/dashboard-dark.png"
             width={2400}
           />

--- a/apps/landing/src/components/ui/SnapshotPlaygroundScroll.tsx
+++ b/apps/landing/src/components/ui/SnapshotPlaygroundScroll.tsx
@@ -330,7 +330,7 @@ function SnapshotPlaygroundScroll({ screenshots }: { screenshots: Screenshot[] }
                             isLoaded ? 'opacity-100' : 'opacity-0'
                           )}
                           height={IMAGE_HEIGHT}
-                          loading={index >= 3 ? 'eager' : undefined}
+                  loading={index >= 3 ? 'lazy' : undefined}
                           onLoad={() => handleImageLoad(index)}
                           priority={index < 3}
                           quality={70}


### PR DESCRIPTION
## Web Performance Audit — Fixes

Findings and fixes from a codebase audit of `dockerman.app` (Next.js 16 + Tailwind CSS v4 + Turbo).

### Fixes

**Critical: Image lazy-loading bug** (`SnapshotPlaygroundScroll.tsx`)
`loading={index >= 3 ? 'eager' : undefined}` should be `'lazy'`. This caused all 14 playground screenshots (~5.4MB of PNGs before optimizer compression) to download eagerly on page load. Only the first 3 are visible; the rest should be deferred.

**LCP image quality** (`HeroImage.tsx`)
Both hero images used `quality={100}`, the maximum. Changed to `quality={75}`, which is visually indistinguishable for UI screenshots but generates significantly smaller optimized images from Next.js's image pipeline.

**Render-blocking font** (`globals.css`)
`NanumPenScript` (a decorative handwriting font used for accent text) used `font-display: block`, which holds back text rendering until the font arrives. Changed to `font-display: swap` — text renders immediately with a fallback and swaps when the font loads.

**797 KB GIF eagerly downloaded on CSS parse** (`globals.css`)
`/images/i-love-you-love.gif` was referenced as a CSS `mask` fallback in `::view-transition-new(root)`. Browsers pre-fetch URLs in CSS at parse time — before any user interaction. The GIF is only needed for the theme-toggle animation (which already sets `--transition-mask` via JS). Changed the fallback from the URL to `none` to defer the fetch until the user actually clicks the toggle.

**Long-term caching for static assets** (`next.config.mjs`)
Added `Cache-Control: public, max-age=31536000, immutable` for `/screenshots/*`, `/fonts/*`, and `/images/*`. Previously these served with `max-age=0, must-revalidate`, forcing a conditional re-fetch on every page visit.

**Removed unused dependency**
`@tabler/icons-react` was listed in `package.json` but is never imported anywhere in the codebase.

### Not changed (informational)

- **Redirect on first visit** (`/` → `/en`): The middleware handles this at the edge and sets a 1-year cookie, so only the very first visit incurs the redirect hop. Acceptable tradeoff for i18n.
- **Dual animation libraries (GSAP + Motion)**: Both are legitimately used — GSAP for scroll-triggered animations via Lenis, Motion for component-level transitions. Consolidating would be a larger refactor.
- **90 KB HTML, uncompressed in headers**: Vercel handles Brotli transparently for browser requests; the `curl -sI` probe didn't advertise `Accept-Encoding: br` correctly.

---

_This PR was generated with [Oz](https://www.warp.dev/oz)._
