### PR TITLE
docs(landing): add CLI documentation section

### DIFF
--- a/apps/landing/content/docs/en/cli/advanced.mdx
+++ b/apps/landing/content/docs/en/cli/advanced.mdx
@@ -1,0 +1,111 @@
+---
+title: Advanced and Scripting
+description: Schema, call escape hatch, Cloudflare Quick Tunnels, managed WSL2 engine, and tips for automation.
+---
+
+This page collects the less-frequent CLI commands and the patterns we use when wrapping `dockerman` from shell scripts, CI pipelines, or LLM tools.
+
+## `schema` and `call`
+
+Every backend RPC the daemon exposes is described in a self-documenting schema. `schema` lets you discover what's available; `call` lets you invoke any RPC by name without a dedicated subcommand.
+
+```bash
+dockerman schema
+dockerman schema fetch_logs
+dockerman schema --format mcp-tools
+
+dockerman call ping_host '{"address":"8.8.8.8"}'
+dockerman call hub_search '{"query":"alpine","page_size":5}'
+dockerman call remove_container '{"name":"web","force":true}' --yes
+```
+
+`call` expects a JSON params object. Destructive RPCs require `--yes` (or `-y`) just like the dedicated subcommands. Streaming RPCs cannot be invoked through `call` — use the dedicated streaming commands so you get the proper envelope.
+
+<Callout type="info">
+  `schema --format mcp-tools` emits an MCP-compatible tool registry. Wire it directly into an LLM agent that already speaks Model Context Protocol.
+</Callout>
+
+## Events
+
+```bash
+dockerman events --filter type=container
+dockerman events --filter type=container --filter event=start
+dockerman events --since 2026-05-01T00:00:00Z --until 2026-05-01T01:00:00Z
+```
+
+`events` is a streaming command and always emits NDJSON [envelopes](/en/docs/cli/streaming) on stdout — there is no `--json` flag because there is no plain mode. Repeat `--filter key=value` for additional filters; matching uses Docker's standard filter semantics. `--since` and `--until` accept Unix timestamps or RFC 3339 datetimes.
+
+## Cloudflare Quick Tunnels
+
+Expose a local container port through a public `trycloudflare.com` URL. Quick Tunnels are ad-hoc and unauthenticated; use them for development and live demos, never for production ingress.
+
+```bash
+dockerman tunnel status --json
+dockerman tunnel install --json
+dockerman tunnel targets web --pretty
+dockerman tunnel create web --host-port 8080 --host-port 8081 --install --yes --json
+dockerman tunnel create web --all --install --yes --json
+dockerman tunnel list --pretty
+dockerman tunnel list --all-hosts --pretty
+dockerman tunnel close web --host-port 8080 --host-ip 0.0.0.0
+dockerman tunnel close-container web
+```
+
+`tunnel create` is destructive in the sense that it changes network exposure, so it requires `--yes`. Pass `--install` if `cloudflared` is not yet installed; the CLI streams installation progress before opening the tunnel. SSH-forwarded remote Docker hosts are not supported as tunnel targets.
+
+`--host-port` and `--all` are mutually exclusive: pick specific published ports or expose every port the container publishes. `--host-ip` requires at least one `--host-port`; you cannot bind by IP without naming the port.
+
+## Managed WSL2 engine (Windows)
+
+On Windows, the daemon can manage a dedicated WSL2 distro called `dockerman-backend` that runs Docker Engine for Linux containers. The CLI shares the same engine as the GUI.
+
+```bash
+dockerman wsl status
+dockerman wsl setup
+dockerman wsl start
+dockerman wsl config read
+dockerman wsl config apply ./daemon.json --yes
+dockerman wsl resources --json
+dockerman wsl stop
+dockerman wsl unregister --yes
+```
+
+`wsl setup` imports the bundled Alpine rootfs, installs Docker Engine and Compose v2 plugins, and starts `dockerd` behind a localhost TCP proxy. Re-running `setup` is idempotent and resumes from the current state.
+
+`wsl unregister --yes` deletes the managed distro **and every container, image, and volume inside it**. There is no recovery path; use it only when you are certain.
+
+## Scripting tips
+
+### Pipe `--json` into `jq`
+
+```bash
+dockerman container list --json | jq '.[] | select(.state=="running") | .name'
+dockerman trivy scan myrepo/app:v1 --json \
+  | jq -c 'select(.kind=="result") | .payload.results[] | .vulnerabilities[]?'
+```
+
+### Combine `--yes` with confirmation gates
+
+```bash
+read -p "Delete unused images? [y/N] " ans
+if [[ "$ans" == "y" ]]; then
+  dockerman image prune --filter dangling=true --yes
+fi
+```
+
+The CLI requires `--yes` regardless of how confident your script is. There is no `--force-yes` or environment-variable bypass; this is intentional.
+
+### Detecting daemon discovery failure
+
+```bash
+if ! dockerman host current >/dev/null 2>&1; then
+  echo "daemon not reachable" >&2
+  exit 3
+fi
+```
+
+Daemon discovery and handshake failures exit with code `3`, distinct from RPC-level failures (`1`) and stream failures (`4`).
+
+### Long-running streams in CI
+
+CI runners often kill processes that produce no output for a few minutes. The daemon's 15s heartbeat means streaming commands always produce *something* on the wire, but plain mode hides heartbeats. Use `--json` in CI so heartbeats surface as visible lines, or pipe through `ts` to add timestamps.

--- a/apps/landing/content/docs/en/cli/compose.mdx
+++ b/apps/landing/content/docs/en/cli/compose.mdx
@@ -1,0 +1,68 @@
+---
+title: Compose
+description: Manage Docker Compose projects, deploy from a compose file, and stream pull/up progress from the CLI.
+---
+
+The `compose` command group works against existing Compose projects (anything with the `com.docker.compose.project` label) and can also deploy a fresh project from a compose file.
+
+<Callout type="warn">
+  Compose commands require a Docker runtime. They are unavailable when the selected host is a Podman target.
+</Callout>
+
+## List projects
+
+```bash
+dockerman compose list
+dockerman compose list --pretty
+```
+
+Returns project name, container count, status, and base path.
+
+## Lifecycle
+
+```bash
+dockerman compose up myproject --detach
+dockerman compose stop myproject
+dockerman compose start myproject
+dockerman compose restart myproject --service web
+dockerman compose remove myproject --remove-volumes --yes
+```
+
+`up`, `stop`, `start`, and `restart` all accept the standard global flags:
+
+| Flag | Purpose |
+| --- | --- |
+| `--working-dir <path>` | Override the project's working directory |
+| `--config-files <paths>` | Comma-separated list of compose files |
+| `--env-file <path>` | Override the env file |
+| `--profile <name>` | Activate a Compose profile |
+| `--progress <mode>` | `auto`, `tty`, `plain`, or `quiet` |
+| `--dry-run` | Print what would happen without applying changes |
+| `--service <name>` | Limit `restart`/`stop`/`start` to a single service |
+
+`compose up` accepts `--detach` (default) or `--attach` (streams logs until the streams close).
+
+`compose remove` (also aliased as `compose down`) is destructive and needs `--yes`. Add `--remove-volumes` to delete the project's named volumes.
+
+## Pull
+
+```bash
+dockerman compose pull myproject --json
+dockerman compose pull myproject --service web --json
+```
+
+Streams pull progress as one NDJSON envelope per layer. Use `--json` for machine-readable output, omit it for the human-friendly progress lines.
+
+## Deploy from a compose file
+
+```bash
+dockerman compose deploy myproject ./docker-compose.yml \
+  --env DATABASE_URL=postgres://... \
+  --env LOG_LEVEL=info
+```
+
+`deploy` takes a project name plus a compose file path. The CLI reads the file, resolves any relative paths against its parent directory, and asks the daemon to create or update the project. Repeat `--env` for each variable you want to inject without modifying the compose file on disk.
+
+<Callout type="info">
+  `deploy` and `up` both end up calling the same daemon RPC. Use `deploy` when the compose file is not yet known to Docker, and `up` for a project that already shows up in `compose list`.
+</Callout>

--- a/apps/landing/content/docs/en/cli/containers.mdx
+++ b/apps/landing/content/docs/en/cli/containers.mdx
@@ -1,0 +1,134 @@
+---
+title: Containers
+description: Lifecycle, logs, stats, terminal, and backup/restore commands for Docker containers.
+---
+
+The `container` command group covers the full lifecycle plus streaming attachments and backup/restore. All commands accept `--host` to target a specific host; otherwise the sticky host from `dockerman host use` is used.
+
+## List and inspect
+
+```bash
+dockerman container list
+dockerman container list --pretty
+dockerman container inspect web
+```
+
+`list` returns the same shape the GUI uses: id, name, image, state, port mappings, created time. Add `--pretty` for a column-aligned table.
+
+## Lifecycle
+
+```bash
+dockerman container start web
+dockerman container stop web --timeout 10
+dockerman container restart web --timeout 10
+dockerman container pause web
+dockerman container unpause web
+dockerman container rename web web-old
+```
+
+`stop` and `restart` accept `--timeout` in seconds; the daemon sends `SIGTERM`, then `SIGKILL` after the timeout.
+
+## Create and clone
+
+```bash
+dockerman container create web nginx:latest --platform linux/amd64
+dockerman container create web nginx:latest --config ./run.json
+dockerman container commit web --repo myrepo --tag snapshot --pause
+```
+
+`--config` accepts a JSON file with the same shape as `bollard::ContainerCreateOptions`. `commit` snapshots a running container into a new image.
+
+## Remove
+
+```bash
+dockerman container remove web --force --volumes --yes
+```
+
+`remove` is destructive. It requires `--yes` (or the global `-y` flag); without it the daemon rejects the call. Add `--force` to remove a running container, `--volumes` to delete anonymous volumes.
+
+## Logs
+
+```bash
+dockerman container logs web --tail 50
+dockerman container logs web --follow --tail 5
+dockerman container logs web --since 2026-05-01T00:00:00Z --timestamps
+dockerman container logs web --follow --json
+```
+
+Without `--json`, plain stdout is log lines only; errors go to stderr. With `--json`, the CLI emits one [streaming envelope](/en/docs/cli/streaming) per frame. `--follow` runs until you press Ctrl+C (exit `130`) or the stream ends naturally (exit `0`).
+
+<Callout type="warn">
+  `--until` is incompatible with `--follow`; the CLI rejects the combination before opening a stream. Use `--since`/`--until` for historical fetches and `--follow`/`--since` for tailing.
+</Callout>
+
+## Stats
+
+```bash
+dockerman container stats web
+dockerman container stats web --pretty
+```
+
+`stats` always streams. Each frame is one NDJSON line containing CPU, memory, network, and block I/O counters. Press Ctrl+C to stop (exit `130`).
+
+## Terminal
+
+```bash
+dockerman container terminal web
+dockerman container terminal web --shell /bin/bash --user root
+```
+
+Allocates a PTY through `docker exec` and attaches your terminal. The CLI refuses to run when stdin/stdout is not a TTY; pipe-based scripting should use `dockerman call exec_*` instead.
+
+## Backup and restore
+
+Backup snapshots a container's filesystem (and optional bind mounts) into a single archive. Restore creates a new container from that archive.
+
+<Steps>
+  <Step>
+    ### Inspect what would be archived
+
+    ```bash
+    dockerman container backup-targets web --pretty
+    ```
+
+    Lists the container's volumes and bind mounts, plus a `safe_to_archive` flag for each bind mount.
+  </Step>
+  <Step>
+    ### Create the archive
+
+    ```bash
+    dockerman container backup web \
+      --output ./web.tar.gz \
+      --pause \
+      --include-all-safe-bind-mounts
+    ```
+
+    Use `--include-bind-mount <index>` to opt in per mount, `--no-pause` to skip the pause/unpause cycle, `--force` to override `safe_to_archive` warnings.
+  </Step>
+  <Step>
+    ### Preview an archive
+
+    ```bash
+    dockerman container backup-preview ./web.tar.gz --pretty
+    ```
+
+    Shows the manifest without restoring.
+  </Step>
+  <Step>
+    ### Restore
+
+    ```bash
+    dockerman container restore ./web.tar.gz \
+      --name web-restored \
+      --volume-strategy rename \
+      --port 8080:80 \
+      --yes
+    ```
+
+    Restore is destructive (it creates a new container that may collide with names/volumes), so `--yes` is required. `--volume-strategy` is one of `rename`, `skip`, `overwrite`.
+  </Step>
+</Steps>
+
+<Callout type="warn">
+  Backup paths are resolved on the CLI side to absolute local paths before being sent to the daemon. The daemon refuses relative paths, symlinks pointing outside the workspace, and paths the user cannot read.
+</Callout>

--- a/apps/landing/content/docs/en/cli/images.mdx
+++ b/apps/landing/content/docs/en/cli/images.mdx
@@ -1,0 +1,123 @@
+---
+title: Images, Hub, and Trivy
+description: Pull, build, push, scan, and search Docker images from the CLI.
+---
+
+The `image`, `hub`, and `trivy` command groups together cover the full image lifecycle: discover on Docker Hub, pull, scan for CVEs, build, push, and clean up.
+
+## List, inspect, and tag
+
+```bash
+dockerman image list
+dockerman image list --pretty
+dockerman image inspect nginx:latest
+dockerman image tag nginx:latest myrepo/nginx --tag staging
+dockerman image history nginx:latest
+dockerman image search nginx --pretty
+```
+
+`image search` queries the Docker Engine's `/images/search` endpoint via the connected daemon. For richer results (descriptions, official badges, tag listings), use [`hub search`](#search-docker-hub) below — the two commands talk to different APIs.
+
+## Pull and push
+
+```bash
+dockerman image pull nginx --tag latest
+dockerman image pull ghcr.io/me/app --tag v1 \
+  --username me --credential "$GHCR_TOKEN" \
+  --serveraddress https://ghcr.io \
+  --json
+
+dockerman image push myrepo/app --tag v1 --json
+```
+
+Both commands stream progress as NDJSON envelopes when `--json` is set. Without `--json` the CLI prints human progress lines and a final status. Authentication via `--username` / `--credential` is per-invocation; the GUI's saved registries are not used by CLI calls.
+
+## Build
+
+```bash
+dockerman image build ./Dockerfile --tag myrepo/app:v1 \
+  --context-path ./ \
+  --buildargs "NODE_ENV=production" \
+  --pull --rm --json
+```
+
+Builds stream progress in the same envelope as pull/push. See `dockerman image build --help` for the full set of flags (build-args, labels, network mode, target stage, platform).
+
+## Remove and prune
+
+```bash
+dockerman image remove nginx:old --force --yes
+dockerman image prune --filter dangling=true --yes
+```
+
+Both require `--yes`. `prune` accepts repeated `--filter` arguments using the same syntax as `docker image prune`.
+
+## Export and import
+
+```bash
+dockerman image export nginx:latest ./nginx.tar
+dockerman image import ./nginx.tar --quiet
+```
+
+Export writes a `docker save`-compatible tarball; import reads one back.
+
+## Search Docker Hub
+
+```bash
+dockerman hub search alpine --pretty
+dockerman hub search nginx --page 2 --page-size 20 --json
+dockerman hub image library/alpine --pretty
+dockerman hub tags library/alpine --page 1 --page-size 25 --pretty
+```
+
+`hub search` returns names, descriptions, star counts, and official/automated flags. `hub image` and `hub tags` show repository metadata and published tags for a `<namespace>/<name>` pair.
+
+## Scan with Trivy
+
+Dockerman ships a managed Trivy binary so scans work offline once installed.
+
+<Steps>
+  <Step>
+    ### Check status
+
+    ```bash
+    dockerman trivy status --json
+    dockerman trivy dir --json
+    ```
+
+    `status` reports `installed: true|false` and the resolved version. `dir` prints the absolute install directory.
+  </Step>
+  <Step>
+    ### Install or update
+
+    ```bash
+    dockerman trivy install --json
+    dockerman trivy update --json
+    ```
+
+    Both stream NDJSON progress while downloading the binary and the vulnerability database.
+  </Step>
+  <Step>
+    ### Scan an image
+
+    ```bash
+    dockerman trivy scan alpine:latest --pretty
+    dockerman trivy scan myrepo/app:v1 --json --db-repository ghcr.io/aquasecurity/trivy-db
+    ```
+
+    Scans stream progress frames followed by a single `kind: result` frame containing the report. Pipe `--json` output into `jq` to filter findings.
+  </Step>
+  <Step>
+    ### Remove
+
+    ```bash
+    dockerman trivy remove --yes
+    ```
+
+    Deletes the managed binary and DB cache. Requires `--yes`.
+  </Step>
+</Steps>
+
+<Callout type="info">
+  `hub` and `trivy` share the daemon's outbound network. They respect the host's HTTPS proxy environment but do not use the GUI's per-host SSH tunnel.
+</Callout>

