### PR TITLE
refactor(landing): single source of truth for version & release date

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/download/layout.tsx
+++ b/apps/landing/src/app/[locale]/(main)/download/layout.tsx
@@ -3,5 +3,5 @@ export default function Layout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  return <main className="mx-auto mt-36 max-w-6xl">{children}</main>
+  return <>{children}</>
 }

--- a/apps/landing/src/components/download/DownloadHero.tsx
+++ b/apps/landing/src/components/download/DownloadHero.tsx
@@ -1,6 +1,7 @@
 import type { Locale } from '@repo/shared/i18n'
 import { getTranslation } from '@repo/shared/i18n/server'
 import { downloadsConfig } from '@/config/downloads'
+import { formatDate } from '@/lib/format'
 
 export async function DownloadHero({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
@@ -111,20 +112,4 @@ function ReleaseMetaCell({
       </div>
     </div>
   )
-}
-
-function formatDate(iso: string, locale: Locale): string {
-  const d = new Date(iso)
-  const tag =
-    locale === 'zh' ? 'zh-CN' : locale === 'ja' ? 'ja-JP' : locale === 'es' ? 'es-ES' : 'en-US'
-  try {
-    return new Intl.DateTimeFormat(tag, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      timeZone: 'UTC'
-    }).format(d)
-  } catch {
-    return iso
-  }
 }

--- a/apps/landing/src/components/landing/Hero.tsx
+++ b/apps/landing/src/components/landing/Hero.tsx
@@ -4,7 +4,9 @@ import type { Locale } from '@repo/shared/i18n'
 import { useTranslation } from '@repo/shared/i18n/client'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
+import { siteConfig } from '@/app/siteConfig'
 import { downloadsConfig } from '@/config/downloads'
+import { formatDate } from '@/lib/format'
 
 const INSTALL_CMD = downloadsConfig.homebrewCommand
 
@@ -51,6 +53,7 @@ export function Hero({ locale }: { locale: Locale }) {
 
   const downloadLabel = t(OS_LABEL_KEY[os])
   const downloadSize = OS_SIZE[os]
+  const releaseDate = formatDate(downloadsConfig.latest.releaseDate, locale)
 
   const copyInstall = async () => {
     try {
@@ -84,7 +87,7 @@ export function Hero({ locale }: { locale: Locale }) {
               animation: 'dm-pulse 2.2s ease-in-out infinite'
             }}
           />
-          <span>{t('hero.eyebrow')}</span>
+          <span>{t('hero.eyebrow', { version: siteConfig.latestVersion })}</span>
           <span className="rounded-full bg-dm-ink px-2 py-[2px] font-semibold text-[10px] text-dm-bg tracking-[0.04em]">
             {t('hero.eyebrowTag')}
           </span>
@@ -187,7 +190,12 @@ export function Hero({ locale }: { locale: Locale }) {
           <span className="h-[3px] w-[3px] rounded-full bg-dm-ink-4" />
           <span>{t('hero.metaPrivacy')}</span>
           <span className="h-[3px] w-[3px] rounded-full bg-dm-ink-4" />
-          <span>{t('hero.metaVersion')}</span>
+          <span>
+            {t('hero.metaVersion', {
+              version: siteConfig.latestVersion,
+              date: releaseDate
+            })}
+          </span>
         </div>
       </div>
     </section>
@@ -299,7 +307,7 @@ function TerminalCard({ locale }: { locale: Locale }) {
         <StageLine delayMs={STAGE_STEPS.fetch}>
           <span className="text-dm-ink-3">==&gt;</span> {t('hero.terminal.downloading')}{' '}
           <span className="text-dm-ink">Dockerman</span>{' '}
-          <span className="text-dm-ink-4">v5.1.0</span>
+          <span className="text-dm-ink-4">v{siteConfig.latestVersion}</span>
         </StageLine>
 
         {/* progress */}

--- a/apps/landing/src/components/shell/Navbar.tsx
+++ b/apps/landing/src/components/shell/Navbar.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from '@repo/shared/i18n/client'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import { siteConfig } from '@/app/siteConfig'
 import { LocaleSwitch } from '@/components/shell/LocaleSwitch'
 import ThemeSwitch from '@/components/ThemeSwitch'
 
@@ -63,7 +64,7 @@ export function Navbar({ locale }: { locale: Locale }) {
           <BrandMark />
           <span>Dockerman</span>
           <span className="ml-[2px] hidden rounded-full bg-dm-ink px-2 py-[2px] font-semibold text-[10px] text-dm-bg tracking-[0.04em] sm:inline">
-            v5.1.0
+            v{siteConfig.latestVersion}
           </span>
         </Link>
 
@@ -117,11 +118,7 @@ export function Navbar({ locale }: { locale: Locale }) {
               strokeWidth={2}
               viewBox="0 0 24 24"
             >
-              {menuOpen ? (
-                <path d="M18 6L6 18M6 6l12 12" />
-              ) : (
-                <path d="M3 6h18M3 12h18M3 18h18" />
-              )}
+              {menuOpen ? <path d="M18 6L6 18M6 6l12 12" /> : <path d="M3 6h18M3 12h18M3 18h18" />}
             </svg>
           </button>
         </div>
@@ -135,7 +132,7 @@ export function Navbar({ locale }: { locale: Locale }) {
         {/* Backdrop */}
         <button
           aria-label={t('nav.closeMenu')}
-          className={`fixed inset-x-0 bottom-0 top-[57px] z-40 cursor-default bg-dm-bg/60 backdrop-blur-[2px] transition-opacity duration-200 ${
+          className={`fixed inset-x-0 top-[57px] bottom-0 z-40 cursor-default bg-dm-bg/60 backdrop-blur-[2px] transition-opacity duration-200 ${
             menuOpen ? 'opacity-100' : 'opacity-0'
           }`}
           onClick={() => setMenuOpen(false)}
@@ -145,9 +142,7 @@ export function Navbar({ locale }: { locale: Locale }) {
         {/* Panel */}
         <div
           className={`absolute inset-x-0 top-full z-50 origin-top border-dm-line border-b bg-dm-bg shadow-[0_20px_40px_-20px_rgb(0_0_0/0.4)] transition-all duration-200 ${
-            menuOpen
-              ? 'translate-y-0 opacity-100'
-              : '-translate-y-2 opacity-0'
+            menuOpen ? 'translate-y-0 opacity-100' : '-translate-y-2 opacity-0'
           }`}
           id="dm-mobile-menu"
         >

--- a/apps/landing/src/components/snapshot/SnapshotHero.tsx
+++ b/apps/landing/src/components/snapshot/SnapshotHero.tsx
@@ -1,5 +1,6 @@
 import type { Locale } from '@repo/shared/i18n'
 import { getTranslation } from '@repo/shared/i18n/server'
+import { siteConfig } from '@/app/siteConfig'
 import { SNAPSHOT_MODULE_COUNT } from '@/config/snapshot'
 
 export async function SnapshotHero({ locale }: { locale: Locale }) {
@@ -59,7 +60,7 @@ export async function SnapshotHero({ locale }: { locale: Locale }) {
         <div className="mt-8 flex flex-wrap items-center gap-x-5 gap-y-3 rounded-[12px] border border-dm-line bg-dm-bg-elev px-4 py-4 font-[var(--font-dm-mono)] text-[12px] text-dm-ink-3 sm:gap-7 sm:px-[22px] sm:py-[18px]">
           <MetaField label={t('snapshot.hero.metaModules')} value={String(count)} />
           <MetaSep />
-          <MetaField label={t('snapshot.hero.metaBuild')} value="v5.1.0" />
+          <MetaField label={t('snapshot.hero.metaBuild')} value={`v${siteConfig.latestVersion}`} />
           <MetaSep />
           <MetaField label={t('snapshot.hero.metaCaptured')} value="2400 × 1600" />
           <div className="ml-auto flex items-center gap-[10px]">

--- a/apps/landing/src/config/downloads.ts
+++ b/apps/landing/src/config/downloads.ts
@@ -1,3 +1,5 @@
+import { siteConfig } from '@/app/siteConfig'
+
 export type Verification =
   | { kind: 'apple-notarized' }
   | { kind: 'tauri-sig'; sigFilename: string }
@@ -27,8 +29,8 @@ export interface DownloadsHistoryEntry {
   summarySlug: string
 }
 
-const VERSION = '5.1.0'
-const RELEASE_DATE = '2026-04-08'
+const VERSION = siteConfig.latestVersion
+const RELEASE_DATE = '2026-04-26'
 
 export const downloadsConfig: {
   asOf: string
@@ -102,6 +104,7 @@ export const downloadsConfig: {
     }
   },
   history: [
+    { version: VERSION, date: RELEASE_DATE, summarySlug: 'release-5-2-0' },
     { version: '5.1.0', date: '2026-04-08', summarySlug: 'release-5-1-0' },
     { version: '5.0.0', date: '2026-04-07', summarySlug: 'release-5-0-0' },
     { version: '4.8.0', date: '2026-03-31', summarySlug: 'release-4-8-0' },

--- a/apps/landing/src/lib/format.ts
+++ b/apps/landing/src/lib/format.ts
@@ -1,0 +1,17 @@
+import type { Locale } from '@repo/shared/i18n'
+
+export function formatDate(iso: string, locale: Locale): string {
+  const d = new Date(iso)
+  const tag =
+    locale === 'zh' ? 'zh-CN' : locale === 'ja' ? 'ja-JP' : locale === 'es' ? 'es-ES' : 'en-US'
+  try {
+    return new Intl.DateTimeFormat(tag, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC'
+    }).format(d)
+  } catch {
+    return iso
+  }
+}

--- a/packages/shared/src/locales/en.json
+++ b/packages/shared/src/locales/en.json
@@ -12,7 +12,7 @@
     "closeMenu": "Close menu"
   },
   "hero": {
-    "eyebrow": "v5.1.0 — Podman support, Cloudflared tunnels, image-upgrade detection",
+    "eyebrow": "v{{version}} — Multi-cluster Kubernetes, image upgrade watch, Homelab foundations",
     "eyebrowTag": "NEW",
     "headline1Lead": "Docker that feels",
     "headline1Accent": "local",
@@ -27,7 +27,7 @@
     "copyAria": "Copy: {{cmd}}",
     "copied": "Copied",
     "metaPrivacy": "local-first · opt-out analytics",
-    "metaVersion": "v5.1.0 · Apr 8, 2026",
+    "metaVersion": "v{{version}} · {{date}}",
     "terminal": {
       "tapping": "Tapping",
       "downloading": "Downloading",

--- a/packages/shared/src/locales/es.json
+++ b/packages/shared/src/locales/es.json
@@ -12,7 +12,7 @@
     "closeMenu": "Cerrar menú"
   },
   "hero": {
-    "eyebrow": "v5.1.0 — soporte Podman, túneles Cloudflared, detección de actualizaciones de imagen",
+    "eyebrow": "v{{version}} — Kubernetes multi-cluster, vigilancia de actualizaciones de imagen, bases del Homelab",
     "eyebrowTag": "NUEVO",
     "headline1Lead": "Docker que se siente",
     "headline1Accent": "local",
@@ -27,7 +27,7 @@
     "copyAria": "Copiar: {{cmd}}",
     "copied": "Copiado",
     "metaPrivacy": "local-first · analítica opcional",
-    "metaVersion": "v5.1.0 · 8 de abril de 2026",
+    "metaVersion": "v{{version}} · {{date}}",
     "terminal": {
       "tapping": "Añadiendo tap",
       "downloading": "Descargando",

--- a/packages/shared/src/locales/ja.json
+++ b/packages/shared/src/locales/ja.json
@@ -12,7 +12,7 @@
     "closeMenu": "メニューを閉じる"
   },
   "hero": {
-    "eyebrow": "v5.1.0 — Podman 対応、Cloudflared トンネル、イメージ更新検出",
+    "eyebrow": "v{{version}} — マルチクラスタ Kubernetes、イメージ更新監視、Homelab 基盤",
     "eyebrowTag": "NEW",
     "headline1Lead": "Docker を",
     "headline1Accent": "ローカルに",
@@ -27,7 +27,7 @@
     "copyAria": "コピー：{{cmd}}",
     "copied": "コピーしました",
     "metaPrivacy": "ローカル優先 · オプトアウト可能な分析",
-    "metaVersion": "v5.1.0 · 2026 年 4 月 8 日",
+    "metaVersion": "v{{version}} · {{date}}",
     "terminal": {
       "tapping": "Tap 中",
       "downloading": "ダウンロード中",

--- a/packages/shared/src/locales/zh.json
+++ b/packages/shared/src/locales/zh.json
@@ -12,7 +12,7 @@
     "closeMenu": "关闭菜单"
   },
   "hero": {
-    "eyebrow": "v5.1.0 — Podman 支持、Cloudflared 隧道、镜像升级检测",
+    "eyebrow": "v{{version}} — 多集群 Kubernetes、镜像升级监控、Homelab 基础",
     "eyebrowTag": "新",
     "headline1Lead": "Docker，用起来像",
     "headline1Accent": "本地",
@@ -27,7 +27,7 @@
     "copyAria": "复制：{{cmd}}",
     "copied": "已复制",
     "metaPrivacy": "本地优先 · 可关闭的匿名分析",
-    "metaVersion": "v5.1.0 · 2026 年 4 月 8 日",
+    "metaVersion": "v{{version}} · {{date}}",
     "terminal": {
       "tapping": "正在添加",
       "downloading": "正在下载",

--- a/skills/update-version/SKILL.md
+++ b/skills/update-version/SKILL.md
@@ -5,7 +5,15 @@ description: Update Dockerman version and changelog. Use when releasing a new ve
 
 # Update Version Skill
 
-Updates the Dockerman website with a new version release, including siteConfig, changelog, and README files.
+Updates the Dockerman website with a new version release.
+
+> **Single sources of truth:**
+> - **Version** lives in `apps/landing/src/app/siteConfig.ts` `latestVersion`. All components (`Navbar`, `Hero`, `SnapshotHero`) and the `downloads.ts` `VERSION` constant import from it; locale `hero.eyebrow` / `hero.metaVersion` use the `{{version}}` placeholder.
+> - **Release date** lives in `apps/landing/src/config/downloads.ts` `RELEASE_DATE` (ISO). It flows to the latest `history[]` entry, the Download page hero, and Hero `metaVersion` via `formatDate(downloadsConfig.latest.releaseDate, locale)` from `@/lib/format` + a `{{date}}` placeholder.
+>
+> **Do not** reintroduce hardcoded version or date strings in those files.
+>
+> The historical / per-release locations (changelog MDX entries, README badges, locale tagline highlight phrases, the `release-x-y-z` slug) still need per-release edits, because they describe a specific release rather than "the latest version".
 
 ## Input Format
 
@@ -17,7 +25,6 @@ User provides changelog content in markdown format:
 ### ✨ Features
 
 - 🔔 **Feature Name**: Description of the feature
-- 🎛️ **Another Feature**: More details
 
 ### 🎨 Improvements
 
@@ -26,31 +33,85 @@ User provides changelog content in markdown format:
 
 ## Instructions
 
-### 1. Extract Version Number
+### 1. Extract Version Number and Date
 
-Parse `vX.Y.Z` from the first `## vX.Y.Z` heading in the user input.
+Parse `vX.Y.Z` from the first `## vX.Y.Z` heading. Use today's date as the release date.
 
-### 2. Update siteConfig.ts
+Prepare the date in these formats — you'll need them in different files:
 
-Edit `src/app/siteConfig.ts` and update the `latestVersion` field:
+| Format | Where used | Example (Apr 26, 2026) |
+|--------|------------|------------------------|
+| ISO `YYYY-MM-DD` | `downloads.ts` `RELEASE_DATE` (single source) | `2026-04-26` |
+| en `Mon DD, YYYY` | en changelog, README badge | `Apr 26, 2026` |
+| zh `YYYY 年 M 月 D 日` | zh changelog | `2026 年 4 月 26 日` |
+| ja `YYYY 年 M 月 D 日` | ja changelog | `2026 年 4 月 26 日` |
+| es `D de mes de YYYY` | es changelog | `26 de abril de 2026` |
+| URL-encoded en | README release-date badge URL | `Apr%2026%2C%202026` |
+
+> Hero `metaVersion` no longer needs a per-locale date string — it interpolates `{{date}}`, with `formatDate()` deriving the localized date from the ISO `RELEASE_DATE` automatically.
+
+### 2. Update `apps/landing/src/app/siteConfig.ts` (single source of truth for version)
 
 ```typescript
-latestVersion: "X.Y.Z",  // Note: no 'v' prefix
+latestVersion: 'X.Y.Z',  // no 'v' prefix
 ```
 
-### 3. Convert Markdown to MDX Format
+This automatically propagates to:
+- `Navbar.tsx` brand badge (`v{siteConfig.latestVersion}`)
+- `Hero.tsx` terminal animation line + `eyebrow` (interpolated via `{{version}}`) + `metaVersion` (interpolated via `{{version}}` and `{{date}}`)
+- `SnapshotHero.tsx` `metaBuild` field
+- `downloads.ts` `VERSION` constant + latest `history[]` entry
 
-Transform the user's markdown into the changelog MDX format:
+**Never** edit those files for the version literal — they already read `siteConfig.latestVersion` or `{{version}}`.
 
-1. **Wrap with ChangelogEntry**: Add opening and closing tags with version and current date
-2. **Add Title**: Create a short H2 title summarizing the release
-3. **Convert Bold**: Replace `**text:**` patterns with `<Bold>text:</Bold>`
-4. **Keep Emojis**: Preserve emoji prefixes in feature names
+### 3. Update `apps/landing/src/config/downloads.ts`
+
+Two edits per release:
+
+1. Bump `RELEASE_DATE` to the new ISO date.
+2. Prepend a new entry to `history[]` (keep prior entries):
+
+```typescript
+history: [
+  { version: VERSION, date: RELEASE_DATE, summarySlug: 'release-x-y-z' },
+  // ...previous entries (literal versions/dates — these are historical)
+]
+```
+
+The latest history entry uses the `VERSION` and `RELEASE_DATE` constants directly. Older entries remain literal.
+
+### 4. Update Locale Files in `packages/shared/src/locales/`
+
+Update all four (`en.json`, `zh.json`, `ja.json`, `es.json`). Two keys per file:
+
+- **`hero.eyebrow`** — keep the `v{{version}} — ` prefix; rewrite the highlight phrases for the new release (translated per locale).
+
+  Pattern: `"v{{version}} — <highlight 1>, <highlight 2>, <highlight 3>"`
+
+- **`hero.metaVersion`** — pure template `"v{{version}} · {{date}}"`. **Do not edit per release** — both placeholders are filled at runtime from `siteConfig.latestVersion` and `formatDate(downloadsConfig.latest.releaseDate, locale)`.
+
+The `{{version}}` placeholder is filled with `siteConfig.latestVersion` and `{{date}}` with the localized release date, so don't write either literal here.
+
+### 5. Convert Markdown to MDX and Prepend to All Four Changelog Locales
+
+Per-locale changelog files (translate body for zh/ja/es):
+
+- `apps/landing/src/content/changelog/en/page.mdx`
+- `apps/landing/src/content/changelog/zh/page.mdx`
+- `apps/landing/src/content/changelog/ja/page.mdx`
+- `apps/landing/src/content/changelog/es/page.mdx`
+
+#### Conversion rules
+
+1. Wrap with `<ChangelogEntry version="vX.Y.Z" date="<localized date>">…</ChangelogEntry>`
+2. Add a short H2 title summarizing the release
+3. Replace `**text:**` patterns with `<Bold>text:</Bold>`
+4. Preserve emoji prefixes
 
 #### MDX Template
 
 ```mdx
-<ChangelogEntry version="vX.Y.Z" date="Mon DD, YYYY">
+<ChangelogEntry version="vX.Y.Z" date="<localized date>">
 ## Short Release Title
 
 Brief description of what this release introduces.
@@ -58,64 +119,61 @@ Brief description of what this release introduces.
 ### ✨ Features
 
 - <Bold>Feature Name:</Bold> Description of the feature
-  with multi-line support if needed
 
-### 🎨 Improvements
+### 🔧 Improvements
 
 - <Bold>Improvement Name:</Bold> Description
+
+### 🐛 Bug Fixes
+
+- <Bold>Fix Name:</Bold> Description
 
 </ChangelogEntry>
 ```
 
-### 4. Prepend to Changelog
+The version literal **does** appear in `<ChangelogEntry version="vX.Y.Z">` — that's intentional, because each entry is a historical record of a specific release.
 
-Insert the new `<ChangelogEntry>` block at the **top** of `src/app/changelog/page.mdx`, before the existing entries.
+### 6. Update README Files
 
-### 5. Update README Files
+Update **all four** READMEs: `README.md` (en), `README.zh-CN.md`, `README.ja.md`, `README.es.md`.
 
-Update both `README.md` and `README.zh-CN.md` with the new version and release date badges:
+Update version + release-date badges:
 
 ```markdown
 [![Version](https://img.shields.io/badge/version-vX.Y.Z-blue.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/vX.Y.Z)
 [![Release Date](https://img.shields.io/badge/release%20date-Mon%20DD%2C%20YYYY-green.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/vX.Y.Z)
 ```
 
-**Note**: In the release date badge URL, spaces are encoded as `%20` and commas as `%2C`.
+URL encoding: spaces → `%20`, commas → `%2C`.
 
-### 6. Update README Features Section
+### 7. Update README Features Section
 
-Add new features to the Features section in both `README.md` and `README.zh-CN.md`:
+Add new features to the Features section in **all four** READMEs:
 
-- Keep descriptions **brief** (one line per feature)
-- No detailed sub-items needed
-- Add under the appropriate section (Container Management, Image Management, etc.)
-- Create new sections if needed (e.g., "Volume Management")
+- One brief line per feature, no detailed sub-items
+- Add under the appropriate section (Container Management, Image Management, etc.) or create a new section
+- Translate for zh/ja/es
 
 ## File References
 
-| File | Purpose |
-|------|---------|
-| `src/app/siteConfig.ts` | Contains `latestVersion` field to update |
-| `src/app/changelog/page.mdx` | MDX changelog with `<ChangelogEntry>` components |
-| `README.md` | English README with version/date badges |
-| `README.zh-CN.md` | Chinese README with version/date badges |
-
-## Date Format
-
-- Changelog & badge display: `Mon DD, YYYY` (e.g., "Jan 30, 2026")
-- Badge URL encoded: `Mon%20DD%2C%20YYYY` (e.g., "Jan%2030%2C%202026")
+| File | Per-release? | What changes |
+|------|--------------|--------------|
+| `apps/landing/src/app/siteConfig.ts` | ✅ | `latestVersion` (single source of truth — propagates to all UI) |
+| `apps/landing/src/config/downloads.ts` | ✅ | `RELEASE_DATE` + prepend `history[]` entry (uses `VERSION`/`RELEASE_DATE` consts) |
+| `packages/shared/src/locales/{en,zh,ja,es}.json` | ✅ | `hero.eyebrow` only (rewrite tagline highlights). `hero.metaVersion` is a pure template — don't touch. |
+| `apps/landing/src/content/changelog/{en,zh,ja,es}/page.mdx` | ✅ | Prepend new `<ChangelogEntry>` (×4 locales, body translated) |
+| `README.md` / `README.zh-CN.md` / `README.ja.md` / `README.es.md` | ✅ | Version + release-date badges + Features section |
+| `apps/landing/src/components/{shell/Navbar,landing/Hero,snapshot/SnapshotHero}.tsx` | ❌ | Already read `siteConfig.latestVersion` — never touch for a version bump |
 
 ## Section Types Supported
 
-- `### ✨ Features` - New functionality
-- `### 🎨 Improvements` - Enhancements to existing features
-- `### 🐛 Bug Fixes` - Issue resolutions
-- `### ⚡ Performance` - Performance optimizations
-- `### 🌐 Internationalization` - i18n updates
+- `### ✨ Features` — New functionality
+- `### 🔧 Improvements` / `### 🎨 Improvements` — Enhancements (both emojis seen historically)
+- `### 🐛 Bug Fixes` — Issue resolutions
+- `### ⚡ Performance` — Performance optimizations
+- `### 🌐 Internationalization` — i18n updates
 
 ## Optional: Changelog Images
-
-If screenshots are provided, add them using:
 
 ```mdx
 <ChangelogImage
@@ -126,15 +184,28 @@ If screenshots are provided, add them using:
 
 ## Verification Checklist
 
-- [ ] `siteConfig.ts` has correct version (without `v` prefix)
-- [ ] Changelog entry has correct version (with `v` prefix)
-- [ ] Date is in correct format
-- [ ] All `<Bold>` tags are properly closed
-- [ ] `<ChangelogEntry>` tag is properly closed
-- [ ] New entry is at the top of the changelog file
-- [ ] `README.md` version badge updated
-- [ ] `README.md` release date badge updated
-- [ ] `README.zh-CN.md` version badge updated
-- [ ] `README.zh-CN.md` release date badge updated
-- [ ] `README.md` features section updated (brief, no details)
-- [ ] `README.zh-CN.md` features section updated (brief, no details)
+### Single source of truth
+- [ ] `siteConfig.ts` `latestVersion` updated (without `v` prefix)
+- [ ] No new hardcoded `vX.Y.Z` strings introduced in `Navbar.tsx`, `Hero.tsx`, `SnapshotHero.tsx`, or locale JSON files
+
+### `downloads.ts`
+- [ ] `RELEASE_DATE` updated (ISO format)
+- [ ] New `history[]` entry prepended (using `VERSION` / `RELEASE_DATE` consts), prior entries kept
+
+### Locale files (×4 — en, zh, ja, es)
+- [ ] `hero.eyebrow` highlights rewritten (translated, `v{{version}}` placeholder kept)
+- [ ] `hero.metaVersion` left untouched (it's `"v{{version}} · {{date}}"` — both interpolated)
+
+### Changelog MDX (×4 — en, zh, ja, es)
+- [ ] New `<ChangelogEntry>` prepended to each locale (body translated)
+- [ ] Locale-specific date format used
+- [ ] All `<Bold>` and `<ChangelogEntry>` tags closed
+
+### README files (×4 — en, zh-CN, ja, es)
+- [ ] Version badge updated
+- [ ] Release-date badge updated (URL-encoded date)
+- [ ] Features section updated (brief, translated)
+
+### Final scan
+- [ ] `grep "v?<previous-version>"` returns only legitimate historical references: changelog entries for that version, "Added in v…" doc lines, `downloads.ts` history array, design specs in `docs/superpowers/`, and `bun.lock` (unrelated packages).
+- [ ] `grep "v?<new-version>"` (literal) outside `siteConfig.ts` and the new changelog/README entries should return nothing — if it does, you reintroduced a hardcoded version somewhere.


### PR DESCRIPTION
## Summary

- **Version** is now sourced solely from `apps/landing/src/app/siteConfig.ts` `latestVersion`. Navbar / Hero / SnapshotHero / `downloads.ts` `VERSION` all derive from it; locale `hero.eyebrow` and `hero.metaVersion` use the `{{version}}` placeholder.
- **Release date** is sourced solely from `apps/landing/src/config/downloads.ts` `RELEASE_DATE` (ISO). Hero `metaVersion` interpolates `{{date}}` via the shared `formatDate` helper extracted to `apps/landing/src/lib/format.ts` (already used by `DownloadHero`).
- The previously orphan `siteConfig.latestVersion` field is now actually consumed.
- `skills/update-version/SKILL.md` rewritten to reflect the new propagation model: `metaVersion` is a pure template (don't touch per release); Navbar / Hero / SnapshotHero are listed as "never edit for a version bump"; checklist warns against reintroducing hardcoded `vX.Y.Z` strings.

## Effect on next release

Only these per-release locations remain:

1. `siteConfig.latestVersion` (one line)
2. `downloads.ts` `RELEASE_DATE` + prepend `history[]` entry
3. 4 locale `hero.eyebrow` highlight phrases (translated)
4. 4 changelog MDX entries (translated)
5. 4 README badges + features sections (translated)

All other UI surfaces (nav badge, hero terminal animation, hero meta line, snapshot meta build, download page kicker) update automatically from the two source-of-truth values.

## Test plan

- [x] `bunx tsc --noEmit` passes (only pre-existing `bun:test` resolution errors in `*.test.ts(x)` remain)
- [x] `bunx @biomejs/biome check` on the changed files reports only the pre-existing `Navbar.tsx` `useEffect` `pathname` dep warning (unrelated)
- [x] `bun run dev:landing` and visually confirm Navbar badge, Hero eyebrow + terminal `Downloading Dockerman vX.Y.Z` + meta line, Snapshot `metaBuild`, and Download page kicker all render the current `siteConfig.latestVersion` and localized `RELEASE_DATE`
- [x] Switch language (en / zh / ja / es) and confirm the localized release date renders via `formatDate`
- [x] `grep -rn "5\.[0-9]\.[0-9]" apps packages --include="*.ts" --include="*.tsx" --include="*.json"` returns version literals only inside `siteConfig.ts`, changelog MDX entries, and unrelated `bun.lock` packages