### PR TITLE
fix(landing): hide expired early-bird UI and centralize discount codes

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -35,62 +35,66 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
 
   return (
     <main>
-      <PricingHero locale={l} />
+      <PricingHero earlyBirdActive={isActive} locale={l} />
 
       {/* Countdown bar */}
-      <section className="px-5 pb-10 sm:px-8">
-        <div className="mx-auto mt-2 max-w-[560px]">
-          <div
-            className="flex flex-col items-center gap-4 rounded-[14px] border p-4 text-center sm:flex-row sm:flex-wrap sm:gap-5 sm:p-5 sm:text-left"
-            style={{
-              borderColor:
-                'color-mix(in srgb, var(--color-dm-warn) 30%, var(--color-dm-line-strong))',
-              backgroundImage:
-                'radial-gradient(ellipse at 10% 50%, color-mix(in srgb, var(--color-dm-warn) 10%, transparent), transparent 60%)',
-              backgroundColor: 'var(--color-dm-bg-elev)'
-            }}
-          >
+      {isActive ? (
+        <section className="px-5 pb-10 sm:px-8">
+          <div className="mx-auto mt-2 max-w-[560px]">
             <div
-              className="grid h-[38px] w-[38px] flex-shrink-0 place-items-center rounded-[9px]"
+              className="flex flex-col items-center gap-4 rounded-[14px] border p-4 text-center sm:flex-row sm:flex-wrap sm:gap-5 sm:p-5 sm:text-left"
               style={{
-                background: 'color-mix(in srgb, var(--color-dm-warn) 14%, transparent)',
-                color: 'var(--color-dm-warn)'
+                borderColor:
+                  'color-mix(in srgb, var(--color-dm-warn) 30%, var(--color-dm-line-strong))',
+                backgroundImage:
+                  'radial-gradient(ellipse at 10% 50%, color-mix(in srgb, var(--color-dm-warn) 10%, transparent), transparent 60%)',
+                backgroundColor: 'var(--color-dm-bg-elev)'
               }}
             >
-              <svg
-                fill="none"
-                height="18"
-                stroke="currentColor"
-                strokeWidth="2"
-                viewBox="0 0 24 24"
-                width="18"
+              <div
+                className="grid h-[38px] w-[38px] flex-shrink-0 place-items-center rounded-[9px]"
+                style={{
+                  background: 'color-mix(in srgb, var(--color-dm-warn) 14%, transparent)',
+                  color: 'var(--color-dm-warn)'
+                }}
               >
-                <circle cx="12" cy="12" r="9" />
-                <path d="M12 7v5l3 2" />
-              </svg>
-            </div>
-            <div className="flex-1 sm:min-w-[200px]">
-              <div className="font-semibold text-[13px] text-dm-ink">
-                {t('pricing.countdown.endsLead')}{' '}
-                <span
-                  className="ml-2 inline-block rounded px-[7px] py-[2px] font-[var(--font-dm-mono)] font-bold text-[10px] tracking-[0.04em]"
-                  style={{ background: 'var(--color-dm-warn)', color: '#000' }}
+                <svg
+                  fill="none"
+                  height="18"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                  width="18"
                 >
-                  {t('pricing.countdown.endsDate')}
-                </span>
+                  <circle cx="12" cy="12" r="9" />
+                  <path d="M12 7v5l3 2" />
+                </svg>
               </div>
-              <div className="mt-[3px] font-[var(--font-dm-mono)] text-[12px] text-dm-ink-3">
-                {t('pricing.countdown.afterNote', {
-                  solo: plans.solo.priceRegular,
-                  devices: plans.team.devices,
-                  team: plans.team.priceRegular
-                })}
+              <div className="flex-1 sm:min-w-[200px]">
+                <div className="font-semibold text-[13px] text-dm-ink">
+                  {t('pricing.countdown.endsLead')}{' '}
+                  <span
+                    className="ml-2 inline-block rounded px-[7px] py-[2px] font-[var(--font-dm-mono)] font-bold text-[10px] tracking-[0.04em]"
+                    style={{ background: 'var(--color-dm-warn)', color: '#000' }}
+                  >
+                    {t('pricing.countdown.endsDate')}
+                  </span>
+                </div>
+                <div className="mt-[3px] font-[var(--font-dm-mono)] text-[12px] text-dm-ink-3">
+                  {t('pricing.countdown.afterNote', {
+                    solo: plans.solo.priceRegular,
+                    devices: plans.team.devices,
+                    team: plans.team.priceRegular
+                  })}
+                </div>
               </div>
+              <Countdown deadlineUtc={earlyBirdDeadlineUtc} locale={l} />
             </div>
-            <Countdown deadlineUtc={earlyBirdDeadlineUtc} locale={l} />
           </div>
-        </div>
-      </section>
+        </section>
+      ) : (
+        <div className="pb-6 sm:pb-8" />
+      )}
 
       {/* Plans */}
       <section className="px-5 sm:px-8">

--- a/apps/landing/src/app/api/checkout/route.ts
+++ b/apps/landing/src/app/api/checkout/route.ts
@@ -1,17 +1,18 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { siteConfig } from '@/app/siteConfig'
+import { pricingConfig } from '@/config/pricing'
 
 const CREEM_BASE_URL =
   process.env.NODE_ENV === 'production' ? 'https://api.creem.io' : 'https://test-api.creem.io'
 
 const PLAN_CONFIG: Record<string, { productId?: string; discountCode?: string }> = {
   '1-device': {
-    productId: process.env.CREEM_PRODUCT_ID_1_DEVICE,
-    discountCode: process.env.CREEM_DISCOUNT_CODE_1_DEVICE
+    productId: process.env.CREEM_PRODUCT_ID_1_DEVICES,
+    discountCode: pricingConfig.discountCodes['1-device']
   },
   '3-devices': {
     productId: process.env.CREEM_PRODUCT_ID_3_DEVICES,
-    discountCode: process.env.CREEM_DISCOUNT_CODE_3_DEVICES
+    discountCode: pricingConfig.discountCodes['3-devices']
   }
 }
 

--- a/apps/landing/src/components/pricing/PricingHero.tsx
+++ b/apps/landing/src/components/pricing/PricingHero.tsx
@@ -1,7 +1,13 @@
 import type { Locale } from '@repo/shared/i18n'
 import { getTranslation } from '@repo/shared/i18n/server'
 
-export async function PricingHero({ locale }: { locale: Locale }) {
+export async function PricingHero({
+  locale,
+  earlyBirdActive = false
+}: {
+  locale: Locale
+  earlyBirdActive?: boolean
+}) {
   const { t } = await getTranslation(locale)
   return (
     <section className="relative overflow-hidden px-5 pt-12 pb-8 sm:px-8 sm:pt-16 sm:pb-10">
@@ -14,26 +20,28 @@ export async function PricingHero({ locale }: { locale: Locale }) {
         }}
       />
       <div className="mx-auto max-w-[1140px] text-center">
-        <span className="inline-flex items-center gap-[10px] rounded-full border border-dm-line-strong bg-dm-bg-elev py-[5px] pr-[10px] pl-[6px] font-[var(--font-dm-mono)] text-[12px] text-dm-ink-2">
-          <span
-            className="h-[6px] w-[6px] rounded-full"
-            style={{
-              background: 'var(--color-dm-warn)',
-              boxShadow: '0 0 0 4px color-mix(in srgb, var(--color-dm-warn) 30%, transparent)',
-              animation: 'dm-pulse 2.2s ease-in-out infinite'
-            }}
-          />
-          <span>{t('pricing.hero.eyebrow')}</span>
-          <span
-            className="rounded-full px-2 py-[2px] font-semibold text-[10px]"
-            style={{ background: 'var(--color-dm-warn)', color: 'var(--color-dm-bg)' }}
-          >
-            {t('pricing.hero.eyebrowTag')}
+        {earlyBirdActive ? (
+          <span className="inline-flex items-center gap-[10px] rounded-full border border-dm-line-strong bg-dm-bg-elev py-[5px] pr-[10px] pl-[6px] font-[var(--font-dm-mono)] text-[12px] text-dm-ink-2">
+            <span
+              className="h-[6px] w-[6px] rounded-full"
+              style={{
+                background: 'var(--color-dm-warn)',
+                boxShadow: '0 0 0 4px color-mix(in srgb, var(--color-dm-warn) 30%, transparent)',
+                animation: 'dm-pulse 2.2s ease-in-out infinite'
+              }}
+            />
+            <span>{t('pricing.hero.eyebrow')}</span>
+            <span
+              className="rounded-full px-2 py-[2px] font-semibold text-[10px]"
+              style={{ background: 'var(--color-dm-warn)', color: 'var(--color-dm-bg)' }}
+            >
+              {t('pricing.hero.eyebrowTag')}
+            </span>
           </span>
-        </span>
+        ) : null}
 
         <h1
-          className="mx-auto mt-[22px] font-bold text-[clamp(48px,7vw,88px)] text-dm-ink leading-[0.98] tracking-[-0.04em]"
+          className={`mx-auto ${earlyBirdActive ? 'mt-[22px]' : ''} font-bold text-[clamp(48px,7vw,88px)] text-dm-ink leading-[0.98] tracking-[-0.04em]`}
           style={{ maxWidth: locale === 'zh' || locale === 'ja' ? 'none' : '16ch' }}
         >
           {t('pricing.hero.titleLead')}{' '}

--- a/apps/landing/src/config/pricing.ts
+++ b/apps/landing/src/config/pricing.ts
@@ -1,5 +1,10 @@
 export const pricingConfig = {
   earlyBirdDeadlineUtc: '2026-04-30T23:59:59Z',
+  // Creem discount codes per plan slug. Leave empty to disable discount.
+  discountCodes: {
+    '1-device': '',
+    '3-devices': ''
+  } as Record<string, string>,
   plans: {
     free: { price: 0 },
     team: { priceEarlyBird: 18.86, priceRegular: 29, devices: 3 },


### PR DESCRIPTION
## Summary
- Conditionally render the pricing countdown bar and Hero "Early Bird" eyebrow on `isActive`, so they disappear automatically after `pricingConfig.earlyBirdDeadlineUtc` (today is past the 2026-04-30 cutoff). Price switching and strike-through were already gated; only the decorative UI was leaking through.
- Move Creem discount codes from per-env vars into `pricingConfig.discountCodes`, keyed by plan slug, currently empty. Re-enabling a future campaign is now a one-file edit.
- Align the 1-device product env var with the name configured on Vercel: `CREEM_PRODUCT_ID_1_DEVICE` → `CREEM_PRODUCT_ID_1_DEVICES` (3-devices was already plural).

## Test plan
- [x] Visit `/pricing` on a deploy where `now > earlyBirdDeadlineUtc`: confirm Hero eyebrow badge and countdown section are hidden, plans show regular price with no strike-through.
- [x] Temporarily set `earlyBirdDeadlineUtc` to a future date locally: confirm eyebrow + countdown reappear and Solo/Team show early-bird price with regular price struck through.
- [x] Click "Get Team" / "Get Solo" with `discountCodes` empty → verify Creem checkout request body has no `discount_code` field (server log).
- [x] Set a mock value in `discountCodes['1-device']` → verify checkout request body includes `discount_code`.
- [x] Confirm Vercel `CREEM_PRODUCT_ID_1_DEVICES` / `CREEM_PRODUCT_ID_3_DEVICES` are set in production env; checkout should not return `Product ID not configured`.