--- a/apps/landing/content/docs/en/cli/index.mdx
+++ b/apps/landing/content/docs/en/cli/index.mdx
@@ -1,0 +1,81 @@
+---
+title: CLI Overview
+description: Daemon-first dockerman CLI for scripting Docker, Kubernetes, Compose, and Trivy workflows from the terminal.
+---
+
+`dockerman` is a thin command-line client that talks to the local **dockerman-daemon** over an authenticated IPC socket. Every feature you can drive from the GUI — containers, images, Compose, Kubernetes read-only, Trivy, Docker Hub, tunnels, WSL — is also reachable from the CLI. Added in v5.3.0.
+
+<Callout type="info">
+  The CLI auto-starts `dockerman-daemon` on demand. You do not need to launch the GUI to use it.
+</Callout>
+
+## Install
+
+The CLI ships in the same release archive as the GUI. Build from source for development:
+
+```bash
+cargo build -p dockerman-cli --release
+./target/release/dockerman --help
+```
+
+The first command that needs a backend will spawn `dockerman-daemon`, write `daemon-ipc.json` into the app data directory, and reuse that handshake for every subsequent call.
+
+## Global flags
+
+| Flag | Purpose |
+| --- | --- |
+| `--host <id>` | Target a specific Docker host. Use `LOCALHOST` for the local socket, or any host id from `dockerman host current`. |
+| `--pretty` | Render human-friendly tables instead of raw JSON (only on commands that opt in). |
+| `--yes` / `-y` | Confirm a destructive command. Required for `remove`, `prune`, `restore`, `tunnel create`, `wsl unregister`, etc. |
+
+## Pick a host
+
+```bash
+dockerman host current
+dockerman host use my-remote
+dockerman --host LOCALHOST container list
+```
+
+`host use` writes the selection to disk; subsequent commands without `--host` use it. Pass `--host` per-command when you want to override without changing the sticky selection.
+
+## System and connectivity
+
+```bash
+dockerman system info
+dockerman system df
+dockerman system ping 8.8.8.8
+dockerman system prune --containers --volumes --yes
+```
+
+## Schema and discovery
+
+Every RPC the daemon exposes is described in a versioned schema. Use it to discover commands, generate clients, or feed an LLM tool registry.
+
+```bash
+dockerman schema
+dockerman schema --format mcp-tools
+dockerman schema fetch_logs
+```
+
+The current schema version is `2`. See [Streaming contract](/en/docs/cli/streaming) for the unary vs streaming distinction.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success, or stream ended naturally |
+| `1` | Generic failure (validation, RPC error, stream body error) |
+| `3` | Discovery or handshake failure (daemon not reachable) |
+| `4` | Streaming heartbeat timeout (no frame for 30s) |
+| `130` | `SIGINT` (Ctrl+C) on a streaming command |
+| `143` | `SIGTERM` on a streaming command |
+
+## What the CLI does not cover
+
+Some workflows live only in the GUI:
+
+- Scheduler tasks and notification channels
+- Alert rules (preset rules run on the daemon, but creation/edit is GUI-only)
+- Time-series metrics history
+
+The full list of CLI commands matches `dockerman --help`. The pages in this section group them by domain.

--- a/apps/landing/content/docs/en/cli/kubernetes.mdx
+++ b/apps/landing/content/docs/en/cli/kubernetes.mdx
@@ -1,0 +1,118 @@
+---
+title: Kubernetes
+description: Read-only Kubernetes commands for cluster discovery, namespace selection, and resource inspection.
+---
+
+The `k8s` command group is **read-only**: it discovers clusters from your kubeconfig, switches between them, and inspects pods, deployments, configmaps, secrets, nodes, and any custom resource the cluster exposes. It does not create, update, or delete resources.
+
+## Pick a cluster and namespace
+
+```bash
+dockerman k8s cluster list
+dockerman k8s cluster current
+dockerman k8s cluster use kubeconfig:dev-context
+dockerman k8s namespace list --cluster kubeconfig:dev-context
+dockerman k8s namespace use workloads --cluster kubeconfig:dev-context
+dockerman k8s namespace current --cluster kubeconfig:dev-context
+```
+
+`cluster use` and `namespace use` write a sticky selection to disk. Subsequent commands without `--cluster` / `--namespace` use that selection.
+
+<Callout type="info">
+  Cluster ids look like `kubeconfig:<context-name>`. Run `dockerman k8s cluster list` to see the exact id for each context the CLI discovers.
+</Callout>
+
+## Cluster overview
+
+```bash
+dockerman k8s overview
+dockerman k8s overview --cluster kubeconfig:dev-context --namespace workloads --pretty
+```
+
+Returns a single-shot snapshot: counts of nodes, pods, deployments, services, plus warning-level events. Useful as a health probe before drilling into individual resources.
+
+## Workload resources
+
+Each workload resource accepts `list` and `get`:
+
+```bash
+dockerman k8s pod list
+dockerman k8s pod get my-pod --namespace workloads
+dockerman k8s deployment list --pretty
+dockerman k8s service get my-svc
+dockerman k8s statefulset list
+dockerman k8s daemonset list
+dockerman k8s job list
+dockerman k8s cronjob list
+dockerman k8s replicaset list
+```
+
+## Networking
+
+```bash
+dockerman k8s ingress list
+dockerman k8s endpoint list
+dockerman k8s endpointslice list
+dockerman k8s networkpolicy list
+```
+
+## Config and storage
+
+```bash
+dockerman k8s configmap list
+dockerman k8s secret list
+dockerman k8s secret get app-secret
+dockerman k8s pvc list
+```
+
+## Cluster-scoped
+
+```bash
+dockerman k8s node list
+dockerman k8s node get worker-1
+dockerman k8s pv list
+dockerman k8s storageclass list
+dockerman k8s clusterrole list
+dockerman k8s clusterrolebinding list
+dockerman k8s crd list
+```
+
+## RBAC
+
+```bash
+dockerman k8s serviceaccount list
+dockerman k8s role list
+dockerman k8s rolebinding list
+```
+
+## Pod logs
+
+```bash
+dockerman k8s pod logs my-pod --namespace workloads
+dockerman k8s pod logs my-pod --container app --tail-lines 100 --timestamps
+dockerman k8s pod logs my-pod --previous --since-time 2026-05-01T00:00:00Z
+```
+
+## Events
+
+```bash
+dockerman k8s event list
+dockerman k8s event list --type Warning --involved-kind Pod
+```
+
+## Generic resources and YAML
+
+For any resource not listed above (custom resources, less-common built-ins), use the generic `resource` subcommand. Discover what's available with `api-resource list`.
+
+```bash
+dockerman k8s api-resource list --cluster kubeconfig:dev-context
+dockerman k8s resource list deployments.apps/v1 --namespace workloads
+dockerman k8s resource yaml secrets.core/v1 app-secret
+dockerman k8s resource yaml mycrd.example.com/v1alpha1 my-instance --json
+```
+
+`resource yaml` prints the redacted manifest. Secret data is replaced with `<REDACTED>` before it leaves the daemon — you cannot retrieve secret values through the CLI.
+
+<Callout type="warn">
+  All k8s commands are read-only by design. To apply changes, use `kubectl` directly. Dockerman's k8s surface is intended for safe inspection from automation and from the GUI.
+</Callout>

--- a/apps/landing/content/docs/en/cli/meta.json
+++ b/apps/landing/content/docs/en/cli/meta.json
@@ -1,0 +1,14 @@
+{
+  "title": "CLI",
+  "pages": [
+    "index",
+    "containers",
+    "images",
+    "networks-volumes",
+    "compose",
+    "kubernetes",
+    "streaming",
+    "advanced"
+  ],
+  "defaultOpen": false
+}

--- a/apps/landing/content/docs/en/cli/networks-volumes.mdx
+++ b/apps/landing/content/docs/en/cli/networks-volumes.mdx
@@ -1,0 +1,93 @@
+---
+title: Networks and Volumes
+description: Manage Docker networks and volumes from the CLI — create, inspect, connect, prune.
+---
+
+The `network` and `volume` command groups expose every operation the GUI offers for these two resource types. Both follow the same patterns as `container` and `image`: `list`, `inspect`, `create`, `remove`/`prune`, plus relationship commands for networks.
+
+## Networks
+
+### List and inspect
+
+```bash
+dockerman network list
+dockerman network list --pretty
+dockerman network inspect bridge
+```
+
+### Create
+
+```bash
+dockerman network create my-net \
+  --driver bridge \
+  --attachable \
+  --enable-ipv6 \
+  --option "com.docker.network.bridge.name=my-bridge" \
+  --label "owner=team-a"
+```
+
+| Flag | Purpose |
+| --- | --- |
+| `--driver <name>` | Network driver (`bridge`, `overlay`, `macvlan`, etc.) |
+| `--internal` | Restrict external connectivity |
+| `--attachable` | Allow standalone containers to attach (overlay only) |
+| `--ingress` | Create the swarm ingress network |
+| `--enable-ipv6` | Enable IPv6 on the network |
+| `--option <k=v>` | Driver-specific option (repeatable) |
+| `--label <k=v>` | Network label (repeatable) |
+
+### Remove
+
+```bash
+dockerman network remove my-net --yes
+```
+
+`remove` requires `--yes`. Built-in networks (`bridge`, `host`, `none`) cannot be removed.
+
+### Connect and disconnect
+
+```bash
+dockerman network connect my-net web
+dockerman network disconnect my-net web --force
+```
+
+`disconnect --force` is required when the container is running and you need to detach it without stopping it.
+
+## Volumes
+
+### List and inspect
+
+```bash
+dockerman volume list
+dockerman volume list --pretty
+dockerman volume inspect data
+```
+
+### Create
+
+```bash
+dockerman volume create data \
+  --driver local \
+  --driver-opt "type=nfs" \
+  --driver-opt "o=addr=10.0.0.1,rw" \
+  --driver-opt "device=:/exports/data" \
+  --label "backup=daily"
+```
+
+`--driver-opt` and `--label` are both repeatable.
+
+### Remove
+
+```bash
+dockerman volume remove data --force --yes
+```
+
+`remove` requires `--yes`. `--force` removes a volume even if it is referenced by a stopped container.
+
+### Prune
+
+```bash
+dockerman volume prune --filter "label=temp=true" --yes
+```
+
+`prune` deletes every dangling (unreferenced) volume that matches the filter set. `--filter` is repeatable and uses Docker's standard filter syntax (`label=`, `label!=`, etc.). Always combine with explicit filters in scripts — bare `volume prune --yes` deletes every dangling volume on the host.

--- a/apps/landing/content/docs/en/cli/streaming.mdx
+++ b/apps/landing/content/docs/en/cli/streaming.mdx
@@ -1,0 +1,74 @@
+---
+title: Streaming Contract
+description: NDJSON envelope, heartbeat, backpressure, and signal handling for streaming RPCs.
+---
+
+Streaming RPCs (`logs -f`, `stats`, `events`, `image pull/push/build`, `compose pull/up`, `trivy scan/install`, `tunnel create`) all share the same wire contract introduced in v5.3.0 with schema version `2`.
+
+## Envelope
+
+When you pass `--json` to a streaming command, each line on stdout is one envelope. The outer envelope carries a monotonic `seq` and a `type` discriminator; data frames carry their typed payload under `payload`.
+
+```json
+{"seq":1,"type":"data","payload":{"line":"hello"}}
+{"seq":2,"type":"heartbeat"}
+{"seq":3,"type":"dropped","payload":{"count":12}}
+{"seq":4,"type":"data","payload":{"kind":"result","report":{"...":"..."}}}
+{"seq":5,"type":"end"}
+{"seq":6,"type":"error","payload":{"code":"docker_not_found","message":"container web not found","details":null}}
+```
+
+| `type` | Meaning |
+| --- | --- |
+| `data` | A normal frame; the typed payload sits in `payload` |
+| `heartbeat` | Liveness ping. Default interval is 15s |
+| `dropped` | Backpressure marker. The daemon dropped `payload.count` frames; emitted before the next frame of any type |
+| `end` | Stream finished cleanly. No more frames will arrive |
+| `error` | Terminal error. `payload` carries `{ code, message, details }`; the stream ends after this frame |
+
+<Callout type="info">
+  Some commands (Trivy scan, Trivy install, Compose pull) embed a second tag inside the data payload. For example, `dockerman trivy scan` emits `data` frames whose `payload.kind` is `"progress"`, `"result"`, or `"error"` — the inner `error` is a stream-internal failure carried over a successful `data` envelope, while the outer `error` envelope is reserved for transport-level failures.
+</Callout>
+
+## Plain mode
+
+Without `--json`, streaming commands print human-friendly output:
+
+- `logs -f`, `events`: one log line per data frame on stdout, errors and diagnostics on stderr.
+- `stats`, `image pull/push/build`, `compose pull/up`, `trivy install/scan`: progress lines on stderr (so you can pipe stdout into a file), final result on stdout when applicable.
+
+## Heartbeat and timeout
+
+The daemon emits a heartbeat every 15s. The CLI waits up to 30s (two heartbeats) before declaring the stream dead and exiting with code `4`. If you wrap CLI calls in a longer pipeline, do not buffer stdout — buffering can hide heartbeats and trigger false-positive timeouts in your own monitoring.
+
+## Backpressure
+
+Each stream has a 256-frame buffer between the daemon and the CLI. When the consumer is slow, the daemon drops the oldest frames and emits a single `Dropped { count }` frame before the next data frame. This keeps streams alive even when terminals (or `jq -c`) lag behind producers.
+
+## Cancellation
+
+Pressing **Ctrl+C** sends `SIGINT`; the CLI catches it, asks the daemon to cancel via `CancelOnDrop`, drains the in-flight frames, and exits with code `130`. `SIGTERM` exits with `143`. The daemon also notices when the TCP/Unix-socket connection drops (browser tab closed, parent process killed) and frees server-side resources without leaking goroutines.
+
+## Exit codes for streams
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Stream ended naturally (container stopped, image fully pulled, scan completed) |
+| `1` | Stream body error after the connection succeeded (also covers pre-body 4xx) |
+| `3` | Daemon discovery / handshake failed before the stream opened |
+| `4` | Heartbeat timeout (no frame for 30s) |
+| `130` | `SIGINT` |
+| `143` | `SIGTERM` |
+
+## Inspect the schema
+
+You can list every streaming RPC and its envelope shape:
+
+```bash
+dockerman schema --format mcp-tools
+dockerman schema follow_logs
+dockerman schema follow_stats
+dockerman schema monitor_events
+```
+
+Streaming RPCs are marked with `streaming: true` and a `StreamFrameEnvelope` reference. Unary callable RPCs (e.g. `fetch_logs`) are marked `callable: true` and have a normal `result` schema.

--- a/apps/landing/content/docs/en/meta.json
+++ b/apps/landing/content/docs/en/meta.json
@@ -8,6 +8,7 @@
     "kubernetes",
     "---",
     "homelab",
+    "cli",
     "advanced",
     "platform",
     "reference"

--- a/apps/landing/content/docs/es/cli/advanced.mdx
+++ b/apps/landing/content/docs/es/cli/advanced.mdx
@@ -1,0 +1,111 @@
+---
+title: "Avanzado y scripting"
+description: "Schema, escape hatch call, Cloudflare Quick Tunnels, motor WSL2 gestionado y consejos para automatización."
+---
+
+Esta página recopila los comandos CLI menos frecuentes y los patrones que usamos al envolver `dockerman` desde shell scripts, pipelines de CI o herramientas LLM.
+
+## `schema` y `call`
+
+Cada RPC backend que el daemon expone está descrito en un schema autocontenido. `schema` te permite descubrir lo que hay disponible; `call` te permite invocar cualquier RPC por nombre sin un subcomando dedicado.
+
+```bash
+dockerman schema
+dockerman schema fetch_logs
+dockerman schema --format mcp-tools
+
+dockerman call ping_host '{"address":"8.8.8.8"}'
+dockerman call hub_search '{"query":"alpine","page_size":5}'
+dockerman call remove_container '{"name":"web","force":true}' --yes
+```
+
+`call` espera un objeto JSON de params. Los RPCs destructivos requieren `--yes` (o `-y`) igual que los subcomandos dedicados. **Los RPCs en streaming no se pueden invocar mediante `call`** — usa los comandos de streaming dedicados para obtener el envelope correcto.
+
+<Callout type="info">
+  `schema --format mcp-tools` emite un registro de herramientas compatible con MCP. Conéctalo directamente a un agente LLM que ya hable Model Context Protocol.
+</Callout>
+
+## Eventos
+
+```bash
+dockerman events --filter type=container
+dockerman events --filter type=container --filter event=start
+dockerman events --since 2026-05-01T00:00:00Z --until 2026-05-01T01:00:00Z
+```
+
+`events` es un comando en streaming y siempre emite [envelopes](/es/docs/cli/streaming) NDJSON en stdout — no hay flag `--json` porque no hay modo plano. Repite `--filter key=value` para filtros adicionales; el matching usa la semántica estándar de filtros de Docker. `--since` y `--until` aceptan timestamps Unix o datetimes RFC 3339.
+
+## Cloudflare Quick Tunnels
+
+Expón un puerto local de un contenedor mediante una URL pública `trycloudflare.com`. Los Quick Tunnels son ad-hoc y no autenticados; úsalos para desarrollo y demos en vivo, nunca como ingress de producción.
+
+```bash
+dockerman tunnel status --json
+dockerman tunnel install --json
+dockerman tunnel targets web --pretty
+dockerman tunnel create web --host-port 8080 --host-port 8081 --install --yes --json
+dockerman tunnel create web --all --install --yes --json
+dockerman tunnel list --pretty
+dockerman tunnel list --all-hosts --pretty
+dockerman tunnel close web --host-port 8080 --host-ip 0.0.0.0
+dockerman tunnel close-container web
+```
+
+`tunnel create` es destructivo en el sentido de que cambia la exposición de red, así que requiere `--yes`. Pasa `--install` si `cloudflared` aún no está instalado; la CLI transmite el progreso de instalación antes de abrir el túnel. Los hosts Docker remotos forwardeados por SSH no están soportados como destino de túneles.
+
+`--host-port` y `--all` son mutuamente excluyentes: o eliges puertos publicados específicos o expones cada puerto que el contenedor publica. `--host-ip` requiere al menos un `--host-port`; no puedes hacer bind por IP sin nombrar el puerto.
+
+## Motor WSL2 gestionado (Windows)
+
+En Windows, el daemon puede gestionar una distro WSL2 dedicada llamada `dockerman-backend` que ejecuta Docker Engine para contenedores Linux. La CLI comparte el mismo motor que la GUI.
+
+```bash
+dockerman wsl status
+dockerman wsl setup
+dockerman wsl start
+dockerman wsl config read
+dockerman wsl config apply ./daemon.json --yes
+dockerman wsl resources --json
+dockerman wsl stop
+dockerman wsl unregister --yes
+```
+
+`wsl setup` importa el rootfs Alpine empaquetado, instala Docker Engine y los plugins de Compose v2, y arranca `dockerd` detrás de un proxy TCP de localhost. Volver a ejecutar `setup` es idempotente y reanuda desde el estado actual.
+
+`wsl unregister --yes` borra la distro gestionada **y todos los contenedores, imágenes y volúmenes que contiene**. No hay vuelta atrás; úsalo sólo cuando estés seguro.
+
+## Consejos de scripting
+
+### Canalizar `--json` a `jq`
+
+```bash
+dockerman container list --json | jq '.[] | select(.state=="running") | .name'
+dockerman trivy scan myrepo/app:v1 --json \
+  | jq -c 'select(.kind=="result") | .payload.results[] | .vulnerabilities[]?'
+```
+
+### Combinar `--yes` con un gate de confirmación
+
+```bash
+read -p "¿Borrar imágenes sin uso? [y/N] " ans
+if [[ "$ans" == "y" ]]; then
+  dockerman image prune --filter dangling=true --yes
+fi
+```
+
+La CLI siempre exige `--yes`, sin importar lo confiado que esté tu script. **No existe** `--force-yes` ni un bypass por variable de entorno; es intencional.
+
+### Detectar fallo de descubrimiento del daemon
+
+```bash
+if ! dockerman host current >/dev/null 2>&1; then
+  echo "daemon inalcanzable" >&2
+  exit 3
+fi
+```
+
+Los fallos de descubrimiento y handshake del daemon salen con código `3`, distinto de los fallos a nivel RPC (`1`) y de los fallos de stream (`4`).
+
+### Streams largos en CI
+
+Los runners de CI suelen matar procesos que no producen salida durante unos minutos. El heartbeat de 15s del daemon garantiza que los comandos de streaming siempre produzcan *algo* por el cable, pero el modo plano oculta los heartbeats. Usa `--json` en CI para que los heartbeats salgan como líneas visibles, o canaliza por `ts` para añadir timestamps a cada línea.

