### PR TITLE
feat(landing): mobile responsive layout

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/download/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/download/page.tsx
@@ -77,7 +77,7 @@ export default async function DownloadPage({ params }: { params: Promise<{ local
     <main>
       <DownloadHero locale={l} />
 
-      <section className="px-8 pt-20 pb-10">
+      <section className="px-5 pt-12 pb-8 sm:px-8 sm:pt-20 sm:pb-10">
         <div className="mx-auto max-w-[1140px]">
           <div className="mb-8 max-w-[680px]">
             <div

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -27,7 +27,7 @@ export default async function LandingPage({ params }: { params: Promise<{ locale
   return (
     <main>
       <Hero locale={l} />
-      <div className="relative px-8">
+      <div className="relative hidden px-5 md:block md:px-8">
         <LiveDashboard locale={l} />
       </div>
       <RuntimeStrip locale={l} />

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -38,10 +38,10 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
       <PricingHero locale={l} />
 
       {/* Countdown bar */}
-      <section className="px-8 pb-10">
+      <section className="px-5 pb-10 sm:px-8">
         <div className="mx-auto mt-2 max-w-[560px]">
           <div
-            className="flex flex-wrap items-center gap-5 rounded-[14px] border p-5"
+            className="flex flex-col items-center gap-4 rounded-[14px] border p-4 text-center sm:flex-row sm:flex-wrap sm:gap-5 sm:p-5 sm:text-left"
             style={{
               borderColor:
                 'color-mix(in srgb, var(--color-dm-warn) 30%, var(--color-dm-line-strong))',
@@ -69,11 +69,11 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
                 <path d="M12 7v5l3 2" />
               </svg>
             </div>
-            <div className="flex-1 text-left">
+            <div className="flex-1 sm:min-w-[200px]">
               <div className="font-semibold text-[13px] text-dm-ink">
                 {t('pricing.countdown.endsLead')}{' '}
                 <span
-                  className="ml-2 rounded px-[7px] py-[2px] font-[var(--font-dm-mono)] font-bold text-[10px] tracking-[0.04em]"
+                  className="ml-2 inline-block rounded px-[7px] py-[2px] font-[var(--font-dm-mono)] font-bold text-[10px] tracking-[0.04em]"
                   style={{ background: 'var(--color-dm-warn)', color: '#000' }}
                 >
                   {t('pricing.countdown.endsDate')}
@@ -93,11 +93,11 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
       </section>
 
       {/* Plans */}
-      <section className="px-8">
+      <section className="px-5 sm:px-8">
         <div className="mx-auto max-w-[1140px]">
           <div
             className="grid items-stretch gap-4"
-            style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))' }}
+            style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 280px), 1fr))' }}
           >
             {/* Free */}
             <PlanCard
@@ -210,9 +210,9 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
       <PricingFaq />
 
       {/* Final CTA */}
-      <section className="px-8 pt-20">
+      <section className="px-5 pt-16 sm:px-8 sm:pt-20">
         <div className="mx-auto max-w-[1140px]">
-          <div className="relative overflow-hidden rounded-[20px] border border-dm-line bg-dm-bg-elev px-10 py-16 text-center">
+          <div className="relative overflow-hidden rounded-[20px] border border-dm-line bg-dm-bg-elev px-6 py-12 text-center sm:px-10 sm:py-16">
             <div
               aria-hidden="true"
               className="pointer-events-none absolute inset-0"

--- a/apps/landing/src/components/changelog/ChangelogPageContent.tsx
+++ b/apps/landing/src/components/changelog/ChangelogPageContent.tsx
@@ -34,7 +34,7 @@ export default function ChangelogPageContent({ copy, entries, locale }: Props) {
   return (
     <>
       {/* page-head: kicker + italic-accent title + sub + toolbar */}
-      <section className="relative px-8 pt-16 pb-7">
+      <section className="relative overflow-hidden px-5 pt-12 pb-6 sm:px-8 sm:pt-16 sm:pb-7">
         <div className="mx-auto max-w-[1280px]">
           {/* kicker */}
           <span className="inline-flex items-center gap-2 rounded-full border border-dm-line-strong bg-dm-bg-elev px-[11px] py-[5px] font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-2 tracking-[0.02em]">
@@ -81,7 +81,7 @@ export default function ChangelogPageContent({ copy, entries, locale }: Props) {
       </section>
 
       {/* Layout: 220px TOC + releases */}
-      <section className="px-8 pb-20">
+      <section className="px-5 pb-16 sm:px-8 sm:pb-20">
         <div className="mx-auto max-w-[1280px]">
           <div className="grid gap-6 pt-8 md:grid-cols-[240px_minmax(0,1fr)] md:gap-[80px]">
             <aside className="hidden md:block">

--- a/apps/landing/src/components/download/DownloadHero.tsx
+++ b/apps/landing/src/components/download/DownloadHero.tsx
@@ -7,7 +7,7 @@ export async function DownloadHero({ locale }: { locale: Locale }) {
   const { latest } = downloadsConfig
   const releaseDate = formatDate(latest.releaseDate, locale)
   return (
-    <section className="relative px-8 pt-14 pb-10">
+    <section className="relative overflow-hidden px-5 pt-10 pb-8 sm:px-8 sm:pt-14 sm:pb-10">
       <div
         aria-hidden
         className="pointer-events-none absolute top-0 left-1/2 -z-[1] h-[420px] w-[900px] -translate-x-1/2 blur-[40px]"

--- a/apps/landing/src/components/download/HomebrewBlock.tsx
+++ b/apps/landing/src/components/download/HomebrewBlock.tsx
@@ -21,10 +21,10 @@ export function HomebrewBlock({ locale }: { locale: Locale }) {
   }
 
   return (
-    <section className="px-8">
+    <section className="px-5 sm:px-8">
       <div className="mx-auto max-w-[1140px]">
-        <div className="grid">
-          <div className="mx-auto flex w-full max-w-[620px] flex-col gap-[10px] rounded-[12px] border border-dm-line bg-dm-bg-elev p-[16px_18px]">
+        <div className="grid grid-cols-1">
+          <div className="mx-auto flex w-full min-w-0 max-w-[620px] flex-col gap-[10px] rounded-[12px] border border-dm-line bg-dm-bg-elev p-[16px_18px]">
             <div className="flex items-center gap-[10px]">
               <div className="grid h-7 w-7 place-items-center rounded-[7px] border border-dm-line bg-dm-bg-soft text-dm-ink-2">
                 <svg fill="currentColor" height="14" viewBox="0 0 24 24" width="14">
@@ -47,7 +47,7 @@ export function HomebrewBlock({ locale }: { locale: Locale }) {
               type="button"
             >
               <span style={{ color: 'var(--color-dm-accent-2)' }}>$</span>
-              <code className="flex-1 overflow-hidden truncate text-dm-ink">{cmd}</code>
+              <code className="min-w-0 flex-1 overflow-hidden truncate text-dm-ink">{cmd}</code>
               <span
                 aria-hidden="true"
                 className="grid h-[22px] w-[22px] flex-shrink-0 place-items-center rounded bg-dm-bg-elev text-dm-ink-3"

--- a/apps/landing/src/components/download/IntegrityBar.tsx
+++ b/apps/landing/src/components/download/IntegrityBar.tsx
@@ -6,9 +6,9 @@ export async function IntegrityBar({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
   const { latest } = downloadsConfig
   return (
-    <section className="px-8">
+    <section className="px-5 sm:px-8">
       <div className="mx-auto mt-10 max-w-[1140px]">
-        <div className="flex flex-wrap items-center gap-[18px] rounded-[12px] border border-dm-line bg-dm-bg-elev p-[18px_22px] text-[13px]">
+        <div className="flex flex-wrap items-center gap-4 rounded-[12px] border border-dm-line bg-dm-bg-elev px-4 py-4 text-[13px] sm:gap-[18px] sm:px-[22px] sm:py-[18px]">
           <div
             className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-[8px]"
             style={{

--- a/apps/landing/src/components/download/ReleasesTable.tsx
+++ b/apps/landing/src/components/download/ReleasesTable.tsx
@@ -6,7 +6,7 @@ import { downloadsConfig } from '@/config/downloads'
 export async function ReleasesTable({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
   return (
-    <section className="px-8 pt-20 pb-10">
+    <section className="px-5 pt-12 pb-8 sm:px-8 sm:pt-20 sm:pb-10">
       <div className="mx-auto max-w-[1140px]">
         <div className="mb-8 max-w-[680px]">
           <div
@@ -34,9 +34,8 @@ export async function ReleasesTable({ locale }: { locale: Locale }) {
             const note = translated === noteKey ? t('download.releases.fallbackNote') : translated
             return (
               <div
-                className="grid items-center gap-4 border-dm-line border-b px-[22px] py-[14px] last:border-b-0 hover:bg-dm-bg-soft"
+                className="grid grid-cols-[1fr_auto_auto] items-center gap-3 border-dm-line border-b px-4 py-[12px] last:border-b-0 hover:bg-dm-bg-soft sm:grid-cols-[120px_1fr_180px_80px] sm:gap-4 sm:px-[22px] sm:py-[14px]"
                 key={h.version}
-                style={{ gridTemplateColumns: '120px 1fr 180px 80px' }}
               >
                 <div className="font-[var(--font-dm-mono)] font-semibold text-[13px] tracking-[-0.01em]">
                   v{h.version}

--- a/apps/landing/src/components/landing/CtaFinal.tsx
+++ b/apps/landing/src/components/landing/CtaFinal.tsx
@@ -5,10 +5,10 @@ import Link from 'next/link'
 export async function CtaFinal({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
   return (
-    <section className="px-8">
-      <div className="mx-auto my-24 max-w-[1240px]">
+    <section className="px-5 sm:px-8">
+      <div className="mx-auto my-16 max-w-[1240px] sm:my-24">
         <div
-          className="relative overflow-hidden rounded-[24px] border border-dm-line-strong bg-dm-bg-elev px-12 py-20 text-center"
+          className="relative overflow-hidden rounded-[24px] border border-dm-line-strong bg-dm-bg-elev px-6 py-12 text-center sm:px-12 sm:py-20"
           style={{
             backgroundImage: `radial-gradient(ellipse at top right, color-mix(in srgb, var(--color-dm-accent-2) 15%, transparent), transparent 50%),
               radial-gradient(ellipse at bottom left, color-mix(in srgb, var(--color-dm-accent) 15%, transparent), transparent 50%)`

--- a/apps/landing/src/components/landing/FeaturesGrid.tsx
+++ b/apps/landing/src/components/landing/FeaturesGrid.tsx
@@ -5,7 +5,7 @@ import { PaletteViz } from './PaletteViz'
 export async function FeaturesGrid({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
   return (
-    <section className="px-8 py-24" id="features">
+    <section className="px-5 py-16 sm:px-8 sm:py-24" id="features">
       <div className="mx-auto max-w-[1240px]">
         <SectionHead t={t} />
         <div className="grid grid-cols-1 gap-4 md:auto-rows-[minmax(200px,auto)] md:grid-cols-6">
@@ -27,7 +27,7 @@ type TFn = (key: string, options?: Record<string, unknown>) => string
 
 function SectionHead({ t }: { t: TFn }) {
   return (
-    <div className="mb-12 flex max-w-[780px] flex-col gap-[14px]">
+    <div className="mb-10 flex max-w-[780px] flex-col gap-[14px] sm:mb-12">
       <div
         className="font-[var(--font-dm-mono)] text-[12px] tracking-[0.04em]"
         style={{ color: 'var(--color-dm-accent)' }}
@@ -89,7 +89,7 @@ function FeatCard({
   }
   return (
     <article
-      className={`relative flex flex-col overflow-hidden rounded-[14px] border border-dm-line bg-dm-bg-elev p-6 transition-all hover:-translate-y-px hover:border-dm-line-strong ${SHAPE_CLASSES[shape]}`}
+      className={`relative flex flex-col overflow-hidden rounded-[14px] border border-dm-line bg-dm-bg-elev p-5 transition-all hover:-translate-y-px hover:border-dm-line-strong sm:p-6 ${SHAPE_CLASSES[shape]}`}
     >
       <div
         className="mb-[14px] grid h-8 w-8 place-items-center rounded-[8px]"

--- a/apps/landing/src/components/landing/Hero.tsx
+++ b/apps/landing/src/components/landing/Hero.tsx
@@ -63,7 +63,7 @@ export function Hero({ locale }: { locale: Locale }) {
   }
 
   return (
-    <section className="relative overflow-hidden px-8 pt-16 pb-8">
+    <section className="relative overflow-hidden px-5 pt-12 pb-8 sm:px-8 sm:pt-16">
       <div
         aria-hidden
         className="pointer-events-none absolute top-0 left-1/2 -z-[1] h-[500px] w-[900px] -translate-x-1/2 blur-[40px]"
@@ -130,12 +130,12 @@ export function Hero({ locale }: { locale: Locale }) {
           {/* Inline copy install command */}
           <button
             aria-label={copied ? t('hero.copied') : t('hero.copyAria', { cmd: INSTALL_CMD })}
-            className="inline-flex cursor-pointer items-center gap-[10px] rounded-[10px] border border-dm-line bg-dm-bg-elev px-[14px] py-[10px] pr-3 font-[var(--font-dm-mono)] text-[13px] text-dm-ink-2 transition-colors hover:border-dm-line-strong"
+            className="inline-flex max-w-full cursor-pointer items-center gap-[10px] rounded-[10px] border border-dm-line bg-dm-bg-elev px-[12px] py-[10px] pr-3 font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-2 transition-colors hover:border-dm-line-strong sm:px-[14px] sm:text-[13px]"
             onClick={copyInstall}
             type="button"
           >
             <span style={{ color: 'var(--color-dm-accent)' }}>$</span>
-            <span>{INSTALL_CMD}</span>
+            <span className="overflow-hidden text-ellipsis whitespace-nowrap">{INSTALL_CMD}</span>
             <span
               aria-hidden="true"
               className="grid h-[22px] w-[22px] place-items-center rounded text-dm-ink-3"

--- a/apps/landing/src/components/landing/ModulesSection.tsx
+++ b/apps/landing/src/components/landing/ModulesSection.tsx
@@ -14,9 +14,9 @@ export async function ModulesSection({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
 
   return (
-    <section className="px-8 py-24" id="modules">
+    <section className="px-5 py-16 sm:px-8 sm:py-24" id="modules">
       <div className="mx-auto max-w-[1240px]">
-        <div className="mb-12 flex max-w-[780px] flex-col gap-[14px]">
+        <div className="mb-10 flex max-w-[780px] flex-col gap-[14px] sm:mb-12">
           <div
             className="font-[var(--font-dm-mono)] text-[12px] tracking-[0.04em]"
             style={{ color: 'var(--color-dm-accent)' }}
@@ -39,13 +39,13 @@ export async function ModulesSection({ locale }: { locale: Locale }) {
           </p>
         </div>
 
-        <div className="grid grid-cols-1 gap-x-12 gap-y-12 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-x-12 gap-y-10 md:grid-cols-2 md:gap-y-12">
           {MODULE_KEYS.map((key) => {
             const bullets = t(`modulesSection.modules.${key}.bullets`, {
               returnObjects: true
             }) as string[]
             return (
-              <article className="border-dm-line border-t pt-10" key={key}>
+              <article className="border-dm-line border-t pt-8 sm:pt-10" key={key}>
                 <div className="flex items-center justify-between pb-[18px] font-[var(--font-dm-mono)] text-[12px] text-dm-ink-4">
                   <span>{MODULE_NUMS[key]}</span>
                   <span

--- a/apps/landing/src/components/landing/RuntimeStrip.tsx
+++ b/apps/landing/src/components/landing/RuntimeStrip.tsx
@@ -7,7 +7,7 @@ export async function RuntimeStrip({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
   return (
     <section className="border-dm-line border-y bg-dm-bg-elev/50">
-      <div className="mx-auto flex max-w-[1240px] flex-wrap items-center justify-between gap-6 px-8 py-6 text-[12px] text-dm-ink-3">
+      <div className="mx-auto flex max-w-[1240px] flex-wrap items-center justify-between gap-x-6 gap-y-3 px-5 py-5 text-[12px] text-dm-ink-3 sm:px-8 sm:py-6">
         <span className="font-[var(--font-dm-mono)] uppercase tracking-wider">
           {t('runtimeStrip.label')}
         </span>

--- a/apps/landing/src/components/policy/PolicyShell.tsx
+++ b/apps/landing/src/components/policy/PolicyShell.tsx
@@ -14,7 +14,7 @@ export function PolicyHero({
   lastUpdated: string
 }) {
   return (
-    <section className="relative px-8 pt-24 pb-12">
+    <section className="relative overflow-hidden px-5 pt-16 pb-10 sm:px-8 sm:pt-24 sm:pb-12">
       <div
         aria-hidden
         className="pointer-events-none absolute top-10 left-1/2 -z-[1] h-[360px] w-[820px] -translate-x-1/2 blur-[40px]"
@@ -73,7 +73,7 @@ export function PolicySection({
 }) {
   const idx = String(index).padStart(2, '0')
   return (
-    <article className="rounded-[14px] border border-dm-line bg-dm-bg-elev p-7">
+    <article className="rounded-[14px] border border-dm-line bg-dm-bg-elev p-5 sm:p-7">
       <div className="flex items-center gap-3">
         <span className="rounded-[6px] border border-dm-line bg-dm-bg-soft px-[8px] py-[3px] font-[var(--font-dm-mono)] text-[11px] text-dm-ink-3 tracking-[0.04em]">
           {idx}
@@ -139,7 +139,7 @@ export function PolicyContact({ intro }: { intro: string }) {
 
 export function PolicyBody({ children }: { children: ReactNode }) {
   return (
-    <section className="px-8 pb-20">
+    <section className="px-5 pb-16 sm:px-8 sm:pb-20">
       <div className="mx-auto flex max-w-[820px] flex-col gap-5">{children}</div>
     </section>
   )

--- a/apps/landing/src/components/pricing/ComparisonTable.tsx
+++ b/apps/landing/src/components/pricing/ComparisonTable.tsx
@@ -136,7 +136,7 @@ export async function ComparisonTable({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
   const groups = buildGroups(t)
   return (
-    <section className="px-8 pt-24 pb-10">
+    <section className="px-5 pt-16 pb-10 sm:px-8 sm:pt-24">
       <div className="mx-auto max-w-[1140px]">
         <div className="mb-9 max-w-[680px]">
           <div
@@ -158,8 +158,8 @@ export async function ComparisonTable({ locale }: { locale: Locale }) {
 
         <div className="overflow-hidden rounded-[14px] border border-dm-line bg-dm-bg-elev text-[13.5px]">
           <div
-            className="grid items-center border-dm-line border-b bg-dm-bg-soft px-[22px] py-[14px] font-[var(--font-dm-mono)] font-semibold text-[11.5px] text-dm-ink-3 uppercase tracking-[0.06em]"
-            style={{ gridTemplateColumns: '2.2fr 1fr 1fr 1fr' }}
+            className="grid items-center gap-1 border-dm-line border-b bg-dm-bg-soft px-3 py-[14px] font-[var(--font-dm-mono)] font-semibold text-[11px] text-dm-ink-3 uppercase tracking-[0.06em] sm:gap-0 sm:px-[22px] sm:text-[11.5px]"
+            style={{ gridTemplateColumns: 'minmax(0, 2.2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr)' }}
           >
             <div className="text-left">{t('pricing.compare.columns.feature')}</div>
             <div className="text-center">{t('pricing.compare.columns.free')}</div>
@@ -172,8 +172,8 @@ export async function ComparisonTable({ locale }: { locale: Locale }) {
           {groups.map((group) => (
             <div key={group.key}>
               <div
-                className="grid items-center border-dm-line border-b bg-dm-bg px-[22px] py-[14px] font-[var(--font-dm-mono)] font-semibold text-[12px] text-dm-ink-2 uppercase tracking-[0.08em]"
-                style={{ gridTemplateColumns: '2.2fr 1fr 1fr 1fr' }}
+                className="grid items-center border-dm-line border-b bg-dm-bg px-3 py-[12px] font-[var(--font-dm-mono)] font-semibold text-[11.5px] text-dm-ink-2 uppercase tracking-[0.08em] sm:px-[22px] sm:py-[14px] sm:text-[12px]"
+                style={{ gridTemplateColumns: 'minmax(0, 2.2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr)' }}
               >
                 <div className="text-left">{t(`pricing.compare.groups.${group.key}`)}</div>
                 <div />
@@ -182,16 +182,16 @@ export async function ComparisonTable({ locale }: { locale: Locale }) {
               </div>
               {group.rows.map((r) => (
                 <div
-                  className="grid items-center border-dm-line border-b px-[22px] py-[14px] last:border-b-0"
+                  className="grid items-center gap-1 border-dm-line border-b px-3 py-[12px] last:border-b-0 sm:gap-0 sm:px-[22px] sm:py-[14px]"
                   key={`${group.key}-${r.key}`}
-                  style={{ gridTemplateColumns: '2.2fr 1fr 1fr 1fr' }}
+                  style={{ gridTemplateColumns: 'minmax(0, 2.2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr)' }}
                 >
-                  <div className="text-left">
-                    <div className="font-medium text-[14px] text-dm-ink tracking-[-0.005em]">
+                  <div className="min-w-0 text-left">
+                    <div className="font-medium text-[12.5px] text-dm-ink tracking-[-0.005em] sm:text-[14px]">
                       {t(`pricing.compare.rows.${r.key}.label`)}
                     </div>
                     {r.hasDesc ? (
-                      <div className="mt-[2px] font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-4">
+                      <div className="mt-[2px] hidden font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-4 sm:block">
                         {t(`pricing.compare.rows.${r.key}.desc`)}
                       </div>
                     ) : null}

--- a/apps/landing/src/components/pricing/PlanCard.tsx
+++ b/apps/landing/src/components/pricing/PlanCard.tsx
@@ -44,8 +44,8 @@ export function PlanCard(p: PlanCardProps) {
     <article
       className={
         highlighted
-          ? 'relative flex flex-col rounded-[16px] border p-8'
-          : 'flex flex-col rounded-[16px] border border-dm-line bg-dm-bg-elev p-8'
+          ? 'relative flex flex-col rounded-[16px] border p-6 sm:p-8'
+          : 'flex flex-col rounded-[16px] border border-dm-line bg-dm-bg-elev p-6 sm:p-8'
       }
       style={
         highlighted

--- a/apps/landing/src/components/pricing/PricingFaq.tsx
+++ b/apps/landing/src/components/pricing/PricingFaq.tsx
@@ -53,7 +53,7 @@ export function PricingFaq() {
   const title = t('pricing.faq.title')
 
   return (
-    <section className="px-8 py-16">
+    <section className="px-5 py-12 sm:px-8 sm:py-16">
       <div className="mx-auto max-w-[820px]">
         <h2 className="font-bold text-[28px] text-dm-ink tracking-[-0.02em]">{title}</h2>
         <Accordion className="mt-6" collapsible type="single">

--- a/apps/landing/src/components/pricing/PricingHero.tsx
+++ b/apps/landing/src/components/pricing/PricingHero.tsx
@@ -4,7 +4,7 @@ import { getTranslation } from '@repo/shared/i18n/server'
 export async function PricingHero({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
   return (
-    <section className="relative px-8 pt-16 pb-10">
+    <section className="relative overflow-hidden px-5 pt-12 pb-8 sm:px-8 sm:pt-16 sm:pb-10">
       <div
         aria-hidden
         className="pointer-events-none absolute top-5 left-1/2 -z-[1] h-[420px] w-[900px] -translate-x-1/2 blur-[40px]"

--- a/apps/landing/src/components/pricing/TrustBar.tsx
+++ b/apps/landing/src/components/pricing/TrustBar.tsx
@@ -6,9 +6,9 @@ import { pricingConfig } from '@/config/pricing'
 export async function TrustBar({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
   return (
-    <section className="px-8">
+    <section>
       <div className="mx-auto max-w-[1140px]">
-        <div className="flex flex-wrap items-center justify-center gap-8 border-dm-line border-y py-6">
+        <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-3 border-dm-line border-y py-5 sm:gap-8 sm:py-6">
           <Item>
             <svg
               fill="none"

--- a/apps/landing/src/components/shell/Footer.tsx
+++ b/apps/landing/src/components/shell/Footer.tsx
@@ -7,8 +7,8 @@ export async function Footer({ locale }: { locale: Locale }) {
   const prefix = (href: string) => `/${locale}${href === '/' ? '' : href}`
 
   return (
-    <footer className="border-dm-line border-t py-12 text-[13px] text-dm-ink-3">
-      <div className="mx-auto max-w-[1240px] px-8">
+    <footer className="border-dm-line border-t py-10 text-[13px] text-dm-ink-3 sm:py-12">
+      <div className="mx-auto max-w-[1240px] px-5 sm:px-8">
         <div className="flex flex-wrap items-start justify-between gap-10">
           {/* Brand column */}
           <div className="flex max-w-[300px] flex-col gap-[10px]">

--- a/apps/landing/src/components/shell/Navbar.tsx
+++ b/apps/landing/src/components/shell/Navbar.tsx
@@ -5,6 +5,7 @@ import type { Locale } from '@repo/shared/i18n'
 import { useTranslation } from '@repo/shared/i18n/client'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { useEffect, useState } from 'react'
 import { LocaleSwitch } from '@/components/shell/LocaleSwitch'
 import ThemeSwitch from '@/components/ThemeSwitch'
 
@@ -19,6 +20,7 @@ const LINKS: { href: string; labelKey: string; anchor?: boolean }[] = [
 export function Navbar({ locale }: { locale: Locale }) {
   const pathname = usePathname()
   const { t } = useTranslation(locale)
+  const [menuOpen, setMenuOpen] = useState(false)
 
   const hrefFor = (href: string) => `/${locale}${href === '/' ? '' : href}`
 
@@ -31,6 +33,21 @@ export function Navbar({ locale }: { locale: Locale }) {
     return pathname.startsWith(full)
   }
 
+  // Close on route change
+  useEffect(() => {
+    setMenuOpen(false)
+  }, [pathname])
+
+  // Lock body scroll while menu open
+  useEffect(() => {
+    if (!menuOpen) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [menuOpen])
+
   return (
     <nav
       className="sticky top-0 z-50 border-dm-line border-b backdrop-blur-[14px]"
@@ -38,14 +55,14 @@ export function Navbar({ locale }: { locale: Locale }) {
         background: 'color-mix(in srgb, var(--color-dm-bg) 80%, transparent)'
       }}
     >
-      <div className="mx-auto flex max-w-[1240px] items-center justify-between px-8 py-[14px]">
+      <div className="mx-auto flex max-w-[1240px] items-center justify-between gap-2 px-4 py-[14px] sm:px-6 md:px-8">
         <Link
-          className="flex items-center gap-[10px] font-bold text-[15px] text-dm-ink tracking-[-0.01em]"
+          className="flex min-w-0 items-center gap-[10px] font-bold text-[15px] text-dm-ink tracking-[-0.01em]"
           href={hrefFor('/')}
         >
           <BrandMark />
           <span>Dockerman</span>
-          <span className="ml-[2px] rounded-full bg-dm-ink px-2 py-[2px] font-semibold text-[10px] text-dm-bg tracking-[0.04em]">
+          <span className="ml-[2px] hidden rounded-full bg-dm-ink px-2 py-[2px] font-semibold text-[10px] text-dm-bg tracking-[0.04em] sm:inline">
             v5.1.0
           </span>
         </Link>
@@ -64,12 +81,12 @@ export function Navbar({ locale }: { locale: Locale }) {
           ))}
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1 sm:gap-2">
           <LocaleSwitch locale={locale} />
           <ThemeSwitch />
           <a
             aria-label={t('nav.github')}
-            className="grid h-8 w-8 place-items-center rounded-md text-dm-ink-2 hover:bg-dm-bg-soft hover:text-dm-ink"
+            className="hidden h-8 w-8 place-items-center rounded-md text-dm-ink-2 hover:bg-dm-bg-soft hover:text-dm-ink sm:grid"
             href="https://github.com/ZingerLittleBee/dockerman.app"
             rel="noopener noreferrer"
             target="_blank"
@@ -77,11 +94,106 @@ export function Navbar({ locale }: { locale: Locale }) {
             <RiGithubFill className="h-4 w-4" />
           </a>
           <Link
-            className="inline-flex items-center gap-2 rounded-lg border border-dm-ink bg-dm-ink px-[14px] py-2 font-medium text-[13px] text-dm-bg transition-transform hover:-translate-y-px"
+            className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg border border-dm-ink bg-dm-ink px-[12px] py-[7px] font-medium text-[12.5px] text-dm-bg transition-transform hover:-translate-y-px sm:px-[14px] sm:py-2 sm:text-[13px]"
             href={hrefFor('/download')}
           >
             {t('nav.download')}
           </Link>
+          <button
+            aria-controls="dm-mobile-menu"
+            aria-expanded={menuOpen}
+            aria-label={menuOpen ? t('nav.closeMenu') : t('nav.openMenu')}
+            className="grid h-8 w-8 cursor-pointer place-items-center rounded-md border border-dm-line bg-dm-bg-elev text-dm-ink-2 transition-colors hover:border-dm-line-strong hover:text-dm-ink md:hidden"
+            onClick={() => setMenuOpen((v) => !v)}
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              viewBox="0 0 24 24"
+            >
+              {menuOpen ? (
+                <path d="M18 6L6 18M6 6l12 12" />
+              ) : (
+                <path d="M3 6h18M3 12h18M3 18h18" />
+              )}
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile menu drawer */}
+      <div
+        aria-hidden={!menuOpen}
+        className={`md:hidden ${menuOpen ? 'pointer-events-auto' : 'pointer-events-none'}`}
+      >
+        {/* Backdrop */}
+        <button
+          aria-label={t('nav.closeMenu')}
+          className={`fixed inset-x-0 bottom-0 top-[57px] z-40 cursor-default bg-dm-bg/60 backdrop-blur-[2px] transition-opacity duration-200 ${
+            menuOpen ? 'opacity-100' : 'opacity-0'
+          }`}
+          onClick={() => setMenuOpen(false)}
+          tabIndex={menuOpen ? 0 : -1}
+          type="button"
+        />
+        {/* Panel */}
+        <div
+          className={`absolute inset-x-0 top-full z-50 origin-top border-dm-line border-b bg-dm-bg shadow-[0_20px_40px_-20px_rgb(0_0_0/0.4)] transition-all duration-200 ${
+            menuOpen
+              ? 'translate-y-0 opacity-100'
+              : '-translate-y-2 opacity-0'
+          }`}
+          id="dm-mobile-menu"
+        >
+          <ul className="mx-auto flex max-w-[1240px] flex-col gap-1 px-4 py-3">
+            {LINKS.map((l) => {
+              const active = isActive(l.href, l.anchor)
+              return (
+                <li key={l.href}>
+                  <Link
+                    className={`flex items-center justify-between rounded-md px-3 py-3 text-[15px] transition-colors ${
+                      active
+                        ? 'bg-dm-bg-soft text-dm-ink'
+                        : 'text-dm-ink-2 hover:bg-dm-bg-soft hover:text-dm-ink'
+                    }`}
+                    href={hrefFor(l.href)}
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    <span>{t(l.labelKey)}</span>
+                    <svg
+                      aria-hidden="true"
+                      className="h-4 w-4 text-dm-ink-4"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeLinecap="round"
+                      strokeWidth={2}
+                      viewBox="0 0 24 24"
+                    >
+                      <path d="M9 6l6 6-6 6" />
+                    </svg>
+                  </Link>
+                </li>
+              )
+            })}
+            <li className="mt-2 border-dm-line border-t pt-3">
+              <a
+                className="flex items-center gap-3 rounded-md px-3 py-3 text-[14px] text-dm-ink-2 hover:bg-dm-bg-soft hover:text-dm-ink"
+                href="https://github.com/ZingerLittleBee/dockerman.app"
+                onClick={() => setMenuOpen(false)}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <RiGithubFill className="h-[18px] w-[18px]" />
+                <span>{t('nav.github')}</span>
+              </a>
+            </li>
+          </ul>
         </div>
       </div>
     </nav>

--- a/apps/landing/src/components/snapshot/SnapshotFeaturesStrip.tsx
+++ b/apps/landing/src/components/snapshot/SnapshotFeaturesStrip.tsx
@@ -24,7 +24,7 @@ const FEATURES: FeatureDef[] = [
 export async function SnapshotFeaturesStrip({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
   return (
-    <section className="border-dm-line border-t px-8 pt-16 pb-10">
+    <section className="border-dm-line border-t px-5 pt-12 pb-10 sm:px-8 sm:pt-16">
       <div className="mx-auto max-w-[1320px]">
         <div className="mb-4 flex items-center gap-[14px] font-[var(--font-dm-mono)] font-semibold text-[11px] text-dm-ink-4 uppercase tracking-[0.1em]">
           {t('snapshot.featuresStrip.kicker')}

--- a/apps/landing/src/components/snapshot/SnapshotHero.tsx
+++ b/apps/landing/src/components/snapshot/SnapshotHero.tsx
@@ -6,7 +6,7 @@ export async function SnapshotHero({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
   const count = SNAPSHOT_MODULE_COUNT
   return (
-    <section className="relative px-8 pt-14 pb-8">
+    <section className="relative overflow-hidden px-5 pt-10 pb-8 sm:px-8 sm:pt-14">
       <div
         aria-hidden
         className="pointer-events-none absolute top-0 left-1/2 -z-[1] h-[420px] w-[900px] -translate-x-1/2 blur-[40px]"
@@ -56,7 +56,7 @@ export async function SnapshotHero({ locale }: { locale: Locale }) {
           {t('snapshot.hero.descriptionPost')}
         </p>
 
-        <div className="mt-8 flex flex-wrap items-center gap-7 rounded-[12px] border border-dm-line bg-dm-bg-elev px-[22px] py-[18px] font-[var(--font-dm-mono)] text-[12px] text-dm-ink-3">
+        <div className="mt-8 flex flex-wrap items-center gap-x-5 gap-y-3 rounded-[12px] border border-dm-line bg-dm-bg-elev px-4 py-4 font-[var(--font-dm-mono)] text-[12px] text-dm-ink-3 sm:gap-7 sm:px-[22px] sm:py-[18px]">
           <MetaField label={t('snapshot.hero.metaModules')} value={String(count)} />
           <MetaSep />
           <MetaField label={t('snapshot.hero.metaBuild')} value="v5.1.0" />

--- a/apps/landing/src/components/snapshot/SnapshotShowcase.tsx
+++ b/apps/landing/src/components/snapshot/SnapshotShowcase.tsx
@@ -146,12 +146,12 @@ export function SnapshotShowcase({
   const n = String(active + 1).padStart(2, '0')
 
   return (
-    <section className="px-8 pt-12 pb-20">
+    <section className="px-5 pt-10 pb-16 sm:px-8 sm:pt-12 sm:pb-20">
       <div className="mx-auto max-w-[1320px]">
         {/* Mobile tab rail */}
         <div
           aria-label={strings.moduleTabsAria}
-          className="-mx-8 mb-5 flex gap-2 overflow-x-auto px-8 pb-4 [scrollbar-width:none] md:hidden [&::-webkit-scrollbar]:hidden"
+          className="-mx-5 mb-5 flex gap-2 overflow-x-auto px-5 pb-4 [scrollbar-width:none] sm:-mx-8 sm:px-8 md:hidden [&::-webkit-scrollbar]:hidden"
           ref={mobRef}
           role="tablist"
         >
@@ -532,7 +532,7 @@ function CaptionStrip({
 }) {
   const [copied, setCopied] = useState(false)
   return (
-    <div className="mt-6 grid grid-cols-1 items-center gap-6 rounded-[14px] border border-dm-line bg-dm-bg-elev px-[26px] py-[22px] md:grid-cols-[1fr_auto]">
+    <div className="mt-6 grid grid-cols-1 items-center gap-5 rounded-[14px] border border-dm-line bg-dm-bg-elev px-5 py-5 sm:gap-6 sm:px-[26px] sm:py-[22px] md:grid-cols-[1fr_auto]">
       <div>
         <h3 className="m-0 font-bold text-[22px] text-dm-ink tracking-[-0.022em]">
           {label} —{' '}

--- a/packages/shared/src/locales/en.json
+++ b/packages/shared/src/locales/en.json
@@ -7,7 +7,9 @@
     "docs": "Docs",
     "download": "Download",
     "github": "GitHub",
-    "changeLanguage": "Change language"
+    "changeLanguage": "Change language",
+    "openMenu": "Open menu",
+    "closeMenu": "Close menu"
   },
   "hero": {
     "eyebrow": "v5.1.0 — Podman support, Cloudflared tunnels, image-upgrade detection",

--- a/packages/shared/src/locales/es.json
+++ b/packages/shared/src/locales/es.json
@@ -7,7 +7,9 @@
     "docs": "Docs",
     "download": "Descargar",
     "github": "GitHub",
-    "changeLanguage": "Cambiar idioma"
+    "changeLanguage": "Cambiar idioma",
+    "openMenu": "Abrir menú",
+    "closeMenu": "Cerrar menú"
   },
   "hero": {
     "eyebrow": "v5.1.0 — soporte Podman, túneles Cloudflared, detección de actualizaciones de imagen",

--- a/packages/shared/src/locales/ja.json
+++ b/packages/shared/src/locales/ja.json
@@ -7,7 +7,9 @@
     "docs": "ドキュメント",
     "download": "ダウンロード",
     "github": "GitHub",
-    "changeLanguage": "言語を変更"
+    "changeLanguage": "言語を変更",
+    "openMenu": "メニューを開く",
+    "closeMenu": "メニューを閉じる"
   },
   "hero": {
     "eyebrow": "v5.1.0 — Podman 対応、Cloudflared トンネル、イメージ更新検出",

--- a/packages/shared/src/locales/zh.json
+++ b/packages/shared/src/locales/zh.json
@@ -7,7 +7,9 @@
     "docs": "文档",
     "download": "下载",
     "github": "GitHub",
-    "changeLanguage": "切换语言"
+    "changeLanguage": "切换语言",
+    "openMenu": "打开菜单",
+    "closeMenu": "关闭菜单"
   },
   "hero": {
     "eyebrow": "v5.1.0 — Podman 支持、Cloudflared 隧道、镜像升级检测",


### PR DESCRIPTION
## Summary

Make the marketing site fully usable on mobile (320–430px viewports). Previously the navbar overflowed, the LiveDashboard preview broke layout, and several sections caused horizontal scroll.

- **Navbar**: hamburger menu with slide-down drawer for nav links; download CTA stays accessible; version badge / GitHub icon hidden on small screens
- **Sections**: section padding adapts (`px-8` → `px-5 sm:px-8`); inner card padding shrinks accordingly across hero/footer/cta/features/modules
- **Homepage LiveDashboard**: hidden on mobile (it's a desktop-app preview that doesn't fit a 360px column)
- **Pricing**: countdown bar centered on mobile (icon → text → timer stacked); 4-col comparison table uses `minmax(0, ...)`, padding/font reduced, descriptions hidden under `sm`
- **Download**: ReleasesTable switches from fixed 4-col grid to `1fr_auto_auto` on mobile; HomebrewBlock fixed via `min-w-0` + `grid-cols-1` so the brew command truncates properly
- **Hero overflow**: every hero now has `overflow-hidden` so the `w-[900px]` decorative glows no longer extend the page width
- **i18n**: added `nav.openMenu` / `nav.closeMenu` strings in en/zh/ja/es

## Test plan

- [x] Verified at 375×812 with `agent-browser`: every page (`/`, `/pricing`, `/download`, `/snapshot`, `/changelog`, `/about`, `/privacy`, `/terms`, `/dpa`) has `scrollWidth === clientWidth`
- [x] Verified at 320×568 (iPhone SE) — navbar, download CTA, hero all fit
- [x] Verified at 430×932 (iPhone 14 Pro Max) — countdown bar centered
- [x] Verified hamburger menu opens, links navigate, menu auto-closes on route change
- [x] Verified desktop layout (1280px) unchanged for navbar + countdown bar