### PR TITLE
Release v5.3.1: Windows CLI copy-command PATH safety fix

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -2,8 +2,8 @@
 
 Language: [🇺🇸 English](./README.md) | [🇨🇳 简体中文](./README.zh-CN.md) | [🇯🇵 日本語](./README.ja.md) | 🇪🇸 Español
 
-[![Version](https://img.shields.io/badge/version-v5.3.0-blue.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.0)
-[![Release Date](https://img.shields.io/badge/release%20date-May%205%2C%202026-green.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.0)
+[![Version](https://img.shields.io/badge/version-v5.3.1-blue.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.1)
+[![Release Date](https://img.shields.io/badge/release%20date-May%2012%2C%202026-green.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.1)
 
 Una UI de escritorio nativa para gestionar Docker **y** Kubernetes — construida con Tauri + Rust. Arranque rápido, ligera en recursos y completamente local: nada sale de tu máquina.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,8 +2,8 @@
 
 Language: [🇺🇸 English](./README.md) | [🇨🇳 简体中文](./README.zh-CN.md) | 🇯🇵 日本語 | [🇪🇸 Español](./README.es.md)
 
-[![Version](https://img.shields.io/badge/version-v5.3.0-blue.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.0)
-[![Release Date](https://img.shields.io/badge/release%20date-May%205%2C%202026-green.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.0)
+[![Version](https://img.shields.io/badge/version-v5.3.1-blue.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.1)
+[![Release Date](https://img.shields.io/badge/release%20date-May%2012%2C%202026-green.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.1)
 
 Docker **と** Kubernetes をまとめて管理できるネイティブデスクトップ UI。Tauri + Rust 製で、起動が速く、軽量、完全ローカル動作――データはマシンの外に出ません。
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Language: 🇺🇸 English | [🇨🇳 简体中文](./README.zh-CN.md) | [🇯🇵 日本語](./README.ja.md) | [🇪🇸 Español](./README.es.md)
 
-[![Version](https://img.shields.io/badge/version-v5.3.0-blue.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.0)
-[![Release Date](https://img.shields.io/badge/release%20date-May%205%2C%202026-green.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.0)
+[![Version](https://img.shields.io/badge/version-v5.3.1-blue.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.1)
+[![Release Date](https://img.shields.io/badge/release%20date-May%2012%2C%202026-green.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.1)
 
 A native desktop UI for managing Docker **and** Kubernetes — built with Tauri + Rust. Fast to launch, light on resources, and entirely local: nothing leaves your machine.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,8 +2,8 @@
 
 Language: [🇺🇸 English](./README.md) | 🇨🇳 简体中文 | [🇯🇵 日本語](./README.ja.md) | [🇪🇸 Español](./README.es.md)
 
-[![Version](https://img.shields.io/badge/version-v5.3.0-blue.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.0)
-[![Release Date](https://img.shields.io/badge/release%20date-May%205%2C%202026-green.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.0)
+[![Version](https://img.shields.io/badge/version-v5.3.1-blue.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.1)
+[![Release Date](https://img.shields.io/badge/release%20date-May%2012%2C%202026-green.svg?style=flat-square)](https://github.com/dockerman/dockerman/releases/tag/v5.3.1)
 
 一个原生桌面端 Docker **与** Kubernetes 管理工具，基于 Tauri + Rust。启动快、占用低、完全本地运行——数据不出本机。
 

--- a/apps/landing/src/app/siteConfig.ts
+++ b/apps/landing/src/app/siteConfig.ts
@@ -14,7 +14,7 @@ export const siteConfig = {
     privacy: '/privacy',
     terms: '/terms'
   },
-  latestVersion: '5.3.0'
+  latestVersion: '5.3.1'
 }
 
 export type siteConfig = typeof siteConfig

--- a/apps/landing/src/config/downloads.ts
+++ b/apps/landing/src/config/downloads.ts
@@ -30,7 +30,7 @@ export interface DownloadsHistoryEntry {
 }
 
 const VERSION = siteConfig.latestVersion
-const RELEASE_DATE = '2026-05-05'
+const RELEASE_DATE = '2026-05-12'
 
 export const downloadsConfig: {
   asOf: string
@@ -104,7 +104,8 @@ export const downloadsConfig: {
     }
   },
   history: [
-    { version: VERSION, date: RELEASE_DATE, summarySlug: 'release-5-3-0' },
+    { version: VERSION, date: RELEASE_DATE, summarySlug: 'release-5-3-1' },
+    { version: '5.3.0', date: '2026-05-05', summarySlug: 'release-5-3-0' },
     { version: '5.2.0', date: '2026-04-26', summarySlug: 'release-5-2-0' },
     { version: '5.1.0', date: '2026-04-08', summarySlug: 'release-5-1-0' },
     { version: '5.0.0', date: '2026-04-07', summarySlug: 'release-5-0-0' },

--- a/apps/landing/src/content/changelog/en/page.mdx
+++ b/apps/landing/src/content/changelog/en/page.mdx
@@ -1,3 +1,14 @@
+<ChangelogEntry version="v5.3.1" date="May 12, 2026">
+## Safer Windows CLI Copy Command
+
+A targeted patch that keeps the Settings → CLI "Copy command" install path from ever touching User PATH, so the GUI's "Install for this user" button remains the single source of PATH updates.
+
+### 🐛 Bug Fixes
+
+- 🪟 <Bold>Windows CLI Copy Command PATH Safety:</Bold> Settings → CLI "Copy command" no longer touches User PATH. The previous PowerShell could collapse User PATH down to just the Dockerman bin directory in edge cases. PATH updates are now handled exclusively by the GUI "Install for this user" button, which uses safe direct registry access. The copied command also writes the ownership marker so manual installs are correctly recognized as Dockerman-managed instead of `Unsupported`.
+
+</ChangelogEntry>
+
 <ChangelogEntry version="v5.3.0" date="May 5, 2026">
 ## Bundled CLI, AI Assistant Plugins & Windows Engine Switcher
 

--- a/apps/landing/src/content/changelog/es/page.mdx
+++ b/apps/landing/src/content/changelog/es/page.mdx
@@ -1,3 +1,14 @@
+<ChangelogEntry version="v5.3.1" date="12 de mayo de 2026">
+## Comando de copia CLI más seguro en Windows
+
+Un parche puntual que evita que «Ajustes → CLI → Copiar comando» toque el PATH del usuario; las actualizaciones del PATH quedan a cargo exclusivamente del botón «Instalar para este usuario» de la GUI.
+
+### 🐛 Corrección de errores
+
+- 🪟 <Bold>Seguridad del PATH en el comando de copia CLI en Windows:</Bold> «Ajustes → CLI → Copiar comando» ya no modifica el PATH del usuario. El PowerShell anterior podía reducir el PATH del usuario únicamente al directorio bin de Dockerman en casos límite. Las actualizaciones del PATH se gestionan ahora exclusivamente desde el botón «Instalar para este usuario» de la GUI, que utiliza acceso directo y seguro al registro. El comando copiado también escribe el marcador de propiedad para que las instalaciones manuales se reconozcan correctamente como gestionadas por Dockerman en lugar de aparecer como `Unsupported`.
+
+</ChangelogEntry>
+
 <ChangelogEntry version="v5.3.0" date="5 de mayo de 2026">
 ## CLI incluido, plugins de asistentes IA y conmutador de motor en Windows
 

--- a/apps/landing/src/content/changelog/ja/page.mdx
+++ b/apps/landing/src/content/changelog/ja/page.mdx
@@ -1,3 +1,14 @@
+<ChangelogEntry version="v5.3.1" date="2026 年 5 月 12 日">
+## Windows CLI コピーコマンドの PATH 安全化
+
+設定 → CLI の「コマンドをコピー」がユーザー PATH に一切触れないようにする小さなパッチです。PATH 更新は GUI の「このユーザーにインストール」ボタンに一本化されました。
+
+### 🐛 バグ修正
+
+- 🪟 <Bold>Windows CLI コピーコマンドの PATH 安全性：</Bold>設定 → CLI の「コマンドをコピー」がユーザー PATH を変更しなくなりました。従来の PowerShell では、エッジケースでユーザー PATH が Dockerman bin ディレクトリのみへ縮退する恐れがありました。PATH 更新は今後 GUI の「このユーザーにインストール」ボタンが安全な直接レジストリ操作で行う唯一の経路となります。コピーされるコマンドは所有マーカーも書き込むため、手動インストールが `Unsupported` ではなく Dockerman 管理として正しく認識されます。
+
+</ChangelogEntry>
+
 <ChangelogEntry version="v5.3.0" date="2026年5月5日">
 ## CLI 同梱、AI アシスタントプラグイン、Windows エンジン切替
 

--- a/apps/landing/src/content/changelog/zh/page.mdx
+++ b/apps/landing/src/content/changelog/zh/page.mdx
@@ -1,3 +1,14 @@
+<ChangelogEntry version="v5.3.1" date="2026 年 5 月 12 日">
+## 更安全的 Windows CLI 复制命令
+
+本次补丁确保「设置 → CLI 复制命令」的安装路径永远不会改动用户 PATH，PATH 更新统一交由 GUI 的「为当前用户安装」按钮处理。
+
+### 🐛 缺陷修复
+
+- 🪟 <Bold>Windows CLI 复制命令的 PATH 安全性：</Bold>「设置 → CLI 复制命令」不再修改用户 PATH。此前的 PowerShell 在某些边界场景下可能把用户 PATH 折叠为仅剩 Dockerman bin 目录。现在 PATH 更新完全由 GUI 的「为当前用户安装」按钮负责，使用安全的直接注册表访问。复制出的命令同时写入归属标记，因此手动安装会被正确识别为 Dockerman 托管，而不再显示为 `Unsupported`。
+
+</ChangelogEntry>
+
 <ChangelogEntry version="v5.3.0" date="2026年5月5日">
 ## 内置 CLI、AI 助手插件与 Windows 引擎切换
 

--- a/packages/shared/src/locales/en.json
+++ b/packages/shared/src/locales/en.json
@@ -12,7 +12,7 @@
     "closeMenu": "Close menu"
   },
   "hero": {
-    "eyebrow": "v{{version}} — Bundled Dockerman CLI, AI assistant plugins, Windows engine switcher",
+    "eyebrow": "v{{version}} — Safer Windows CLI copy command, no User PATH overwrites, ownership marker on manual installs",
     "eyebrowTag": "NEW",
     "headline1Lead": "Docker that feels",
     "headline1Accent": "local",

--- a/packages/shared/src/locales/es.json
+++ b/packages/shared/src/locales/es.json
@@ -12,7 +12,7 @@
     "closeMenu": "Cerrar menú"
   },
   "hero": {
-    "eyebrow": "v{{version}} — CLI Dockerman incluido, plugins de asistentes IA, conmutador de motor Windows",
+    "eyebrow": "v{{version}} — Comando de copia CLI más seguro en Windows, sin sobrescribir el PATH de usuario, marcador de propiedad en instalaciones manuales",
     "eyebrowTag": "NUEVO",
     "headline1Lead": "Docker que se siente",
     "headline1Accent": "local",

--- a/packages/shared/src/locales/ja.json
+++ b/packages/shared/src/locales/ja.json
@@ -12,7 +12,7 @@
     "closeMenu": "メニューを閉じる"
   },
   "hero": {
-    "eyebrow": "v{{version}} — Dockerman CLI 同梱、AI アシスタントプラグイン、Windows エンジン切替",
+    "eyebrow": "v{{version}} — Windows CLI コピーコマンドの PATH 安全化、ユーザー PATH を破壊しない、手動インストールに所有マーカー",
     "eyebrowTag": "NEW",
     "headline1Lead": "Docker を",
     "headline1Accent": "ローカルに",

--- a/packages/shared/src/locales/zh.json
+++ b/packages/shared/src/locales/zh.json
@@ -12,7 +12,7 @@
     "closeMenu": "关闭菜单"
   },
   "hero": {
-    "eyebrow": "v{{version}} — 内置 Dockerman CLI、AI 助手插件、Windows 引擎切换",
+    "eyebrow": "v{{version}} — 更安全的 Windows CLI 复制命令、不再覆盖用户 PATH、手动安装写入归属标记",
     "eyebrowTag": "新",
     "headline1Lead": "Docker，用起来像",
     "headline1Accent": "本地",


### PR DESCRIPTION
## Summary

- **v5.3.1 release**: Settings → CLI "Copy command" on Windows no longer touches User PATH. Previous PowerShell could collapse User PATH down to just the Dockerman bin directory in edge cases. PATH updates are now exclusive to the GUI "Install for this user" button (direct registry access). The copied command writes the ownership marker so manual installs are recognized as Dockerman-managed instead of `Unsupported`.
- Bumps `siteConfig.latestVersion` to `5.3.1`, `RELEASE_DATE` to `2026-05-12`, prepends history entry, and propagates the change through changelogs (en/zh/ja/es), README badges (×4), and `hero.eyebrow` taglines.
- Also bundles the prior tripoli-v3 work: CLI docs (overview, containers, images, compose, k8s, networks/volumes, streaming, advanced, skills) across four locales, clip-path theme transitions for Hero and docs sidebar, `siteConfig.latestVersion` as single source of truth refactor, and assorted landing fixes.

## Test plan

- [x] `apps/landing` builds and serves with `latestVersion: '5.3.1'` reflected in Navbar, Hero, SnapshotHero, and Download page
- [x] `/changelog` shows the new v5.3.1 entry as the top item in all four locales
- [x] README badges render v5.3.1 + May 12, 2026 in all four locales
- [x] Hero eyebrow displays the new tagline interpolated with v5.3.1
- [x] `grep "v?5\.3\.1"` returns only the expected locations (siteConfig, changelog entries, READMEs)