--- a/apps/landing/content/docs/es/cli/compose.mdx
+++ b/apps/landing/content/docs/es/cli/compose.mdx
@@ -1,0 +1,68 @@
+---
+title: "Compose"
+description: "Gestiona proyectos Docker Compose, despliega desde un fichero compose y transmite el progreso de pull/up desde la CLI."
+---
+
+El grupo `compose` opera sobre proyectos Compose existentes (cualquier recurso con la etiqueta `com.docker.compose.project`) y también puede desplegar un proyecto nuevo desde un fichero compose.
+
+<Callout type="warn">
+  Los comandos de Compose requieren un runtime Docker. No están disponibles cuando el host seleccionado es un objetivo Podman.
+</Callout>
+
+## Listar proyectos
+
+```bash
+dockerman compose list
+dockerman compose list --pretty
+```
+
+Devuelve nombre del proyecto, número de contenedores, estado y ruta base.
+
+## Ciclo de vida
+
+```bash
+dockerman compose up myproject --detach
+dockerman compose stop myproject
+dockerman compose start myproject
+dockerman compose restart myproject --service web
+dockerman compose remove myproject --remove-volumes --yes
+```
+
+`up`, `stop`, `start` y `restart` aceptan los flags globales estándar:
+
+| Flag | Propósito |
+| --- | --- |
+| `--working-dir <ruta>` | Sobrescribe el directorio de trabajo del proyecto |
+| `--config-files <rutas>` | Lista de ficheros compose separados por comas |
+| `--env-file <ruta>` | Sobrescribe el fichero env |
+| `--profile <nombre>` | Activa un perfil de Compose |
+| `--progress <modo>` | `auto`, `tty`, `plain` o `quiet` |
+| `--dry-run` | Imprime qué pasaría sin aplicar cambios |
+| `--service <nombre>` | Limita `restart`/`stop`/`start` a un único servicio |
+
+`compose up` acepta `--detach` (por defecto) o `--attach` (transmite logs hasta que los streams se cierren).
+
+`compose remove` (también con alias `compose down`) es destructivo y necesita `--yes`. Añade `--remove-volumes` para borrar los volúmenes nombrados del proyecto.
+
+## Pull
+
+```bash
+dockerman compose pull myproject --json
+dockerman compose pull myproject --service web --json
+```
+
+Transmite el progreso del pull como un envelope NDJSON por capa. Usa `--json` para salida procesable por máquinas, omítelo para las líneas de progreso legibles.
+
+## Desplegar desde un fichero compose
+
+```bash
+dockerman compose deploy myproject ./docker-compose.yml \
+  --env DATABASE_URL=postgres://... \
+  --env LOG_LEVEL=info
+```
+
+`deploy` toma un nombre de proyecto más una ruta a un fichero compose. La CLI lee el fichero, resuelve las rutas relativas contra su directorio padre y pide al daemon que cree o actualice el proyecto. Repite `--env` para cada variable que quieras inyectar sin modificar el fichero compose en disco.
+
+<Callout type="info">
+  `deploy` y `up` acaban llamando al mismo RPC del daemon. Usa `deploy` cuando el fichero compose aún no es conocido por Docker, y `up` para un proyecto que ya aparece en `compose list`.
+</Callout>

--- a/apps/landing/content/docs/es/cli/containers.mdx
+++ b/apps/landing/content/docs/es/cli/containers.mdx
@@ -1,0 +1,134 @@
+---
+title: "Contenedores"
+description: "Ciclo de vida, logs, stats, terminal y comandos de backup/restore para contenedores Docker."
+---
+
+El grupo `container` cubre el ciclo de vida completo más los attach en streaming y backup/restore. Todos los comandos aceptan `--host` para apuntar a un host concreto; si no se indica, se usa el host persistente fijado con `dockerman host use`.
+
+## Listar e inspeccionar
+
+```bash
+dockerman container list
+dockerman container list --pretty
+dockerman container inspect web
+```
+
+`list` devuelve la misma estructura que la GUI: id, nombre, imagen, estado, mapeo de puertos, fecha de creación. Añade `--pretty` para obtener una tabla alineada por columnas.
+
+## Ciclo de vida
+
+```bash
+dockerman container start web
+dockerman container stop web --timeout 10
+dockerman container restart web --timeout 10
+dockerman container pause web
+dockerman container unpause web
+dockerman container rename web web-old
+```
+
+`stop` y `restart` aceptan `--timeout` en segundos; el daemon envía `SIGTERM` y luego `SIGKILL` tras el timeout.
+
+## Crear y clonar
+
+```bash
+dockerman container create web nginx:latest --platform linux/amd64
+dockerman container create web nginx:latest --config ./run.json
+dockerman container commit web --repo myrepo --tag snapshot --pause
+```
+
+`--config` admite un fichero JSON con la misma forma que `bollard::ContainerCreateOptions`. `commit` toma una snapshot de un contenedor en ejecución como nueva imagen.
+
+## Eliminar
+
+```bash
+dockerman container remove web --force --volumes --yes
+```
+
+`remove` es destructivo. Necesita `--yes` (o el flag global `-y`); sin él, el daemon rechaza la llamada. Añade `--force` para eliminar un contenedor en marcha y `--volumes` para borrar los volúmenes anónimos.
+
+## Logs
+
+```bash
+dockerman container logs web --tail 50
+dockerman container logs web --follow --tail 5
+dockerman container logs web --since 2026-05-01T00:00:00Z --timestamps
+dockerman container logs web --follow --json
+```
+
+Sin `--json`, stdout sólo contiene líneas de log; los errores van a stderr. Con `--json`, la CLI emite un [envelope de streaming](/es/docs/cli/streaming) por frame. `--follow` corre hasta que pulses Ctrl+C (salida `130`) o el stream termine de forma natural (salida `0`).
+
+<Callout type="warn">
+  `--until` es incompatible con `--follow`; la CLI rechaza esa combinación antes de abrir el stream. Usa `--since`/`--until` para descargas históricas y `--follow`/`--since` para seguimiento en vivo.
+</Callout>
+
+## Stats
+
+```bash
+dockerman container stats web
+dockerman container stats web --pretty
+```
+
+`stats` siempre se transmite en streaming. Cada frame es una línea NDJSON con contadores de CPU, memoria, red y E/S de bloque. Pulsa Ctrl+C para detener (salida `130`).
+
+## Terminal
+
+```bash
+dockerman container terminal web
+dockerman container terminal web --shell /bin/bash --user root
+```
+
+Asigna un PTY mediante `docker exec` y lo conecta a tu terminal. La CLI rechaza la ejecución cuando stdin/stdout no son una TTY; los scripts basados en pipes deben usar `dockerman call exec_*`.
+
+## Backup y restore
+
+Backup empaqueta el sistema de ficheros del contenedor (y los bind mounts opcionales) en un único archivo. Restore crea un nuevo contenedor a partir de ese archivo.
+
+<Steps>
+  <Step>
+    ### Inspeccionar lo que se archivaría
+
+    ```bash
+    dockerman container backup-targets web --pretty
+    ```
+
+    Lista los volúmenes y bind mounts del contenedor, con un flag `safe_to_archive` por cada bind mount.
+  </Step>
+  <Step>
+    ### Crear el archivo
+
+    ```bash
+    dockerman container backup web \
+      --output ./web.tar.gz \
+      --pause \
+      --include-all-safe-bind-mounts
+    ```
+
+    Usa `--include-bind-mount <índice>` para activar mounts uno a uno, `--no-pause` para saltarte el ciclo pause/unpause, `--force` para anular las advertencias `safe_to_archive`.
+  </Step>
+  <Step>
+    ### Previsualizar un archivo
+
+    ```bash
+    dockerman container backup-preview ./web.tar.gz --pretty
+    ```
+
+    Muestra el manifest sin restaurar nada.
+  </Step>
+  <Step>
+    ### Restaurar
+
+    ```bash
+    dockerman container restore ./web.tar.gz \
+      --name web-restored \
+      --volume-strategy rename \
+      --port 8080:80 \
+      --yes
+    ```
+
+    Restore es destructivo (crea un contenedor que puede chocar con nombres/volúmenes existentes), por lo que `--yes` es obligatorio. `--volume-strategy` admite `rename`, `skip` u `overwrite`.
+  </Step>
+</Steps>
+
+<Callout type="warn">
+  Las rutas de backup se resuelven en la CLI a rutas locales absolutas antes de enviarlas al daemon. El daemon rechaza rutas relativas, symlinks que apunten fuera del workspace y rutas que el usuario no pueda leer.
+</Callout>

