### PR TITLE
feat(landing): clip-path theme switch transition

### DIFF
--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -339,50 +339,14 @@ a {
   @apply visible;
 }
 
-::view-transition-group(root) {
-  animation-timing-function: var(--expo-in);
+/* Theme toggle uses view-transitions + clip-path: disable defaults so the
+   WAAPI animation in ThemeSwitch drives the reveal. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
 }
 
 ::view-transition-new(root) {
-  mask:
-    var(--transition-mask, url("/images/i-love-you-love.gif")) center / 0
-    no-repeat;
-  animation: scale 1.5s;
-  animation-fill-mode: both;
+  z-index: 1;
 }
-
-::view-transition-old(root),
-.dark::view-transition-old(root) {
-  animation: scale 1.5s;
-  animation-fill-mode: both;
-}
-
-@keyframes scale {
-  0% {
-    mask-size: 0;
-  }
-  10% {
-    mask-size: 50vmax;
-  }
-  90% {
-    mask-size: 50vmax;
-  }
-  100% {
-    mask-size: 2000vmax;
-  }
-}
-
-/* View Transition styles for theme toggle animation */
-/*::view-transition-old(root),*/
-/*::view-transition-new(root) {*/
-/*  animation: none;*/
-/*  mix-blend-mode: normal;*/
-/*}*/
-
-/*::view-transition-old(root) {*/
-/*  z-index: 1;*/
-/*}*/
-
-/*::view-transition-new(root) {*/
-/*  z-index: 9999;*/
-/*}*/

--- a/apps/landing/src/components/DocsThemeToggle.tsx
+++ b/apps/landing/src/components/DocsThemeToggle.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { RiMoonLine, RiSunLine } from '@remixicon/react'
+import { useTheme } from 'next-themes'
+import { useEffect, useState } from 'react'
+import { applyThemeWithTransition } from '@/lib/theme-transition'
+
+export function DocsThemeToggle({ className }: { className?: string }) {
+  const { resolvedTheme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const value = mounted ? resolvedTheme : null
+  const isLight = value === 'light'
+  const next = isLight ? 'dark' : 'light'
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      className={[
+        'ms-auto inline-flex items-center rounded-full border p-0 *:rounded-full *:size-6.5 *:p-1.5',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      data-theme-toggle=""
+      onClick={() => applyThemeWithTransition(() => setTheme(next))}
+      type="button"
+    >
+      <span
+        className={
+          isLight
+            ? 'bg-fd-accent text-fd-accent-foreground'
+            : 'text-fd-muted-foreground'
+        }
+      >
+        <RiSunLine className="size-full" />
+      </span>
+      <span
+        className={
+          value === 'dark'
+            ? 'bg-fd-accent text-fd-accent-foreground'
+            : 'text-fd-muted-foreground'
+        }
+      >
+        <RiMoonLine className="size-full" />
+      </span>
+    </button>
+  )
+}

--- a/apps/landing/src/components/ThemeSwitch.tsx
+++ b/apps/landing/src/components/ThemeSwitch.tsx
@@ -5,7 +5,7 @@ import { RiMoonLine, RiSunLine } from '@remixicon/react'
 import { useTheme } from 'next-themes'
 import type React from 'react'
 import { useEffect, useState } from 'react'
-import { flushSync } from 'react-dom'
+import { applyThemeWithTransition } from '@/lib/theme-transition'
 
 const OPTIONS = [
   { value: 'light', label: 'Light', Icon: RiSunLine },
@@ -28,36 +28,7 @@ function ThemeSwitch() {
   const onChange = (value: string) => {
     const fromTheme = theme
 
-    const apply = () => setTheme(value)
-
-    const supportsViewTransition =
-      typeof document !== 'undefined' &&
-      typeof document.startViewTransition === 'function'
-    const prefersReducedMotion =
-      typeof window !== 'undefined' &&
-      window.matchMedia('(prefers-reduced-motion: reduce)').matches
-
-    if (!supportsViewTransition || prefersReducedMotion) {
-      apply()
-    } else {
-      const transition = document.startViewTransition(() => {
-        flushSync(apply)
-      })
-      transition.ready
-        .then(() => {
-          document.documentElement.animate(
-            { clipPath: ['inset(0 0 100% 0)', 'inset(0)'] },
-            {
-              pseudoElement: '::view-transition-new(root)',
-              duration: 600,
-              easing: 'cubic-bezier(0.16, 1, 0.3, 1)',
-            },
-          )
-        })
-        .catch(() => {
-          /* swallow transition aborts */
-        })
-    }
+    applyThemeWithTransition(() => setTheme(value))
 
     import('posthog-js')
       .then(({ default: posthog }) => {

--- a/apps/landing/src/components/ThemeSwitch.tsx
+++ b/apps/landing/src/components/ThemeSwitch.tsx
@@ -5,6 +5,7 @@ import { RiMoonLine, RiSunLine } from '@remixicon/react'
 import { useTheme } from 'next-themes'
 import type React from 'react'
 import { useEffect, useState } from 'react'
+import { flushSync } from 'react-dom'
 
 const OPTIONS = [
   { value: 'light', label: 'Light', Icon: RiSunLine },
@@ -26,7 +27,38 @@ function ThemeSwitch() {
 
   const onChange = (value: string) => {
     const fromTheme = theme
-    setTheme(value)
+
+    const apply = () => setTheme(value)
+
+    const supportsViewTransition =
+      typeof document !== 'undefined' &&
+      typeof document.startViewTransition === 'function'
+    const prefersReducedMotion =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    if (!supportsViewTransition || prefersReducedMotion) {
+      apply()
+    } else {
+      const transition = document.startViewTransition(() => {
+        flushSync(apply)
+      })
+      transition.ready
+        .then(() => {
+          document.documentElement.animate(
+            { clipPath: ['inset(0 0 100% 0)', 'inset(0)'] },
+            {
+              pseudoElement: '::view-transition-new(root)',
+              duration: 600,
+              easing: 'cubic-bezier(0.16, 1, 0.3, 1)',
+            },
+          )
+        })
+        .catch(() => {
+          /* swallow transition aborts */
+        })
+    }
+
     import('posthog-js')
       .then(({ default: posthog }) => {
         posthog.capture('footer_theme_changed', {

--- a/apps/landing/src/lib/layout.shared.tsx
+++ b/apps/landing/src/lib/layout.shared.tsx
@@ -1,9 +1,13 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared'
+import { DocsThemeToggle } from '@/components/DocsThemeToggle'
 
 export function baseOptions(locale?: string): BaseLayoutProps {
   return {
     nav: {
       title: locale === 'zh' ? 'Dockerman 文档' : 'Dockerman Docs'
+    },
+    themeSwitch: {
+      component: <DocsThemeToggle />
     }
   }
 }

--- a/apps/landing/src/lib/theme-transition.ts
+++ b/apps/landing/src/lib/theme-transition.ts
@@ -1,0 +1,39 @@
+'use client'
+
+import { flushSync } from 'react-dom'
+
+export function applyThemeWithTransition(apply: () => void) {
+  if (typeof document === 'undefined') {
+    apply()
+    return
+  }
+
+  const supportsViewTransition = typeof document.startViewTransition === 'function'
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+  if (!supportsViewTransition || prefersReducedMotion) {
+    apply()
+    return
+  }
+
+  const transition = document.startViewTransition(() => {
+    flushSync(apply)
+  })
+
+  transition.ready
+    .then(() => {
+      document.documentElement.animate(
+        { clipPath: ['inset(0 0 100% 0)', 'inset(0)'] },
+        {
+          pseudoElement: '::view-transition-new(root)',
+          duration: 600,
+          easing: 'cubic-bezier(0.16, 1, 0.3, 1)',
+        },
+      )
+    })
+    .catch(() => {
+      /* swallow transition aborts */
+    })
+}


### PR DESCRIPTION
## Summary

- Replace the mask-based view-transition with a clip-path top-to-bottom reveal driven by `document.startViewTransition` + WAAPI on `::view-transition-new(root)`. Falls back to direct `setTheme` when `startViewTransition` is unsupported or `prefers-reduced-motion: reduce` is set.
- Extract the transition into a shared helper (`lib/theme-transition.ts`) and reuse it in the marketing navbar `ThemeSwitch` and a new `DocsThemeToggle` supplied via fumadocs `themeSwitch.component`, so the docs sidebar toggle uses the same animation while keeping its original bottom-right position (`ms-auto p-0`).

## Test plan

- [x] On `/`, click navbar theme toggle — confirm clip-path reveal from top to bottom
- [x] On `/docs/*`, click sidebar bottom theme toggle — confirm same reveal and the button stays bottom-right
- [x] Enable "Reduce motion" in OS settings — toggles still work, no animation
- [x] In a browser without `startViewTransition` (e.g. Firefox) — toggles still work, instant switch