--- a/apps/landing/content/docs/es/cli/images.mdx
+++ b/apps/landing/content/docs/es/cli/images.mdx
@@ -1,0 +1,123 @@
+---
+title: "Imágenes, Hub y Trivy"
+description: "Pull, build, push, escaneo y búsqueda de imágenes Docker desde la CLI."
+---
+
+Los grupos `image`, `hub` y `trivy` cubren juntos el ciclo de vida completo de las imágenes: descubrir en Docker Hub, hacer pull, escanear CVEs, build, push y limpieza.
+
+## Listar, inspeccionar y etiquetar
+
+```bash
+dockerman image list
+dockerman image list --pretty
+dockerman image inspect nginx:latest
+dockerman image tag nginx:latest myrepo/nginx --tag staging
+dockerman image history nginx:latest
+dockerman image search nginx --pretty
+```
+
+`image search` consulta el endpoint `/images/search` del Docker Engine a través del daemon conectado. Para resultados más ricos (descripciones, badges oficiales, listado de tags), usa [`hub search`](#buscar-en-docker-hub) más abajo — los dos comandos hablan con APIs distintas.
+
+## Pull y push
+
+```bash
+dockerman image pull nginx --tag latest
+dockerman image pull ghcr.io/me/app --tag v1 \
+  --username me --credential "$GHCR_TOKEN" \
+  --serveraddress https://ghcr.io \
+  --json
+
+dockerman image push myrepo/app --tag v1 --json
+```
+
+Ambos comandos transmiten progreso como envelopes NDJSON cuando se pasa `--json`. Sin `--json` la CLI imprime líneas de progreso legibles y un estado final. La autenticación con `--username` / `--credential` es por invocación; las credenciales guardadas en la GUI no se reutilizan en la CLI.
+
+## Build
+
+```bash
+dockerman image build ./Dockerfile --tag myrepo/app:v1 \
+  --context-path ./ \
+  --buildargs "NODE_ENV=production" \
+  --pull --rm --json
+```
+
+Los builds transmiten progreso con el mismo envelope que pull/push. Para el conjunto completo de flags (build-args, labels, network mode, target stage, platform), consulta `dockerman image build --help`.
+
+## Eliminar y purgar
+
+```bash
+dockerman image remove nginx:old --force --yes
+dockerman image prune --filter dangling=true --yes
+```
+
+Ambos requieren `--yes`. `prune` admite `--filter` repetidos con la misma sintaxis que `docker image prune`.
+
+## Exportar e importar
+
+```bash
+dockerman image export nginx:latest ./nginx.tar
+dockerman image import ./nginx.tar --quiet
+```
+
+`export` escribe un tarball compatible con `docker save`; `import` lo lee de vuelta.
+
+## Buscar en Docker Hub
+
+```bash
+dockerman hub search alpine --pretty
+dockerman hub search nginx --page 2 --page-size 20 --json
+dockerman hub image library/alpine --pretty
+dockerman hub tags library/alpine --page 1 --page-size 25 --pretty
+```
+
+`hub search` devuelve nombre, descripción, número de estrellas y los flags official/automated. `hub image` y `hub tags` muestran metadatos del repositorio y los tags publicados de un par `<namespace>/<name>`.
+
+## Escanear con Trivy
+
+Dockerman incluye un binario de Trivy gestionado, así los escaneos funcionan offline una vez instalado.
+
+<Steps>
+  <Step>
+    ### Comprobar el estado
+
+    ```bash
+    dockerman trivy status --json
+    dockerman trivy dir --json
+    ```
+
+    `status` reporta `installed: true|false` y la versión resuelta. `dir` imprime el directorio de instalación absoluto.
+  </Step>
+  <Step>
+    ### Instalar o actualizar
+
+    ```bash
+    dockerman trivy install --json
+    dockerman trivy update --json
+    ```
+
+    Ambos transmiten progreso NDJSON mientras descargan el binario y la base de datos de vulnerabilidades.
+  </Step>
+  <Step>
+    ### Escanear una imagen
+
+    ```bash
+    dockerman trivy scan alpine:latest --pretty
+    dockerman trivy scan myrepo/app:v1 --json --db-repository ghcr.io/aquasecurity/trivy-db
+    ```
+
+    Los escaneos transmiten frames de progreso seguidos de un único frame `kind: result` con el informe. Filtra hallazgos canalizando la salida `--json` a `jq`.
+  </Step>
+  <Step>
+    ### Eliminar
+
+    ```bash
+    dockerman trivy remove --yes
+    ```
+
+    Borra el binario gestionado y la cache de la BD. Requiere `--yes`.
+  </Step>
+</Steps>
+
+<Callout type="info">
+  `hub` y `trivy` comparten la red saliente del daemon. Respetan las variables de entorno HTTPS proxy del host pero **no** usan el túnel SSH por host configurado en la GUI.
+</Callout>

--- a/apps/landing/content/docs/es/cli/index.mdx
+++ b/apps/landing/content/docs/es/cli/index.mdx
@@ -1,0 +1,81 @@
+---
+title: "Resumen de la CLI"
+description: "CLI dockerman daemon-first para automatizar flujos de Docker, Kubernetes, Compose y Trivy desde la terminal."
+---
+
+`dockerman` es un cliente de línea de comandos ligero que se comunica con el **dockerman-daemon** local a través de un socket IPC autenticado. Cada función disponible en la GUI — contenedores, imágenes, Compose, Kubernetes en modo lectura, Trivy, Docker Hub, túneles, WSL — es accesible también desde la CLI. Añadido en v5.3.0.
+
+<Callout type="info">
+  La CLI inicia `dockerman-daemon` automáticamente cuando hace falta. No necesitas abrir la GUI para usarla.
+</Callout>
+
+## Instalación
+
+La CLI se distribuye en el mismo paquete de release que la GUI. Para compilar desde fuente en desarrollo:
+
+```bash
+cargo build -p dockerman-cli --release
+./target/release/dockerman --help
+```
+
+El primer comando que necesite el backend lanzará `dockerman-daemon`, escribirá `daemon-ipc.json` en el directorio de datos de la app y reutilizará ese handshake en cada llamada posterior.
+
+## Flags globales
+
+| Flag | Propósito |
+| --- | --- |
+| `--host <id>` | Apunta a un host Docker concreto. Usa `LOCALHOST` para el socket local, o cualquier id de host de `dockerman host current`. |
+| `--pretty` | Renderiza tablas legibles en lugar de JSON crudo (sólo en comandos que lo aceptan). |
+| `--yes` / `-y` | Confirma una operación destructiva. Obligatorio en `remove`, `prune`, `restore`, `tunnel create`, `wsl unregister`, etc. |
+
+## Elegir un host
+
+```bash
+dockerman host current
+dockerman host use my-remote
+dockerman --host LOCALHOST container list
+```
+
+`host use` persiste la elección en disco; los comandos posteriores sin `--host` la usan. Pasa `--host` por comando cuando quieras anular sin cambiar la selección persistente.
+
+## Sistema y conectividad
+
+```bash
+dockerman system info
+dockerman system df
+dockerman system ping 8.8.8.8
+dockerman system prune --containers --volumes --yes
+```
+
+## Schema y descubrimiento
+
+Cada RPC que el daemon expone está descrito en un schema versionado. Úsalo para descubrir comandos, generar clientes o alimentar un registro de herramientas LLM.
+
+```bash
+dockerman schema
+dockerman schema --format mcp-tools
+dockerman schema fetch_logs
+```
+
+La versión actual del schema es `2`. Consulta el [Contrato de streaming](/es/docs/cli/streaming) para la diferencia entre RPCs unarios y de streaming.
+
+## Códigos de salida
+
+| Código | Significado |
+| --- | --- |
+| `0` | Éxito, o el stream terminó de forma natural |
+| `1` | Fallo genérico (validación, error de RPC, error en el cuerpo del stream) |
+| `3` | Fallo de descubrimiento o handshake (daemon inalcanzable) |
+| `4` | Timeout de heartbeat de stream (ningún frame en 30s) |
+| `130` | `SIGINT` (Ctrl+C) en un comando de streaming |
+| `143` | `SIGTERM` en un comando de streaming |
+
+## Lo que la CLI no cubre
+
+Algunos flujos sólo viven en la GUI:
+
+- Tareas del scheduler y canales de notificación
+- Reglas de alerta (las reglas predefinidas se ejecutan en el daemon, pero crear/editar es sólo GUI)
+- Histórico de métricas time-series
+
+La lista completa de comandos coincide con `dockerman --help`. Las páginas de esta sección los agrupan por dominio.

--- a/apps/landing/content/docs/es/cli/kubernetes.mdx
+++ b/apps/landing/content/docs/es/cli/kubernetes.mdx
@@ -1,0 +1,118 @@
+---
+title: "Kubernetes"
+description: "Comandos Kubernetes en modo lectura para descubrimiento de clusters, selección de namespaces e inspección de recursos."
+---
+
+El grupo `k8s` es **sólo lectura**: descubre clusters desde tu kubeconfig, alterna entre ellos e inspecciona pods, deployments, configmaps, secrets, nodes y cualquier recurso personalizado que el cluster exponga. No crea, actualiza ni elimina recursos.
+
+## Elegir cluster y namespace
+
+```bash
+dockerman k8s cluster list
+dockerman k8s cluster current
+dockerman k8s cluster use kubeconfig:dev-context
+dockerman k8s namespace list --cluster kubeconfig:dev-context
+dockerman k8s namespace use workloads --cluster kubeconfig:dev-context
+dockerman k8s namespace current --cluster kubeconfig:dev-context
+```
+
+`cluster use` y `namespace use` persisten una selección en disco. Los comandos posteriores sin `--cluster` / `--namespace` la usan.
+
+<Callout type="info">
+  Los ids de cluster tienen forma `kubeconfig:<nombre-de-context>`. Ejecuta `dockerman k8s cluster list` para ver el id exacto de cada context que la CLI descubra.
+</Callout>
+
+## Resumen de cluster
+
+```bash
+dockerman k8s overview
+dockerman k8s overview --cluster kubeconfig:dev-context --namespace workloads --pretty
+```
+
+Devuelve una snapshot única: contadores de nodes, pods, deployments, services, más eventos de nivel warning. Útil como sonda de salud antes de profundizar en recursos individuales.
+
+## Recursos de workload
+
+Cada recurso de workload acepta `list` y `get`:
+
+```bash
+dockerman k8s pod list
+dockerman k8s pod get my-pod --namespace workloads
+dockerman k8s deployment list --pretty
+dockerman k8s service get my-svc
+dockerman k8s statefulset list
+dockerman k8s daemonset list
+dockerman k8s job list
+dockerman k8s cronjob list
+dockerman k8s replicaset list
+```
+
+## Networking
+
+```bash
+dockerman k8s ingress list
+dockerman k8s endpoint list
+dockerman k8s endpointslice list
+dockerman k8s networkpolicy list
+```
+
+## Configuración y almacenamiento
+
+```bash
+dockerman k8s configmap list
+dockerman k8s secret list
+dockerman k8s secret get app-secret
+dockerman k8s pvc list
+```
+
+## Cluster-scoped
+
+```bash
+dockerman k8s node list
+dockerman k8s node get worker-1
+dockerman k8s pv list
+dockerman k8s storageclass list
+dockerman k8s clusterrole list
+dockerman k8s clusterrolebinding list
+dockerman k8s crd list
+```
+
+## RBAC
+
+```bash
+dockerman k8s serviceaccount list
+dockerman k8s role list
+dockerman k8s rolebinding list
+```
+
+## Logs de pod
+
+```bash
+dockerman k8s pod logs my-pod --namespace workloads
+dockerman k8s pod logs my-pod --container app --tail-lines 100 --timestamps
+dockerman k8s pod logs my-pod --previous --since-time 2026-05-01T00:00:00Z
+```
+
+## Eventos
+
+```bash
+dockerman k8s event list
+dockerman k8s event list --type Warning --involved-kind Pod
+```
+
+## Recursos genéricos y YAML
+
+Para cualquier recurso no listado arriba (recursos personalizados, integrados poco frecuentes), usa el subcomando `resource` genérico. Descubre lo disponible con `api-resource list`.
+
+```bash
+dockerman k8s api-resource list --cluster kubeconfig:dev-context
+dockerman k8s resource list deployments.apps/v1 --namespace workloads
+dockerman k8s resource yaml secrets.core/v1 app-secret
+dockerman k8s resource yaml mycrd.example.com/v1alpha1 my-instance --json
+```
+
+`resource yaml` imprime el manifest sanitizado. El campo `data` de los Secret se reemplaza por `<REDACTED>` antes de salir del daemon — **no puedes leer el contenido en claro de un Secret a través de la CLI**.
+
+<Callout type="warn">
+  Todos los comandos k8s son sólo lectura por diseño. Para aplicar cambios, usa `kubectl` directamente. La superficie k8s de Dockerman está pensada para inspección segura desde automatización y desde la GUI.
+</Callout>

--- a/apps/landing/content/docs/es/cli/meta.json
+++ b/apps/landing/content/docs/es/cli/meta.json
@@ -1,0 +1,14 @@
+{
+  "title": "CLI",
+  "pages": [
+    "index",
+    "containers",
+    "images",
+    "networks-volumes",
+    "compose",
+    "kubernetes",
+    "streaming",
+    "advanced"
+  ],
+  "defaultOpen": false
+}

--- a/apps/landing/content/docs/es/cli/networks-volumes.mdx
+++ b/apps/landing/content/docs/es/cli/networks-volumes.mdx
@@ -1,0 +1,93 @@
+---
+title: "Redes y volúmenes"
+description: "Gestiona redes y volúmenes Docker desde la CLI — crear, inspeccionar, conectar, purgar."
+---
+
+Los grupos `network` y `volume` exponen todas las operaciones que la GUI ofrece para estos dos tipos de recursos. Ambos siguen los mismos patrones que `container` e `image`: `list`, `inspect`, `create`, `remove`/`prune`, más comandos de relación para redes.
+
+## Redes
+
+### Listar e inspeccionar
+
+```bash
+dockerman network list
+dockerman network list --pretty
+dockerman network inspect bridge
+```
+
+### Crear
+
+```bash
+dockerman network create my-net \
+  --driver bridge \
+  --attachable \
+  --enable-ipv6 \
+  --option "com.docker.network.bridge.name=my-bridge" \
+  --label "owner=team-a"
+```
+
+| Flag | Propósito |
+| --- | --- |
+| `--driver <name>` | Driver de red (`bridge`, `overlay`, `macvlan`, etc.) |
+| `--internal` | Restringe la conectividad externa |
+| `--attachable` | Permite que contenedores standalone se conecten (sólo overlay) |
+| `--ingress` | Crea la red ingress de swarm |
+| `--enable-ipv6` | Activa IPv6 en la red |
+| `--option <k=v>` | Opción específica del driver (repetible) |
+| `--label <k=v>` | Label de red (repetible) |
+
+### Eliminar
+
+```bash
+dockerman network remove my-net --yes
+```
+
+`remove` requiere `--yes`. Las redes integradas (`bridge`, `host`, `none`) no pueden eliminarse.
+
+### Connect y disconnect
+
+```bash
+dockerman network connect my-net web
+dockerman network disconnect my-net web --force
+```
+
+`disconnect --force` es necesario cuando el contenedor está en marcha y quieres desconectarlo sin pararlo.
+
+## Volúmenes
+
+### Listar e inspeccionar
+
+```bash
+dockerman volume list
+dockerman volume list --pretty
+dockerman volume inspect data
+```
+
+### Crear
+
+```bash
+dockerman volume create data \
+  --driver local \
+  --driver-opt "type=nfs" \
+  --driver-opt "o=addr=10.0.0.1,rw" \
+  --driver-opt "device=:/exports/data" \
+  --label "backup=daily"
+```
+
+`--driver-opt` y `--label` son ambos repetibles.
+
+### Eliminar
+
+```bash
+dockerman volume remove data --force --yes
+```
+
+`remove` requiere `--yes`. `--force` elimina un volumen incluso si está referenciado por un contenedor parado.
+
+### Purgar
+
+```bash
+dockerman volume prune --filter "label=temp=true" --yes
+```
+
+`prune` borra todos los volúmenes huérfanos (sin referencias) que coincidan con el conjunto de filtros. `--filter` es repetible y usa la sintaxis estándar de filtros de Docker (`label=`, `label!=`, etc.). Combina siempre con filtros explícitos en scripts — un `volume prune --yes` sin filtros borra todos los volúmenes huérfanos del host.

--- a/apps/landing/content/docs/es/cli/streaming.mdx
+++ b/apps/landing/content/docs/es/cli/streaming.mdx
@@ -1,0 +1,74 @@
+---
+title: "Contrato de streaming"
+description: "Envelope NDJSON, heartbeat, contrapresión y manejo de señales para los RPCs en streaming."
+---
+
+Los RPCs en streaming (`logs -f`, `stats`, `events`, `image pull/push/build`, `compose pull/up`, `trivy scan/install`, `tunnel create`) comparten el mismo contrato de cable introducido en v5.3.0 con la versión `2` de schema.
+
+## Envelope
+
+Cuando pasas `--json` a un comando de streaming, cada línea de stdout es un envelope. El envelope externo lleva un `seq` monotónico y un discriminador `type`; los frames de datos llevan su payload tipado bajo `payload`.
+
+```json
+{"seq":1,"type":"data","payload":{"line":"hello"}}
+{"seq":2,"type":"heartbeat"}
+{"seq":3,"type":"dropped","payload":{"count":12}}
+{"seq":4,"type":"data","payload":{"kind":"result","report":{"...":"..."}}}
+{"seq":5,"type":"end"}
+{"seq":6,"type":"error","payload":{"code":"docker_not_found","message":"container web not found","details":null}}
+```
+
+| `type` | Significado |
+| --- | --- |
+| `data` | Frame normal; el payload tipado va en `payload` |
+| `heartbeat` | Ping de keep-alive. El intervalo por defecto es 15s |
+| `dropped` | Marcador de contrapresión. El daemon descartó `payload.count` frames; se emite antes del siguiente frame de cualquier tipo |
+| `end` | El stream terminó limpiamente. No llegarán más frames |
+| `error` | Error terminal. `payload` lleva `{ code, message, details }`; el stream finaliza tras este frame |
+
+<Callout type="info">
+  Algunos comandos (Trivy scan, Trivy install, Compose pull) embeben un segundo tag dentro del payload de datos. Por ejemplo, `dockerman trivy scan` emite frames `data` cuyo `payload.kind` es `"progress"`, `"result"` o `"error"` — el `error` interno es un fallo de stream interno transportado sobre un envelope `data` exitoso, mientras que el envelope `error` externo está reservado para fallos a nivel de transporte.
+</Callout>
+
+## Modo plano
+
+Sin `--json`, los comandos en streaming imprimen salida legible:
+
+- `logs -f`, `events`: una línea de log por frame de datos en stdout, errores y diagnósticos en stderr.
+- `stats`, `image pull/push/build`, `compose pull/up`, `trivy install/scan`: líneas de progreso en stderr (para que puedas redirigir stdout a un fichero), resultado final en stdout cuando aplica.
+
+## Heartbeat y timeout
+
+El daemon emite un heartbeat cada 15s. La CLI espera hasta 30s (dos heartbeats) antes de declarar el stream muerto y salir con código `4`. Si envuelves llamadas a la CLI en un pipeline más largo, no bufferices stdout — el buffering puede ocultar los heartbeats y disparar falsos positivos en tu propia monitorización.
+
+## Contrapresión
+
+Cada stream tiene un buffer de 256 frames entre el daemon y la CLI. Cuando el consumidor es lento, el daemon descarta los frames más viejos y emite un único frame `Dropped { count }` antes del siguiente frame de datos. Esto mantiene los streams vivos cuando los terminales (o `jq -c`) se quedan atrás respecto a los productores.
+
+## Cancelación
+
+Pulsar **Ctrl+C** envía `SIGINT`; la CLI lo captura, pide al daemon que cancele vía `CancelOnDrop`, drena los frames en vuelo y sale con código `130`. `SIGTERM` sale con `143`. El daemon también detecta cuando se cae la conexión TCP / socket Unix (cierre de pestaña del navegador, proceso padre matado) y libera recursos del lado servidor sin fugar goroutines.
+
+## Códigos de salida para streams
+
+| Código | Significado |
+| --- | --- |
+| `0` | El stream terminó de forma natural (contenedor parado, imagen completamente descargada, escaneo terminado) |
+| `1` | Error en el cuerpo del stream tras conexión exitosa (incluye 4xx pre-cuerpo) |
+| `3` | Falló el descubrimiento / handshake del daemon antes de abrir el stream |
+| `4` | Timeout de heartbeat (ningún frame en 30s) |
+| `130` | `SIGINT` |
+| `143` | `SIGTERM` |
+
+## Inspeccionar el schema
+
+Puedes listar cada RPC en streaming y la forma de su envelope:
+
+```bash
+dockerman schema --format mcp-tools
+dockerman schema follow_logs
+dockerman schema follow_stats
+dockerman schema monitor_events
+```
+
+Los RPCs en streaming se marcan con `streaming: true` y una referencia `StreamFrameEnvelope`. Los RPCs unarios callable (p. ej. `fetch_logs`) se marcan con `callable: true` y tienen un schema `result` normal.

--- a/apps/landing/content/docs/es/meta.json
+++ b/apps/landing/content/docs/es/meta.json
@@ -8,6 +8,7 @@
     "kubernetes",
     "---",
     "homelab",
+    "cli",
     "advanced",
     "platform",
     "reference"

--- a/apps/landing/content/docs/ja/cli/advanced.mdx
+++ b/apps/landing/content/docs/ja/cli/advanced.mdx
@@ -1,0 +1,111 @@
+---
+title: "高度な機能とスクリプト化"
+description: "Schema、call エスケープハッチ、Cloudflare Quick Tunnels、管理対象 WSL2 エンジン、自動化のヒント。"
+---
+
+このページは使用頻度の低い CLI コマンドと、シェルスクリプト、CI パイプライン、LLM ツールチェーンから `dockerman` をラップする際によく使うパターンをまとめます。
+
+## `schema` と `call`
+
+daemon が公開するすべてのバックエンド RPC は自己記述的な schema を持ちます。`schema` で利用可能な RPC を発見し、`call` で専用サブコマンドなしに任意の RPC を名前で呼び出せます。
+
+```bash
+dockerman schema
+dockerman schema fetch_logs
+dockerman schema --format mcp-tools
+
+dockerman call ping_host '{"address":"8.8.8.8"}'
+dockerman call hub_search '{"query":"alpine","page_size":5}'
+dockerman call remove_container '{"name":"web","force":true}' --yes
+```
+
+`call` は params の JSON オブジェクトを受け取ります。破壊的 RPC は専用サブコマンドと同じく `--yes`（または `-y`）が必要です。**ストリーミング RPC は `call` で呼べません**——正しいエンベロープを得るには専用のストリーミングコマンドを使ってください。
+
+<Callout type="info">
+  `schema --format mcp-tools` は MCP 互換のツールレジストリを出力します。Model Context Protocol を喋る LLM agent にそのまま接続できます。
+</Callout>
+
+## イベント
+
+```bash
+dockerman events --filter type=container
+dockerman events --filter type=container --filter event=start
+dockerman events --since 2026-05-01T00:00:00Z --until 2026-05-01T01:00:00Z
+```
+
+`events` はストリーミングコマンドで、stdout に常に NDJSON [エンベロープ](/ja/docs/cli/streaming) を出力します——平文モードがないので `--json` フラグもありません。`--filter key=value` を複数回指定することで条件を追加できます；マッチングは Docker 標準のフィルタセマンティクスです。`--since` と `--until` は Unix タイムスタンプか RFC 3339 の日時を受け付けます。
+
+## Cloudflare Quick Tunnels
+
+ローカルコンテナのポートを公開 `trycloudflare.com` URL で公開します。Quick Tunnels はその場限りで認証なし——開発やライブデモ用途に限り、本番 ingress には絶対使わないでください。
+
+```bash
+dockerman tunnel status --json
+dockerman tunnel install --json
+dockerman tunnel targets web --pretty
+dockerman tunnel create web --host-port 8080 --host-port 8081 --install --yes --json
+dockerman tunnel create web --all --install --yes --json
+dockerman tunnel list --pretty
+dockerman tunnel list --all-hosts --pretty
+dockerman tunnel close web --host-port 8080 --host-ip 0.0.0.0
+dockerman tunnel close-container web
+```
+
+`tunnel create` はネットワーク露出面を変えるので破壊的扱い、`--yes` が必須です。`cloudflared` が未インストールなら `--install` を付けてください；CLI はインストール進捗をストリーミングしてからトンネルを開きます。SSH 転送のリモート Docker ホストはトンネルターゲットとしてサポートされません。
+
+`--host-port` と `--all` は互いに排他的です：特定の公開ポートを選ぶか、コンテナが公開しているすべてのポートを露出するかのどちらか。`--host-ip` は最低 1 つの `--host-port` と組み合わせる必要があります；ポートを指定せず IP だけでバインドすることはできません。
+
+## 管理対象 WSL2 エンジン（Windows）
+
+Windows では、daemon が `dockerman-backend` という専用 WSL2 ディストリを管理し、その中で Docker Engine を動かして Linux コンテナを実行できます。CLI と GUI は同一エンジンを共有します。
+
+```bash
+dockerman wsl status
+dockerman wsl setup
+dockerman wsl start
+dockerman wsl config read
+dockerman wsl config apply ./daemon.json --yes
+dockerman wsl resources --json
+dockerman wsl stop
+dockerman wsl unregister --yes
+```
+
+`wsl setup` は同梱の Alpine rootfs をインポートし、Docker Engine と Compose v2 プラグインをインストール、`dockerd` を localhost TCP プロキシ越しに起動します。`setup` の再実行は冪等で、現在の状態から続行します。
+
+`wsl unregister --yes` は管理対象ディストリを削除し、**その中の全コンテナ、イメージ、ボリュームも削除します**。復元手段はありません。確信があるときだけ使ってください。
+
+## スクリプト化のヒント
+
+### `--json` を `jq` にパイプ
+
+```bash
+dockerman container list --json | jq '.[] | select(.state=="running") | .name'
+dockerman trivy scan myrepo/app:v1 --json \
+  | jq -c 'select(.kind=="result") | .payload.results[] | .vulnerabilities[]?'
+```
+
+### `--yes` と確認ゲートを併用
+
+```bash
+read -p "未使用イメージを削除しますか？ [y/N] " ans
+if [[ "$ans" == "y" ]]; then
+  dockerman image prune --filter dangling=true --yes
+fi
+```
+
+CLI はスクリプトがどれほど自信を持っていても常に `--yes` を要求します。**`--force-yes` も環境変数によるバイパスも存在しません**——これは意図的な設計です。
+
+## daemon 発見失敗の検知
+
+```bash
+if ! dockerman host current >/dev/null 2>&1; then
+  echo "daemon に到達できません" >&2
+  exit 3
+fi
+```
+
+daemon 発見とハンドシェイク失敗の終了コードは `3` で、RPC レベルの失敗（`1`）や stream 失敗（`4`）とは別です。
+
+### CI での長時間ストリーム
+
+CI ランナーは数分間出力がないプロセスを kill しがちです。daemon の 15 秒ハートビートはストリーミングコマンドが*何かしら*ワイヤに流すことを保証しますが、平文モードではハートビートは隠れます。CI では `--json` を使ってハートビートを可視行として現すか、`ts` にパイプして各行にタイムスタンプを付けてください。

--- a/apps/landing/content/docs/ja/cli/compose.mdx
+++ b/apps/landing/content/docs/ja/cli/compose.mdx
@@ -1,0 +1,68 @@
+---
+title: "Compose"
+description: "Docker Compose プロジェクトの管理、compose ファイルからのデプロイ、CLI での pull/up 進捗ストリーミング。"
+---
+
+`compose` コマンド群は既存の Compose プロジェクト（`com.docker.compose.project` ラベルを持つリソース）を操作するほか、compose ファイルから新規プロジェクトを直接デプロイすることもできます。
+
+<Callout type="warn">
+  Compose コマンドには Docker ランタイムが必要です。選択中のホストが Podman ターゲットの場合は使えません。
+</Callout>
+
+## プロジェクト一覧
+
+```bash
+dockerman compose list
+dockerman compose list --pretty
+```
+
+プロジェクト名、コンテナ数、状態、ベースパスを返します。
+
+## ライフサイクル
+
+```bash
+dockerman compose up myproject --detach
+dockerman compose stop myproject
+dockerman compose start myproject
+dockerman compose restart myproject --service web
+dockerman compose remove myproject --remove-volumes --yes
+```
+
+`up`、`stop`、`start`、`restart` はすべて標準のグローバルフラグを受け付けます：
+
+| フラグ | 用途 |
+| --- | --- |
+| `--working-dir <パス>` | プロジェクトの作業ディレクトリを上書き |
+| `--config-files <パス>` | カンマ区切りの compose ファイルリスト |
+| `--env-file <パス>` | env ファイルを上書き |
+| `--profile <名前>` | Compose プロファイルを有効化 |
+| `--progress <モード>` | `auto`、`tty`、`plain`、`quiet` |
+| `--dry-run` | 変更を適用せず、実行内容だけ表示 |
+| `--service <名前>` | `restart`/`stop`/`start` を 1 つのサービスに限定 |
+
+`compose up` は `--detach`（デフォルト）または `--attach`（ストリームが閉じるまでログを流し続ける）を受け取ります。
+
+`compose remove`（`compose down` の別名）は破壊的なので `--yes` が必須です。プロジェクトの named ボリュームも削除する場合は `--remove-volumes` を付けます。
+
+## Pull
+
+```bash
+dockerman compose pull myproject --json
+dockerman compose pull myproject --service web --json
+```
+
+レイヤごとに 1 つの NDJSON エンベロープで pull 進捗を流します。機械可読な出力には `--json`、人間向け進捗行には省略してください。
+
+## compose ファイルからデプロイ
+
+```bash
+dockerman compose deploy myproject ./docker-compose.yml \
+  --env DATABASE_URL=postgres://... \
+  --env LOG_LEVEL=info
+```
+
+`deploy` はプロジェクト名と compose ファイルのパスを取ります。CLI がファイルを読み、相対パスをその親ディレクトリに対して解決し、daemon にプロジェクトの作成または更新を依頼します。compose ファイルをディスク上で書き換えずに変数を注入したい場合は `--env` を複数回繰り返してください。
+
+<Callout type="info">
+  `deploy` と `up` は最終的に同じ daemon RPC を呼び出します。compose ファイルがまだ Docker に認識されていないなら `deploy`、`compose list` に既に表示されているプロジェクトには `up` を使ってください。
+</Callout>

--- a/apps/landing/content/docs/ja/cli/containers.mdx
+++ b/apps/landing/content/docs/ja/cli/containers.mdx
@@ -1,0 +1,134 @@
+---
+title: "コンテナ"
+description: "Docker コンテナのライフサイクル、ログ、stats、ターミナル、およびバックアップ/リストアコマンド。"
+---
+
+`container` コマンド群は完全なライフサイクルに加えて、ストリーミングアタッチとバックアップ/リストアもカバーします。すべてのコマンドが `--host` を受け取り、特定のホストを対象にできます；指定しない場合は `dockerman host use` で固定したホストを使用します。
+
+## 一覧と詳細
+
+```bash
+dockerman container list
+dockerman container list --pretty
+dockerman container inspect web
+```
+
+`list` は GUI と同じ構造を返します：id、名前、イメージ、状態、ポートマッピング、作成時刻。`--pretty` を付けると整列したテーブルになります。
+
+## ライフサイクル
+
+```bash
+dockerman container start web
+dockerman container stop web --timeout 10
+dockerman container restart web --timeout 10
+dockerman container pause web
+dockerman container unpause web
+dockerman container rename web web-old
+```
+
+`stop` と `restart` の `--timeout` は秒単位；daemon はまず `SIGTERM` を送り、タイムアウト経過後に `SIGKILL` を送ります。
+
+## 作成とクローン
+
+```bash
+dockerman container create web nginx:latest --platform linux/amd64
+dockerman container create web nginx:latest --config ./run.json
+dockerman container commit web --repo myrepo --tag snapshot --pause
+```
+
+`--config` は `bollard::ContainerCreateOptions` と同じ形の JSON ファイルを受け取ります。`commit` は実行中のコンテナをスナップショット化して新しいイメージにします。
+
+## 削除
+
+```bash
+dockerman container remove web --force --volumes --yes
+```
+
+`remove` は破壊的操作です。`--yes`（またはグローバル `-y`）が必須で、なしでは daemon が拒否します。`--force` で実行中のコンテナを削除、`--volumes` で匿名ボリュームも削除します。
+
+## ログ
+
+```bash
+dockerman container logs web --tail 50
+dockerman container logs web --follow --tail 5
+dockerman container logs web --since 2026-05-01T00:00:00Z --timestamps
+dockerman container logs web --follow --json
+```
+
+`--json` なしの場合、stdout はログ行のみ；エラーは stderr に出ます。`--json` 付きの場合、各フレームを 1 行の [ストリーミングエンベロープ](/ja/docs/cli/streaming) として出力します。`--follow` は Ctrl+C を押すまで（終了コード `130`）、または stream が自然終了するまで（終了コード `0`）継続します。
+
+<Callout type="warn">
+  `--until` は `--follow` と併用できません；CLI が stream を開く前に拒否します。履歴取得には `--since`/`--until`、追跡には `--follow`/`--since` を使ってください。
+</Callout>
+
+## Stats
+
+```bash
+dockerman container stats web
+dockerman container stats web --pretty
+```
+
+`stats` は常にストリーミングです。各フレームは CPU、メモリ、ネットワーク、ブロック I/O のカウンタを含む 1 行の NDJSON。Ctrl+C で停止します（終了コード `130`）。
+
+## ターミナル
+
+```bash
+dockerman container terminal web
+dockerman container terminal web --shell /bin/bash --user root
+```
+
+`docker exec` 経由で PTY を割り当て、現在のターミナルにアタッチします。stdin/stdout が TTY でない場合 CLI は実行を拒否します；パイプベースのスクリプトでは `dockerman call exec_*` を使ってください。
+
+## バックアップとリストア
+
+バックアップはコンテナのファイルシステム（および任意で bind mount）を 1 つのアーカイブにまとめます。リストアはそのアーカイブから新しいコンテナを作成します。
+
+<Steps>
+  <Step>
+    ### 何がアーカイブされるか確認
+
+    ```bash
+    dockerman container backup-targets web --pretty
+    ```
+
+    コンテナのボリュームと bind mount を一覧し、各 bind mount に `safe_to_archive` フラグを付けます。
+  </Step>
+  <Step>
+    ### アーカイブ作成
+
+    ```bash
+    dockerman container backup web \
+      --output ./web.tar.gz \
+      --pause \
+      --include-all-safe-bind-mounts
+    ```
+
+    個別に mount を選ぶ場合は `--include-bind-mount <インデックス>`、pause/unpause サイクルをスキップするには `--no-pause`、`safe_to_archive` 警告を無視するには `--force`。
+  </Step>
+  <Step>
+    ### アーカイブをプレビュー
+
+    ```bash
+    dockerman container backup-preview ./web.tar.gz --pretty
+    ```
+
+    リストアせずに manifest だけを表示します。
+  </Step>
+  <Step>
+    ### リストア
+
+    ```bash
+    dockerman container restore ./web.tar.gz \
+      --name web-restored \
+      --volume-strategy rename \
+      --port 8080:80 \
+      --yes
+    ```
+
+    リストアは破壊的（既存の名前/ボリュームと衝突しうる新しいコンテナを作成）なので `--yes` が必須。`--volume-strategy` は `rename`、`skip`、`overwrite` のいずれか。
+  </Step>
+</Steps>
+
+<Callout type="warn">
+  バックアップパスは CLI 側で絶対ローカルパスに解決されてから daemon に送られます。daemon は相対パス、ワークスペース外を指すシンボリックリンク、ユーザーが読めないパスを拒否します。
+</Callout>

--- a/apps/landing/content/docs/ja/cli/images.mdx
+++ b/apps/landing/content/docs/ja/cli/images.mdx
@@ -1,0 +1,123 @@
+---
+title: "イメージ、Hub、Trivy"
+description: "CLI から Docker イメージの pull、build、push、スキャン、検索を行います。"
+---
+
+`image`、`hub`、`trivy` の 3 つのコマンド群で、イメージの完全なライフサイクルをカバーします：Docker Hub での発見、pull、CVE スキャン、build、push、クリーンアップ。
+
+## 一覧、詳細、タグ付け
+
+```bash
+dockerman image list
+dockerman image list --pretty
+dockerman image inspect nginx:latest
+dockerman image tag nginx:latest myrepo/nginx --tag staging
+dockerman image history nginx:latest
+dockerman image search nginx --pretty
+```
+
+`image search` は接続先の daemon を通じて Docker Engine の `/images/search` エンドポイントを叩きます。より豊富な情報（説明、公式バッジ、タグ一覧）が必要な場合は、下の [`hub search`](#docker-hub-を検索) を使ってください——両者は別の API と通信します。
+
+## Pull と push
+
+```bash
+dockerman image pull nginx --tag latest
+dockerman image pull ghcr.io/me/app --tag v1 \
+  --username me --credential "$GHCR_TOKEN" \
+  --serveraddress https://ghcr.io \
+  --json
+
+dockerman image push myrepo/app --tag v1 --json
+```
+
+`--json` を付けると、両コマンドとも進捗を NDJSON エンベロープでストリーミングします。`--json` なしでは人間向けの進捗行と最終ステータスを出力します。`--username` / `--credential` による認証は呼び出しごとに一度きり；GUI に保存されたレジストリ認証情報は CLI からは使われません。
+
+## Build
+
+```bash
+dockerman image build ./Dockerfile --tag myrepo/app:v1 \
+  --context-path ./ \
+  --buildargs "NODE_ENV=production" \
+  --pull --rm --json
+```
+
+build は pull/push と同じエンベロープで進捗を流します。フラグの完全な一覧（build-args、labels、network mode、target stage、platform）は `dockerman image build --help` を参照してください。
+
+## 削除とクリーンアップ
+
+```bash
+dockerman image remove nginx:old --force --yes
+dockerman image prune --filter dangling=true --yes
+```
+
+両方とも `--yes` が必須です。`prune` は `--filter` を複数回指定でき、構文は `docker image prune` と同じです。
+
+## エクスポートとインポート
+
+```bash
+dockerman image export nginx:latest ./nginx.tar
+dockerman image import ./nginx.tar --quiet
+```
+
+`export` は `docker save` 互換の tarball を書き出し、`import` はそれを読み戻します。
+
+## Docker Hub を検索
+
+```bash
+dockerman hub search alpine --pretty
+dockerman hub search nginx --page 2 --page-size 20 --json
+dockerman hub image library/alpine --pretty
+dockerman hub tags library/alpine --page 1 --page-size 25 --pretty
+```
+
+`hub search` は名前、説明、スター数、official/automated フラグを返します。`hub image` と `hub tags` は `<namespace>/<name>` のリポジトリメタデータと公開タグを表示します。
+
+## Trivy でスキャン
+
+Dockerman は管理対象の Trivy バイナリを同梱しているので、インストール後はオフラインでもスキャンできます。
+
+<Steps>
+  <Step>
+    ### ステータスを確認
+
+    ```bash
+    dockerman trivy status --json
+    dockerman trivy dir --json
+    ```
+
+    `status` は `installed: true|false` と解決されたバージョンを返します。`dir` は絶対インストールパスを出力します。
+  </Step>
+  <Step>
+    ### インストールまたは更新
+
+    ```bash
+    dockerman trivy install --json
+    dockerman trivy update --json
+    ```
+
+    両者とも、バイナリと脆弱性データベースのダウンロード進捗を NDJSON でストリーミングします。
+  </Step>
+  <Step>
+    ### イメージをスキャン
+
+    ```bash
+    dockerman trivy scan alpine:latest --pretty
+    dockerman trivy scan myrepo/app:v1 --json --db-repository ghcr.io/aquasecurity/trivy-db
+    ```
+
+    スキャンは進捗フレームの後、レポートを含む 1 つの `kind: result` フレームで終わります。`--json` 出力を `jq` にパイプして脆弱性をフィルタできます。
+  </Step>
+  <Step>
+    ### 削除
+
+    ```bash
+    dockerman trivy remove --yes
+    ```
+
+    管理対象バイナリと DB キャッシュを削除します。`--yes` が必須です。
+  </Step>
+</Steps>
+
+<Callout type="info">
+  `hub` と `trivy` は daemon の外向きネットワークを共有します。ホストの HTTPS プロキシ環境変数には従いますが、GUI で設定したホスト別 SSH トンネルは**使いません**。
+</Callout>

--- a/apps/landing/content/docs/ja/cli/index.mdx
+++ b/apps/landing/content/docs/ja/cli/index.mdx
@@ -1,0 +1,81 @@
+---
+title: "CLI 概要"
+description: "Daemon-first の dockerman CLI で、ターミナルから Docker、Kubernetes、Compose、Trivy のワークフローをスクリプト化できます。"
+---
+
+`dockerman` は、認証付きの IPC ソケット経由でローカルの **dockerman-daemon** と通信する軽量なコマンドラインクライアントです。GUI で利用できるすべての機能——コンテナ、イメージ、Compose、Kubernetes 読み取り専用、Trivy、Docker Hub、トンネル、WSL——は CLI からも操作できます。v5.3.0 で追加。
+
+<Callout type="info">
+  CLI は必要に応じて `dockerman-daemon` を自動起動します。CLI を使うだけなら GUI を立ち上げる必要はありません。
+</Callout>
+
+## インストール
+
+CLI は GUI と同じリリースアーカイブに同梱されています。開発時はソースからビルドしてください：
+
+```bash
+cargo build -p dockerman-cli --release
+./target/release/dockerman --help
+```
+
+バックエンドが必要な最初のコマンドが `dockerman-daemon` を起動し、`daemon-ipc.json` を app data ディレクトリに書き出します。以降のコマンドはそのハンドシェイクを再利用します。
+
+## グローバルフラグ
+
+| フラグ | 用途 |
+| --- | --- |
+| `--host <id>` | 特定の Docker ホストを指定。ローカルソケットには `LOCALHOST`、または `dockerman host current` で表示される host id を渡す。 |
+| `--pretty` | 生 JSON ではなく整形済みテーブルを出力（対応コマンドのみ）。 |
+| `--yes` / `-y` | 破壊的操作を確認。`remove`、`prune`、`restore`、`tunnel create`、`wsl unregister` などで必須。 |
+
+## ホストを選ぶ
+
+```bash
+dockerman host current
+dockerman host use my-remote
+dockerman --host LOCALHOST container list
+```
+
+`host use` は選択をディスクに保存します；以降 `--host` を省略したコマンドはこれを使います。永続選択を変えずに 1 回だけ上書きしたい場合は、コマンドごとに `--host` を渡してください。
+
+## システムと疎通確認
+
+```bash
+dockerman system info
+dockerman system df
+dockerman system ping 8.8.8.8
+dockerman system prune --containers --volumes --yes
+```
+
+## Schema と発見
+
+daemon が公開するすべての RPC はバージョン付き schema に記述されています。コマンドの発見、クライアント生成、LLM ツールレジストリへの投入に使えます。
+
+```bash
+dockerman schema
+dockerman schema --format mcp-tools
+dockerman schema fetch_logs
+```
+
+現在の schema バージョンは `2`。unary 呼び出しとストリーミング呼び出しの違いは [ストリーミング契約](/ja/docs/cli/streaming) を参照してください。
+
+## 終了コード
+
+| コード | 意味 |
+| --- | --- |
+| `0` | 成功、または stream が自然終了 |
+| `1` | 一般的な失敗（バリデーション、RPC エラー、stream 本体エラー） |
+| `3` | 発見またはハンドシェイク失敗（daemon に到達不能） |
+| `4` | ストリーミングのハートビートタイムアウト（30 秒間フレームなし） |
+| `130` | ストリーミングコマンドへの `SIGINT`（Ctrl+C） |
+| `143` | ストリーミングコマンドへの `SIGTERM` |
+
+## CLI でカバーしない範囲
+
+GUI でのみ提供されているワークフロー：
+
+- スケジューラータスクと通知チャネル
+- アラートルール（プリセットルールは daemon 上で動くが、作成・編集は GUI のみ）
+- 時系列メトリクスの履歴
+
+コマンドの完全な一覧は `dockerman --help` と一致します。本セクション以降のページではドメインごとにまとめます。

--- a/apps/landing/content/docs/ja/cli/kubernetes.mdx
+++ b/apps/landing/content/docs/ja/cli/kubernetes.mdx
@@ -1,0 +1,118 @@
+---
+title: "Kubernetes"
+description: "クラスタ発見、namespace 切替、リソース閲覧のための読み取り専用 Kubernetes コマンド。"
+---
+
+`k8s` コマンド群は**読み取り専用**です：kubeconfig からクラスタを発見し、切り替え、pod、deployment、configmap、secret、node、およびクラスタが公開する任意のカスタムリソースを閲覧します。リソースの作成・更新・削除は行いません。
+
+## クラスタと namespace を選ぶ
+
+```bash
+dockerman k8s cluster list
+dockerman k8s cluster current
+dockerman k8s cluster use kubeconfig:dev-context
+dockerman k8s namespace list --cluster kubeconfig:dev-context
+dockerman k8s namespace use workloads --cluster kubeconfig:dev-context
+dockerman k8s namespace current --cluster kubeconfig:dev-context
+```
+
+`cluster use` と `namespace use` は選択をディスクに保存します。以降 `--cluster` / `--namespace` を省略したコマンドはこの選択を使います。
+
+<Callout type="info">
+  クラスタ id は `kubeconfig:<context-name>` の形式です。CLI が発見する各 context の正確な id は `dockerman k8s cluster list` で確認してください。
+</Callout>
+
+## クラスタ概要
+
+```bash
+dockerman k8s overview
+dockerman k8s overview --cluster kubeconfig:dev-context --namespace workloads --pretty
+```
+
+ワンショットのスナップショットを返します：node、pod、deployment、service の数と、warning レベルのイベント。個別のリソースを掘り下げる前のヘルスチェックとして便利です。
+
+## ワークロードリソース
+
+各ワークロードリソースは `list` と `get` を受け取ります：
+
+```bash
+dockerman k8s pod list
+dockerman k8s pod get my-pod --namespace workloads
+dockerman k8s deployment list --pretty
+dockerman k8s service get my-svc
+dockerman k8s statefulset list
+dockerman k8s daemonset list
+dockerman k8s job list
+dockerman k8s cronjob list
+dockerman k8s replicaset list
+```
+
+## ネットワーキング
+
+```bash
+dockerman k8s ingress list
+dockerman k8s endpoint list
+dockerman k8s endpointslice list
+dockerman k8s networkpolicy list
+```
+
+## 設定とストレージ
+
+```bash
+dockerman k8s configmap list
+dockerman k8s secret list
+dockerman k8s secret get app-secret
+dockerman k8s pvc list
+```
+
+## クラスタスコープ
+
+```bash
+dockerman k8s node list
+dockerman k8s node get worker-1
+dockerman k8s pv list
+dockerman k8s storageclass list
+dockerman k8s clusterrole list
+dockerman k8s clusterrolebinding list
+dockerman k8s crd list
+```
+
+## RBAC
+
+```bash
+dockerman k8s serviceaccount list
+dockerman k8s role list
+dockerman k8s rolebinding list
+```
+
+## Pod ログ
+
+```bash
+dockerman k8s pod logs my-pod --namespace workloads
+dockerman k8s pod logs my-pod --container app --tail-lines 100 --timestamps
+dockerman k8s pod logs my-pod --previous --since-time 2026-05-01T00:00:00Z
+```
+
+## イベント
+
+```bash
+dockerman k8s event list
+dockerman k8s event list --type Warning --involved-kind Pod
+```
+
+## 汎用リソースと YAML
+
+上記に載っていないリソース（カスタムリソース、あまり使われない組み込みリソース）には汎用 `resource` サブコマンドを使います。利用可能なリソースは `api-resource list` で発見できます。
+
+```bash
+dockerman k8s api-resource list --cluster kubeconfig:dev-context
+dockerman k8s resource list deployments.apps/v1 --namespace workloads
+dockerman k8s resource yaml secrets.core/v1 app-secret
+dockerman k8s resource yaml mycrd.example.com/v1alpha1 my-instance --json
+```
+
+`resource yaml` はマスク済みの manifest を出力します。Secret の `data` フィールドは daemon を出る前に `<REDACTED>` に置換されます——**CLI から Secret の平文を取得することはできません**。
+
+<Callout type="warn">
+  すべての k8s コマンドは設計上、読み取り専用です。変更を加えるには `kubectl` を直接使ってください。Dockerman の k8s インターフェースは自動化と GUI からの安全な閲覧用途を想定しています。
+</Callout>

--- a/apps/landing/content/docs/ja/cli/meta.json
+++ b/apps/landing/content/docs/ja/cli/meta.json
@@ -1,0 +1,14 @@
+{
+  "title": "CLI",
+  "pages": [
+    "index",
+    "containers",
+    "images",
+    "networks-volumes",
+    "compose",
+    "kubernetes",
+    "streaming",
+    "advanced"
+  ],
+  "defaultOpen": false
+}

--- a/apps/landing/content/docs/ja/cli/networks-volumes.mdx
+++ b/apps/landing/content/docs/ja/cli/networks-volumes.mdx
@@ -1,0 +1,93 @@
+---
+title: "ネットワークとボリューム"
+description: "Docker のネットワークとボリュームを CLI で管理——作成、詳細表示、接続、クリーンアップ。"
+---
+
+`network` と `volume` コマンド群は、GUI が提供するこの 2 種類のリソースに対するすべての操作を網羅します。どちらも `container` や `image` と同じパターン：`list`、`inspect`、`create`、`remove`/`prune`、加えてネットワークには関係性コマンド。
+
+## ネットワーク
+
+### 一覧と詳細
+
+```bash
+dockerman network list
+dockerman network list --pretty
+dockerman network inspect bridge
+```
+
+### 作成
+
+```bash
+dockerman network create my-net \
+  --driver bridge \
+  --attachable \
+  --enable-ipv6 \
+  --option "com.docker.network.bridge.name=my-bridge" \
+  --label "owner=team-a"
+```
+
+| フラグ | 用途 |
+| --- | --- |
+| `--driver <name>` | ネットワークドライバ（`bridge`、`overlay`、`macvlan` など） |
+| `--internal` | 外部接続を制限 |
+| `--attachable` | 単独コンテナの接続を許可（overlay 限定） |
+| `--ingress` | swarm の ingress ネットワークを作成 |
+| `--enable-ipv6` | ネットワークで IPv6 を有効化 |
+| `--option <k=v>` | ドライバ固有オプション（複数指定可） |
+| `--label <k=v>` | ネットワークラベル（複数指定可） |
+
+### 削除
+
+```bash
+dockerman network remove my-net --yes
+```
+
+`remove` には `--yes` が必須。組み込みネットワーク（`bridge`、`host`、`none`）は削除できません。
+
+### 接続と切断
+
+```bash
+dockerman network connect my-net web
+dockerman network disconnect my-net web --force
+```
+
+コンテナが動作中で、停止せずに切断する必要がある場合は `disconnect --force` が必要です。
+
+## ボリューム
+
+### 一覧と詳細
+
+```bash
+dockerman volume list
+dockerman volume list --pretty
+dockerman volume inspect data
+```
+
+### 作成
+
+```bash
+dockerman volume create data \
+  --driver local \
+  --driver-opt "type=nfs" \
+  --driver-opt "o=addr=10.0.0.1,rw" \
+  --driver-opt "device=:/exports/data" \
+  --label "backup=daily"
+```
+
+`--driver-opt` と `--label` はどちらも複数指定可能です。
+
+### 削除
+
+```bash
+dockerman volume remove data --force --yes
+```
+
+`remove` には `--yes` が必須。`--force` を付けると、停止中のコンテナから参照されているボリュームでも強制削除します。
+
+### クリーンアップ
+
+```bash
+dockerman volume prune --filter "label=temp=true" --yes
+```
+
+`prune` はフィルタ集合に一致する未参照（ダングリング）ボリュームをすべて削除します。`--filter` は複数指定可能で、Docker 標準のフィルタ構文（`label=`、`label!=` など）を使います。スクリプト内では必ず明示的なフィルタと組み合わせてください——フィルタなしの `volume prune --yes` はホスト上の**すべての**ダングリングボリュームを削除します。

--- a/apps/landing/content/docs/ja/cli/streaming.mdx
+++ b/apps/landing/content/docs/ja/cli/streaming.mdx
@@ -1,0 +1,74 @@
+---
+title: "ストリーミング契約"
+description: "ストリーミング RPC の NDJSON エンベロープ、ハートビート、バックプレッシャ、シグナル処理。"
+---
+
+ストリーミング RPC（`logs -f`、`stats`、`events`、`image pull/push/build`、`compose pull/up`、`trivy scan/install`、`tunnel create`）はすべて、v5.3.0 で導入された同一の通信契約（schema バージョン `2`）を共有します。
+
+## エンベロープ
+
+ストリーミングコマンドに `--json` を渡すと、stdout の各行が 1 つのエンベロープになります。外側のエンベロープは単調増加する `seq` と `type` 判別子を持ち、データフレームはその型付きペイロードを `payload` に格納します。
+
+```json
+{"seq":1,"type":"data","payload":{"line":"hello"}}
+{"seq":2,"type":"heartbeat"}
+{"seq":3,"type":"dropped","payload":{"count":12}}
+{"seq":4,"type":"data","payload":{"kind":"result","report":{"...":"..."}}}
+{"seq":5,"type":"end"}
+{"seq":6,"type":"error","payload":{"code":"docker_not_found","message":"container web not found","details":null}}
+```
+
+| `type` | 意味 |
+| --- | --- |
+| `data` | 通常のフレーム；型付きペイロードは `payload` に入る |
+| `heartbeat` | 生存確認。デフォルト間隔は 15 秒 |
+| `dropped` | バックプレッシャの目印。daemon が `payload.count` 個のフレームを破棄；どの種類であれ次のフレームの前に発行される |
+| `end` | stream が正常終了。これ以上フレームは届かない |
+| `error` | 致命的エラー。`payload` には `{ code, message, details }`；このフレームの後に stream は終了する |
+
+<Callout type="info">
+  一部のコマンド（Trivy scan、Trivy install、Compose pull）はデータペイロード内にもう 1 段の tag を埋め込みます。例えば `dockerman trivy scan` は `data` フレームを発行し、その `payload.kind` は `"progress"`、`"result"`、`"error"` のいずれか——内側の `error` は成功した `data` エンベロープ越しに運ばれる stream 内エラーで、外側の `error` エンベロープはトランスポートレベルの障害用に予約されています。
+</Callout>
+
+## 平文モード
+
+`--json` なしでは、ストリーミングコマンドは人間向けの出力をします：
+
+- `logs -f`、`events`：データフレーム 1 つにつき 1 行のログを stdout に、エラーと診断は stderr に。
+- `stats`、`image pull/push/build`、`compose pull/up`、`trivy install/scan`：進捗行は stderr（stdout をファイルにリダイレクトできるように）、最終結果は該当するコマンドで stdout に。
+
+## ハートビートとタイムアウト
+
+daemon は 15 秒ごとにハートビートを送ります。CLI は最大 30 秒（ハートビート 2 回分）待った後、stream を死亡判定し、終了コード `4` で終わります。CLI 呼び出しを長いパイプラインで包むときは stdout をバッファしないでください——バッファリングはハートビートを隠してしまい、自分の監視に偽陽性を発生させます。
+
+## バックプレッシャ
+
+各 stream には daemon と CLI の間に 256 フレーム分のバッファがあります。コンシューマが遅い場合、daemon は古いフレームを破棄し、次のデータフレームの前に `Dropped { count }` フレームを 1 つ発行します。これによりターミナル（または `jq -c`）がプロデューサに追いつかないときも stream を生かし続けます。
+
+## キャンセル
+
+**Ctrl+C** を押すと `SIGINT` が送られます；CLI がこれをキャッチし、`CancelOnDrop` 経由で daemon にキャンセルを依頼し、進行中のフレームを排水してから終了コード `130` で終わります。`SIGTERM` は `143` で終わります。daemon は TCP / Unix ソケットの切断（ブラウザタブを閉じた、親プロセスが kill された）も検知し、サーバー側リソースを goroutine リークなしに解放します。
+
+## ストリーム終了コード
+
+| コード | 意味 |
+| --- | --- |
+| `0` | stream が自然終了（コンテナ停止、イメージ pull 完了、スキャン完了） |
+| `1` | 接続成功後の本体エラー（本体前の 4xx を含む） |
+| `3` | stream を開く前に daemon の発見 / ハンドシェイクが失敗 |
+| `4` | ハートビートタイムアウト（30 秒間フレームなし） |
+| `130` | `SIGINT` |
+| `143` | `SIGTERM` |
+
+## schema を確認
+
+ストリーミング RPC とそのエンベロープ形状を一覧できます：
+
+```bash
+dockerman schema --format mcp-tools
+dockerman schema follow_logs
+dockerman schema follow_stats
+dockerman schema monitor_events
+```
+
+ストリーミング RPC は `streaming: true` と `StreamFrameEnvelope` 参照でマークされます。unary callable RPC（例：`fetch_logs`）は `callable: true` でマークされ、通常の `result` schema を持ちます。

--- a/apps/landing/content/docs/ja/meta.json
+++ b/apps/landing/content/docs/ja/meta.json
@@ -8,6 +8,7 @@
     "kubernetes",
     "---",
     "homelab",
+    "cli",
     "advanced",
     "platform",
     "reference"

--- a/apps/landing/content/docs/zh/cli/advanced.mdx
+++ b/apps/landing/content/docs/zh/cli/advanced.mdx
@@ -1,0 +1,111 @@
+---
+title: "进阶与脚本化"
+description: "Schema、call escape hatch、Cloudflare Quick Tunnels、受管 WSL2 引擎，以及自动化技巧。"
+---
+
+本页汇集使用频率较低的 CLI 命令，以及在 shell 脚本、CI 流水线、LLM 工具链中包装 `dockerman` 时常用的模式。
+
+## `schema` 与 `call`
+
+daemon 暴露的每个后端 RPC 都有自描述 schema。`schema` 用于发现可用 RPC，`call` 用于按名称调用任意 RPC，无需专用子命令。
+
+```bash
+dockerman schema
+dockerman schema fetch_logs
+dockerman schema --format mcp-tools
+
+dockerman call ping_host '{"address":"8.8.8.8"}'
+dockerman call hub_search '{"query":"alpine","page_size":5}'
+dockerman call remove_container '{"name":"web","force":true}' --yes
+```
+
+`call` 接受 JSON 形式的参数对象。破坏性 RPC 与专用子命令一样需要 `--yes`（或 `-y`）。**流式 RPC 不能通过 `call` 调用**——请使用对应的流式命令以获得正确的封装。
+
+<Callout type="info">
+  `schema --format mcp-tools` 输出 MCP 兼容的工具注册表，可直接接入支持 Model Context Protocol 的 LLM agent。
+</Callout>
+
+## 事件
+
+```bash
+dockerman events --filter type=container
+dockerman events --filter type=container --filter event=start
+dockerman events --since 2026-05-01T00:00:00Z --until 2026-05-01T01:00:00Z
+```
+
+`events` 是流式命令，stdout 始终输出 NDJSON [封装](/zh/docs/cli/streaming)——没有 `--json` 标志，也没有"普通模式"。多次 `--filter key=value` 叠加过滤；语义与 Docker 标准过滤器一致。`--since` 和 `--until` 接受 Unix 时间戳或 RFC 3339 日期时间。
+
+## Cloudflare Quick Tunnels
+
+通过公开的 `trycloudflare.com` URL 暴露本地容器端口。Quick Tunnels 是临时且无身份验证的——仅用于开发和实时演示，**不要**用于生产入口。
+
+```bash
+dockerman tunnel status --json
+dockerman tunnel install --json
+dockerman tunnel targets web --pretty
+dockerman tunnel create web --host-port 8080 --host-port 8081 --install --yes --json
+dockerman tunnel create web --all --install --yes --json
+dockerman tunnel list --pretty
+dockerman tunnel list --all-hosts --pretty
+dockerman tunnel close web --host-port 8080 --host-ip 0.0.0.0
+dockerman tunnel close-container web
+```
+
+`tunnel create` 改变网络暴露面，属于破坏性操作，必须传 `--yes`。`cloudflared` 未安装时加 `--install`，CLI 会先流式安装再开隧道。SSH 转发的远程 Docker 主机不支持作为隧道目标。
+
+`--host-port` 与 `--all` 互斥：要么指定具体的已发布端口，要么暴露容器发布的所有端口。`--host-ip` 至少需要配合一个 `--host-port`；不能仅按 IP 绑定而不指定端口。
+
+## 受管 WSL2 引擎（Windows）
+
+在 Windows 上，daemon 可以管理一个名为 `dockerman-backend` 的专用 WSL2 发行版，运行 Docker Engine 跑 Linux 容器。CLI 与 GUI 共享同一引擎。
+
+```bash
+dockerman wsl status
+dockerman wsl setup
+dockerman wsl start
+dockerman wsl config read
+dockerman wsl config apply ./daemon.json --yes
+dockerman wsl resources --json
+dockerman wsl stop
+dockerman wsl unregister --yes
+```
+
+`wsl setup` 导入内置的 Alpine rootfs，安装 Docker Engine 与 Compose v2 插件，并以本地 TCP 代理启动 `dockerd`。重复执行 `setup` 是幂等的，会从当前状态恢复。
+
+`wsl unregister --yes` 删除受管发行版，**以及其中的所有容器、镜像和卷**。无法恢复，只在确定时使用。
+
+## 脚本化技巧
+
+### 用 `jq` 解析 `--json`
+
+```bash
+dockerman container list --json | jq '.[] | select(.state=="running") | .name'
+dockerman trivy scan myrepo/app:v1 --json \
+  | jq -c 'select(.kind=="result") | .payload.results[] | .vulnerabilities[]?'
+```
+
+### `--yes` 与确认网关结合
+
+```bash
+read -p "删除未使用的镜像？[y/N] " ans
+if [[ "$ans" == "y" ]]; then
+  dockerman image prune --filter dangling=true --yes
+fi
+```
+
+CLI 始终要求 `--yes`，无论脚本自身多确定。**不存在** `--force-yes` 或环境变量绕过——这是有意的设计。
+
+### 检测 daemon 发现失败
+
+```bash
+if ! dockerman host current >/dev/null 2>&1; then
+  echo "daemon 不可达" >&2
+  exit 3
+fi
+```
+
+daemon 发现和握手失败的退出码为 `3`，与 RPC 级别失败（`1`）和流失败（`4`）区分开。
+
+### CI 中的长流
+
+CI runner 经常 kill 一段时间无输出的进程。daemon 的 15 秒心跳保证流式命令始终在线缆上有动静，但**普通模式会隐藏心跳**。CI 中建议用 `--json`，让心跳作为可见行出现；或管道接入 `ts` 给每行加时间戳。

--- a/apps/landing/content/docs/zh/cli/compose.mdx
+++ b/apps/landing/content/docs/zh/cli/compose.mdx
@@ -1,0 +1,68 @@
+---
+title: "Compose"
+description: "管理 Docker Compose 项目、从 compose 文件部署、并在 CLI 中流式查看 pull/up 进度。"
+---
+
+`compose` 命令组针对已存在的 Compose 项目（即包含 `com.docker.compose.project` 标签的资源）操作，也支持从 compose 文件直接部署新项目。
+
+<Callout type="warn">
+  Compose 命令需要 Docker 运行时。所选主机为 Podman 时不可用。
+</Callout>
+
+## 列出项目
+
+```bash
+dockerman compose list
+dockerman compose list --pretty
+```
+
+返回项目名、容器数、状态、根路径。
+
+## 生命周期
+
+```bash
+dockerman compose up myproject --detach
+dockerman compose stop myproject
+dockerman compose start myproject
+dockerman compose restart myproject --service web
+dockerman compose remove myproject --remove-volumes --yes
+```
+
+`up`、`stop`、`start`、`restart` 都接受标准的全局参数：
+
+| 参数 | 用途 |
+| --- | --- |
+| `--working-dir <路径>` | 覆盖项目工作目录 |
+| `--config-files <路径>` | 逗号分隔的 compose 文件列表 |
+| `--env-file <路径>` | 覆盖 env 文件 |
+| `--profile <名称>` | 启用 Compose profile |
+| `--progress <模式>` | `auto`、`tty`、`plain`、`quiet` |
+| `--dry-run` | 仅打印将要执行的操作，不实际修改 |
+| `--service <名称>` | 将 `restart`/`stop`/`start` 限制为单个服务 |
+
+`compose up` 接受 `--detach`（默认）或 `--attach`（流式输出日志直到流关闭）。
+
+`compose remove`（别名 `compose down`）是破坏性操作，必须传 `--yes`。加 `--remove-volumes` 同时删除项目命名卷。
+
+## Pull
+
+```bash
+dockerman compose pull myproject --json
+dockerman compose pull myproject --service web --json
+```
+
+每层一帧 NDJSON 封装的拉取进度。`--json` 输出适合机器解析，省略它则得到人类友好的进度行。
+
+## 从 compose 文件部署
+
+```bash
+dockerman compose deploy myproject ./docker-compose.yml \
+  --env DATABASE_URL=postgres://... \
+  --env LOG_LEVEL=info
+```
+
+`deploy` 接受项目名 + compose 文件路径。CLI 读取文件、按其父目录解析相对路径、然后请求 daemon 创建或更新项目。多次 `--env` 注入变量，无需修改磁盘上的 compose 文件。
+
+<Callout type="info">
+  `deploy` 与 `up` 最终走同一个 daemon RPC。compose 文件还未被 Docker 识别时用 `deploy`；`compose list` 中已经能看到的项目用 `up`。
+</Callout>

--- a/apps/landing/content/docs/zh/cli/containers.mdx
+++ b/apps/landing/content/docs/zh/cli/containers.mdx
@@ -1,0 +1,134 @@
+---
+title: "容器"
+description: "Docker 容器的生命周期、日志、统计、终端，以及备份/恢复命令。"
+---
+
+`container` 命令组覆盖完整的容器生命周期、流式附加，以及备份/恢复。所有命令都接受 `--host` 指定目标主机；未指定时使用 `dockerman host use` 设置的默认主机。
+
+## 列表与详情
+
+```bash
+dockerman container list
+dockerman container list --pretty
+dockerman container inspect web
+```
+
+`list` 返回 GUI 使用的相同结构：id、名称、镜像、状态、端口映射、创建时间。加 `--pretty` 输出对齐表格。
+
+## 生命周期
+
+```bash
+dockerman container start web
+dockerman container stop web --timeout 10
+dockerman container restart web --timeout 10
+dockerman container pause web
+dockerman container unpause web
+dockerman container rename web web-old
+```
+
+`stop` 和 `restart` 的 `--timeout` 单位为秒；daemon 先发 `SIGTERM`，超时后发 `SIGKILL`。
+
+## 创建与克隆
+
+```bash
+dockerman container create web nginx:latest --platform linux/amd64
+dockerman container create web nginx:latest --config ./run.json
+dockerman container commit web --repo myrepo --tag snapshot --pause
+```
+
+`--config` 接受 JSON 文件，结构与 `bollard::ContainerCreateOptions` 一致。`commit` 把运行中的容器快照成新镜像。
+
+## 删除
+
+```bash
+dockerman container remove web --force --volumes --yes
+```
+
+`remove` 是破坏性操作，必须传 `--yes`（或全局 `-y`），否则 daemon 拒绝执行。`--force` 删除运行中的容器，`--volumes` 同时删除匿名卷。
+
+## 日志
+
+```bash
+dockerman container logs web --tail 50
+dockerman container logs web --follow --tail 5
+dockerman container logs web --since 2026-05-01T00:00:00Z --timestamps
+dockerman container logs web --follow --json
+```
+
+不带 `--json` 时，stdout 仅输出日志行，错误信息走 stderr。带 `--json` 时，每帧一行 [流式封装](/zh/docs/cli/streaming)。`--follow` 持续运行直到按 Ctrl+C（退出码 `130`）或流自然结束（退出码 `0`）。
+
+<Callout type="warn">
+  `--until` 与 `--follow` 互斥；CLI 在打开流之前就会拒绝同时使用。历史回填用 `--since`/`--until`，持续跟踪用 `--follow`/`--since`。
+</Callout>
+
+## 统计
+
+```bash
+dockerman container stats web
+dockerman container stats web --pretty
+```
+
+`stats` 始终是流式输出。每帧是一行 NDJSON，包含 CPU、内存、网络、块 I/O 计数。按 Ctrl+C 停止（退出码 `130`）。
+
+## 终端
+
+```bash
+dockerman container terminal web
+dockerman container terminal web --shell /bin/bash --user root
+```
+
+通过 `docker exec` 分配 PTY 并附加到当前终端。当 stdin/stdout 不是 TTY 时，CLI 拒绝执行；管道脚本应改用 `dockerman call exec_*`。
+
+## 备份与恢复
+
+备份将容器的文件系统（以及可选的 bind mount）打包为单个归档；恢复从该归档创建新容器。
+
+<Steps>
+  <Step>
+    ### 检查归档目标
+
+    ```bash
+    dockerman container backup-targets web --pretty
+    ```
+
+    列出容器的卷和 bind mount，并为每个 bind mount 标注 `safe_to_archive`。
+  </Step>
+  <Step>
+    ### 创建归档
+
+    ```bash
+    dockerman container backup web \
+      --output ./web.tar.gz \
+      --pause \
+      --include-all-safe-bind-mounts
+    ```
+
+    使用 `--include-bind-mount <索引>` 单独选择 mount，`--no-pause` 跳过暂停/恢复，`--force` 忽略 `safe_to_archive` 警告。
+  </Step>
+  <Step>
+    ### 预览归档
+
+    ```bash
+    dockerman container backup-preview ./web.tar.gz --pretty
+    ```
+
+    显示 manifest 而不实际恢复。
+  </Step>
+  <Step>
+    ### 恢复
+
+    ```bash
+    dockerman container restore ./web.tar.gz \
+      --name web-restored \
+      --volume-strategy rename \
+      --port 8080:80 \
+      --yes
+    ```
+
+    恢复是破坏性操作（可能与已有名称/卷冲突），必须传 `--yes`。`--volume-strategy` 取值为 `rename`、`skip`、`overwrite`。
+  </Step>
+</Steps>
+
+<Callout type="warn">
+  备份路径在 CLI 端解析为绝对本地路径后才发给 daemon。daemon 拒绝相对路径、指向工作区外的符号链接，以及当前用户无法读取的路径。
+</Callout>

--- a/apps/landing/content/docs/zh/cli/images.mdx
+++ b/apps/landing/content/docs/zh/cli/images.mdx
@@ -1,0 +1,123 @@
+---
+title: "镜像、Hub 与 Trivy"
+description: "在 CLI 中拉取、构建、推送、扫描和搜索 Docker 镜像。"
+---
+
+`image`、`hub`、`trivy` 三个命令组共同覆盖完整的镜像生命周期：在 Docker Hub 上发现镜像、拉取、扫描 CVE、构建、推送、清理。
+
+## 列表、详情与打 tag
+
+```bash
+dockerman image list
+dockerman image list --pretty
+dockerman image inspect nginx:latest
+dockerman image tag nginx:latest myrepo/nginx --tag staging
+dockerman image history nginx:latest
+dockerman image search nginx --pretty
+```
+
+`image search` 通过连接的 daemon 调用 Docker Engine 的 `/images/search` 接口。需要更丰富的结果（描述、官方标记、tag 列表）时，请使用下方的 [`hub search`](#搜索-docker-hub)——两条命令访问的是不同的 API。
+
+## 拉取与推送
+
+```bash
+dockerman image pull nginx --tag latest
+dockerman image pull ghcr.io/me/app --tag v1 \
+  --username me --credential "$GHCR_TOKEN" \
+  --serveraddress https://ghcr.io \
+  --json
+
+dockerman image push myrepo/app --tag v1 --json
+```
+
+带 `--json` 时进度以 NDJSON 封装流式输出；不带 `--json` 时输出人类可读的进度行和最终状态。`--username` / `--credential` 仅作用于本次调用，CLI 不复用 GUI 中保存的 registry 凭证。
+
+## 构建
+
+```bash
+dockerman image build ./Dockerfile --tag myrepo/app:v1 \
+  --context-path ./ \
+  --buildargs "NODE_ENV=production" \
+  --pull --rm --json
+```
+
+构建使用与 pull/push 相同的进度封装。完整参数（build-args、labels、network mode、target stage、platform）见 `dockerman image build --help`。
+
+## 删除与清理
+
+```bash
+dockerman image remove nginx:old --force --yes
+dockerman image prune --filter dangling=true --yes
+```
+
+两者都需要 `--yes`。`prune` 支持多次 `--filter`，语法与 `docker image prune` 一致。
+
+## 导出与导入
+
+```bash
+dockerman image export nginx:latest ./nginx.tar
+dockerman image import ./nginx.tar --quiet
+```
+
+`export` 写出与 `docker save` 兼容的 tar 包；`import` 反向导入。
+
+## 搜索 Docker Hub
+
+```bash
+dockerman hub search alpine --pretty
+dockerman hub search nginx --page 2 --page-size 20 --json
+dockerman hub image library/alpine --pretty
+dockerman hub tags library/alpine --page 1 --page-size 25 --pretty
+```
+
+`hub search` 返回名称、描述、星标数、官方/自动构建标记。`hub image` 和 `hub tags` 显示 `<namespace>/<name>` 仓库的元数据和发布的标签。
+
+## 使用 Trivy 扫描
+
+Dockerman 内置受管的 Trivy 二进制；安装后即可离线扫描。
+
+<Steps>
+  <Step>
+    ### 检查状态
+
+    ```bash
+    dockerman trivy status --json
+    dockerman trivy dir --json
+    ```
+
+    `status` 返回 `installed: true|false` 和已解析的版本号。`dir` 输出绝对安装路径。
+  </Step>
+  <Step>
+    ### 安装或更新
+
+    ```bash
+    dockerman trivy install --json
+    dockerman trivy update --json
+    ```
+
+    两者都以 NDJSON 流式输出二进制和漏洞数据库下载进度。
+  </Step>
+  <Step>
+    ### 扫描镜像
+
+    ```bash
+    dockerman trivy scan alpine:latest --pretty
+    dockerman trivy scan myrepo/app:v1 --json --db-repository ghcr.io/aquasecurity/trivy-db
+    ```
+
+    扫描先输出多帧进度，最后输出一帧 `kind: result` 包含完整报告。`--json` 输出可管道传给 `jq` 过滤漏洞。
+  </Step>
+  <Step>
+    ### 删除
+
+    ```bash
+    dockerman trivy remove --yes
+    ```
+
+    删除受管二进制和数据库缓存，必须传 `--yes`。
+  </Step>
+</Steps>
+
+<Callout type="info">
+  `hub` 和 `trivy` 共用 daemon 的出站网络。它们遵循主机的 HTTPS 代理环境变量，但**不**走 GUI 配置的逐主机 SSH 隧道。
+</Callout>

--- a/apps/landing/content/docs/zh/cli/index.mdx
+++ b/apps/landing/content/docs/zh/cli/index.mdx
@@ -1,0 +1,81 @@
+---
+title: "命令行总览"
+description: "Daemon-first 的 dockerman CLI，可在终端中脚本化操作 Docker、Kubernetes、Compose 和 Trivy 工作流。"
+---
+
+`dockerman` 是一个轻量级命令行客户端，它通过带身份验证的 IPC 套接字与本地 **dockerman-daemon** 通信。GUI 中可用的所有功能——容器、镜像、Compose、Kubernetes 只读、Trivy、Docker Hub、隧道、WSL——都可以通过 CLI 调用。v5.3.0 新增。
+
+<Callout type="info">
+  CLI 会按需自动启动 `dockerman-daemon`，无需打开 GUI 即可使用。
+</Callout>
+
+## 安装
+
+CLI 与 GUI 一同打包发布。本地开发时可从源码构建：
+
+```bash
+cargo build -p dockerman-cli --release
+./target/release/dockerman --help
+```
+
+第一条需要后端的命令会自动拉起 `dockerman-daemon`，将 `daemon-ipc.json` 写入 app data 目录，后续命令复用此握手信息。
+
+## 全局参数
+
+| 参数 | 用途 |
+| --- | --- |
+| `--host <id>` | 指定 Docker 主机。本地套接字使用 `LOCALHOST`，或使用 `dockerman host current` 中列出的主机 id。 |
+| `--pretty` | 渲染人类友好的表格而非原始 JSON（仅适用于支持的命令）。 |
+| `--yes` / `-y` | 确认破坏性操作。`remove`、`prune`、`restore`、`tunnel create`、`wsl unregister` 等命令必须使用。 |
+
+## 选择主机
+
+```bash
+dockerman host current
+dockerman host use my-remote
+dockerman --host LOCALHOST container list
+```
+
+`host use` 将选择持久化到磁盘；后续未传 `--host` 的命令会沿用该主机。需要单次覆盖但不改变默认值时，按命令传 `--host`。
+
+## 系统与连通性
+
+```bash
+dockerman system info
+dockerman system df
+dockerman system ping 8.8.8.8
+dockerman system prune --containers --volumes --yes
+```
+
+## Schema 与发现
+
+daemon 暴露的每个 RPC 都有版本化的 schema。可用于发现命令、生成客户端、或喂给 LLM 工具注册表。
+
+```bash
+dockerman schema
+dockerman schema --format mcp-tools
+dockerman schema fetch_logs
+```
+
+当前 schema 版本为 `2`。一元调用与流式调用的区分见 [流式契约](/zh/docs/cli/streaming)。
+
+## 退出码
+
+| 退出码 | 含义 |
+| --- | --- |
+| `0` | 成功，或流自然结束 |
+| `1` | 通用失败（参数校验、RPC 错误、流体错误） |
+| `3` | 发现或握手失败（daemon 不可达） |
+| `4` | 流式心跳超时（30 秒未收到帧） |
+| `130` | 流式命令被 `SIGINT`（Ctrl+C）中断 |
+| `143` | 流式命令被 `SIGTERM` 中断 |
+
+## CLI 不覆盖的范围
+
+部分工作流仅在 GUI 中可用：
+
+- 调度任务和通知通道
+- 告警规则（预设规则在 daemon 上运行，但创建/编辑仅 GUI 支持）
+- 时序指标历史
+
+完整命令列表与 `dockerman --help` 一致。本节后续页面按领域分组介绍。

--- a/apps/landing/content/docs/zh/cli/kubernetes.mdx
+++ b/apps/landing/content/docs/zh/cli/kubernetes.mdx
@@ -1,0 +1,118 @@
+---
+title: "Kubernetes"
+description: "只读 Kubernetes 命令：发现集群、切换命名空间、查看资源。"
+---
+
+`k8s` 命令组是**只读**的：从 kubeconfig 发现集群、切换、查看 pod、deployment、configmap、secret、node 以及任意自定义资源。**不**支持创建、更新或删除资源。
+
+## 选择集群和命名空间
+
+```bash
+dockerman k8s cluster list
+dockerman k8s cluster current
+dockerman k8s cluster use kubeconfig:dev-context
+dockerman k8s namespace list --cluster kubeconfig:dev-context
+dockerman k8s namespace use workloads --cluster kubeconfig:dev-context
+dockerman k8s namespace current --cluster kubeconfig:dev-context
+```
+
+`cluster use` 和 `namespace use` 把选择持久化到磁盘。后续未传 `--cluster` / `--namespace` 的命令使用该选择。
+
+<Callout type="info">
+  集群 id 形如 `kubeconfig:<context-name>`。运行 `dockerman k8s cluster list` 查看 CLI 发现的每个 context 的精确 id。
+</Callout>
+
+## 集群总览
+
+```bash
+dockerman k8s overview
+dockerman k8s overview --cluster kubeconfig:dev-context --namespace workloads --pretty
+```
+
+返回一次性快照：node、pod、deployment、service 的计数，以及 warning 级别事件。适合在深入查看具体资源前做一次健康度探测。
+
+## 工作负载资源
+
+每种工作负载资源都支持 `list` 和 `get`：
+
+```bash
+dockerman k8s pod list
+dockerman k8s pod get my-pod --namespace workloads
+dockerman k8s deployment list --pretty
+dockerman k8s service get my-svc
+dockerman k8s statefulset list
+dockerman k8s daemonset list
+dockerman k8s job list
+dockerman k8s cronjob list
+dockerman k8s replicaset list
+```
+
+## 网络
+
+```bash
+dockerman k8s ingress list
+dockerman k8s endpoint list
+dockerman k8s endpointslice list
+dockerman k8s networkpolicy list
+```
+
+## 配置与存储
+
+```bash
+dockerman k8s configmap list
+dockerman k8s secret list
+dockerman k8s secret get app-secret
+dockerman k8s pvc list
+```
+
+## 集群级资源
+
+```bash
+dockerman k8s node list
+dockerman k8s node get worker-1
+dockerman k8s pv list
+dockerman k8s storageclass list
+dockerman k8s clusterrole list
+dockerman k8s clusterrolebinding list
+dockerman k8s crd list
+```
+
+## RBAC
+
+```bash
+dockerman k8s serviceaccount list
+dockerman k8s role list
+dockerman k8s rolebinding list
+```
+
+## Pod 日志
+
+```bash
+dockerman k8s pod logs my-pod --namespace workloads
+dockerman k8s pod logs my-pod --container app --tail-lines 100 --timestamps
+dockerman k8s pod logs my-pod --previous --since-time 2026-05-01T00:00:00Z
+```
+
+## 事件
+
+```bash
+dockerman k8s event list
+dockerman k8s event list --type Warning --involved-kind Pod
+```
+
+## 通用资源与 YAML
+
+对于上方未列出的资源（自定义资源、不常用内置资源），使用通用 `resource` 子命令。先用 `api-resource list` 发现可用资源：
+
+```bash
+dockerman k8s api-resource list --cluster kubeconfig:dev-context
+dockerman k8s resource list deployments.apps/v1 --namespace workloads
+dockerman k8s resource yaml secrets.core/v1 app-secret
+dockerman k8s resource yaml mycrd.example.com/v1alpha1 my-instance --json
+```
+
+`resource yaml` 输出脱敏后的 manifest。secret 的 `data` 字段在离开 daemon 之前已替换为 `<REDACTED>` —— **CLI 无法读取 secret 明文**。
+
+<Callout type="warn">
+  所有 k8s 命令按设计只读。需要修改资源时请直接使用 `kubectl`。Dockerman 的 k8s 接口面向自动化和 GUI 中的安全只读场景。
+</Callout>

--- a/apps/landing/content/docs/zh/cli/meta.json
+++ b/apps/landing/content/docs/zh/cli/meta.json
@@ -1,0 +1,14 @@
+{
+  "title": "命令行",
+  "pages": [
+    "index",
+    "containers",
+    "images",
+    "networks-volumes",
+    "compose",
+    "kubernetes",
+    "streaming",
+    "advanced"
+  ],
+  "defaultOpen": false
+}

--- a/apps/landing/content/docs/zh/cli/networks-volumes.mdx
+++ b/apps/landing/content/docs/zh/cli/networks-volumes.mdx
@@ -1,0 +1,93 @@
+---
+title: "网络与卷"
+description: "在 CLI 中管理 Docker 网络与卷——创建、查看、连接、清理。"
+---
+
+`network` 与 `volume` 命令组完整覆盖 GUI 在这两类资源上的所有操作。模式与 `container`、`image` 一致：`list`、`inspect`、`create`、`remove`/`prune`，以及网络的关联命令。
+
+## 网络
+
+### 列表与详情
+
+```bash
+dockerman network list
+dockerman network list --pretty
+dockerman network inspect bridge
+```
+
+### 创建
+
+```bash
+dockerman network create my-net \
+  --driver bridge \
+  --attachable \
+  --enable-ipv6 \
+  --option "com.docker.network.bridge.name=my-bridge" \
+  --label "owner=team-a"
+```
+
+| 参数 | 用途 |
+| --- | --- |
+| `--driver <name>` | 网络驱动（`bridge`、`overlay`、`macvlan` 等） |
+| `--internal` | 限制对外连通性 |
+| `--attachable` | 允许独立容器加入（仅 overlay） |
+| `--ingress` | 创建 swarm ingress 网络 |
+| `--enable-ipv6` | 在网络上启用 IPv6 |
+| `--option <k=v>` | 驱动相关选项（可重复） |
+| `--label <k=v>` | 网络标签（可重复） |
+
+### 删除
+
+```bash
+dockerman network remove my-net --yes
+```
+
+`remove` 需要 `--yes`。内建网络（`bridge`、`host`、`none`）无法删除。
+
+### 连接与断开
+
+```bash
+dockerman network connect my-net web
+dockerman network disconnect my-net web --force
+```
+
+容器正在运行、需要在不停止容器的情况下脱离网络时，必须传 `disconnect --force`。
+
+## 卷
+
+### 列表与详情
+
+```bash
+dockerman volume list
+dockerman volume list --pretty
+dockerman volume inspect data
+```
+
+### 创建
+
+```bash
+dockerman volume create data \
+  --driver local \
+  --driver-opt "type=nfs" \
+  --driver-opt "o=addr=10.0.0.1,rw" \
+  --driver-opt "device=:/exports/data" \
+  --label "backup=daily"
+```
+
+`--driver-opt` 与 `--label` 均可重复。
+
+### 删除
+
+```bash
+dockerman volume remove data --force --yes
+```
+
+`remove` 需要 `--yes`。`--force` 在卷被已停止容器引用时仍强制删除。
+
+### 清理
+
+```bash
+dockerman volume prune --filter "label=temp=true" --yes
+```
+
+`prune` 删除匹配过滤集的所有悬空（无引用）卷。`--filter` 可重复，语法与 Docker 标准过滤器一致（`label=`、`label!=` 等）。脚本中务必显式加过滤条件——不带过滤的 `volume prune --yes` 会删除主机上**所有**悬空卷。

--- a/apps/landing/content/docs/zh/cli/streaming.mdx
+++ b/apps/landing/content/docs/zh/cli/streaming.mdx
@@ -1,0 +1,74 @@
+---
+title: "流式契约"
+description: "流式 RPC 的 NDJSON 封装、心跳、背压与信号处理。"
+---
+
+所有流式 RPC（`logs -f`、`stats`、`events`、`image pull/push/build`、`compose pull/up`、`trivy scan/install`、`tunnel create`）共享 v5.3.0 引入的同一套线缆契约（schema 版本 `2`）。
+
+## 封装结构
+
+带 `--json` 时，stdout 上每一行是一帧封装。外层封装包含单调递增的 `seq` 和 `type` 判别字段；数据帧的强类型负载在 `payload` 中。
+
+```json
+{"seq":1,"type":"data","payload":{"line":"hello"}}
+{"seq":2,"type":"heartbeat"}
+{"seq":3,"type":"dropped","payload":{"count":12}}
+{"seq":4,"type":"data","payload":{"kind":"result","report":{"...":"..."}}}
+{"seq":5,"type":"end"}
+{"seq":6,"type":"error","payload":{"code":"docker_not_found","message":"container web not found","details":null}}
+```
+
+| `type` | 含义 |
+| --- | --- |
+| `data` | 普通数据帧；强类型负载在 `payload` 中 |
+| `heartbeat` | 存活检测。默认间隔 15 秒 |
+| `dropped` | 背压标记。daemon 丢弃了 `payload.count` 帧；在下一帧（任意类型）之前发出 |
+| `end` | 流正常结束，后续不再有帧 |
+| `error` | 终止错误。`payload` 包含 `{ code, message, details }`；该帧之后流结束 |
+
+<Callout type="info">
+  部分命令（Trivy scan、Trivy install、Compose pull）会在 data 负载内部再嵌套一层 tag。例如 `dockerman trivy scan` 发送的 `data` 帧，其 `payload.kind` 取值为 `"progress"`、`"result"`、`"error"`——内层 `error` 是流内部的业务错误，承载在成功的 `data` 封装上；而外层的 `error` 封装专门表示传输层失败。
+</Callout>
+
+## 普通模式
+
+不带 `--json` 时，流式命令输出对人友好的内容：
+
+- `logs -f`、`events`：每个 data 帧一行日志到 stdout，错误和诊断到 stderr。
+- `stats`、`image pull/push/build`、`compose pull/up`、`trivy install/scan`：进度行写到 stderr（这样可以把 stdout 重定向到文件），最终结果（如有）写到 stdout。
+
+## 心跳与超时
+
+daemon 每 15 秒发出一次心跳。CLI 最多等待 30 秒（两个心跳）后判定流已死，以退出码 `4` 退出。在更长的管道中包装 CLI 调用时，**不要缓冲 stdout**——缓冲会隐藏心跳，触发监控误报。
+
+## 背压
+
+每条流在 daemon 与 CLI 之间有 256 帧的缓冲区。消费方过慢时，daemon 丢弃最旧的帧，并在下一帧数据之前发出一帧 `Dropped { count }`。这能在终端（或 `jq -c`）跟不上生产者时保持流不断。
+
+## 取消
+
+按 **Ctrl+C** 发送 `SIGINT`；CLI 捕获后请求 daemon 通过 `CancelOnDrop` 取消，排空在途帧后以退出码 `130` 退出。`SIGTERM` 退出码为 `143`。daemon 也会感知 TCP / Unix 套接字连接断开（关闭浏览器标签、父进程被 kill），自动释放服务端资源，避免 goroutine 泄漏。
+
+## 流式退出码
+
+| 退出码 | 含义 |
+| --- | --- |
+| `0` | 流自然结束（容器停止、镜像拉取完成、扫描结束） |
+| `1` | 连接成功后流体出错（含连接前的 4xx） |
+| `3` | 流打开前 daemon 发现 / 握手失败 |
+| `4` | 心跳超时（30 秒未收到帧） |
+| `130` | `SIGINT` |
+| `143` | `SIGTERM` |
+
+## 查看 schema
+
+可以列出每个流式 RPC 及其封装结构：
+
+```bash
+dockerman schema --format mcp-tools
+dockerman schema follow_logs
+dockerman schema follow_stats
+dockerman schema monitor_events
+```
+
+流式 RPC 标记为 `streaming: true` 并引用 `StreamFrameEnvelope`。一元 callable RPC（如 `fetch_logs`）标记为 `callable: true`，使用普通 `result` schema。

--- a/apps/landing/content/docs/zh/meta.json
+++ b/apps/landing/content/docs/zh/meta.json
@@ -8,6 +8,7 @@
     "kubernetes",
     "---",
     "homelab",
+    "cli",
     "advanced",
     "platform",
     "reference"


### PR DESCRIPTION
## Summary

- Adds a new **CLI** section to the docs covering daemon-first `dockerman` (introduced in v5.3.0).
- 8 pages × 4 locales (en / zh / es / ja), one URL per commit so individual pages can be reviewed, reverted, or cherry-picked independently.
- Sidebar nav updated in each locale's root `meta.json`.

## Pages

| Route | Coverage |
| --- | --- |
| `/cli` | Install, daemon-first bootstrap, `--host` / `--pretty` / `--yes`, `host` & `system`, schema, exit codes |
| `/cli/containers` | Lifecycle, logs (incl. `--follow` / `--until` exclusivity), stats, terminal, backup/restore |
| `/cli/images` | image ops including `image search`, `hub search/image/tags`, `trivy status/install/scan/dir/remove` |
| `/cli/networks-volumes` | network create/connect/disconnect, volume create/prune, destructive-flag callouts |
| `/cli/compose` | list/up/pull/restart/remove/deploy with global Compose flags |
| `/cli/kubernetes` | Cluster & namespace selection, overview, all read-only resources, generic `resource yaml` with secret redaction |
| `/cli/streaming` | NDJSON envelope (`seq` / `type` / `payload`), heartbeat, backpressure, Trivy/Compose inner-tag note, exit codes |
| `/cli/advanced` | `schema` + `call`, events, Cloudflare Quick Tunnels, managed WSL2 engine, scripting tips |

## Verification

- All flags, command shapes, and exit codes cross-checked against the `crates/dockerman-cli` source (`cli.rs`, `commands/*`, `stream/client.rs`, `error.rs`).
- Streaming envelope shape verified against `Envelope<T>` in `crates/dockerman-cli/src/stream/client.rs` (`tag = "type"`, `seq` flat, `Heartbeat`/`Dropped`/`End`/`Error` variants).
- Destructive command list reconciled with `commands/call.rs::DESTRUCTIVE_RPCS` plus CLI-side `--yes` gates in `tunnel.rs:79` and `container.rs:439`.

## Test plan

- [x] `bun dev:landing` and click through each `/cli/*` route in en/zh/es/ja.
- [x] Confirm sidebar shows **CLI** between **Homelab** and **Advanced** in all four locales.
- [x] Spot-check internal links (`/cli/streaming`, `/cli/images#search-docker-hub`, etc.) resolve.