### PR TITLE
SEO overhaul for landing + docs (sitemap, hreflang, JSON-LD, perf)

### DIFF
--- a/apps/landing/content/docs/en/guides/compose.mdx
+++ b/apps/landing/content/docs/en/guides/compose.mdx
@@ -1,0 +1,39 @@
+---
+title: Docker Compose
+description: Manage multi-container applications with Docker Compose
+---
+
+## Overview
+
+Dockerman supports Docker Compose for managing multi-container applications. Import a Compose file, start and stop services, and view per-service logs.
+
+## Importing a Compose Project
+
+1. Click **Import** on the Compose page
+2. Select a `docker-compose.yml` file or a directory that contains one
+3. Dockerman parses the file and lists every defined service
+
+## Managing Services
+
+Each Compose project lists its services with their current state. You can:
+
+- **Start All** — start every service in the project
+- **Stop All** — stop every running service
+- **Start / Stop** an individual service
+- **Restart** a specific service
+
+## Viewing Logs
+
+Select a service to view its logs. You can:
+
+- Stream logs in real time
+- Filter by service name
+- Search within the logs
+
+## Environment Variables
+
+Compose projects can use `.env` files. Dockerman reads them automatically from the project directory.
+
+## Removing a Project
+
+Click **Remove** to tear down every container, network, and volume created by the Compose project.

--- a/apps/landing/content/docs/en/guides/containers.mdx
+++ b/apps/landing/content/docs/en/guides/containers.mdx
@@ -1,0 +1,55 @@
+---
+title: Container Management
+description: Manage Docker containers with Dockerman
+---
+
+## Overview
+
+Dockerman provides a visual interface for managing Docker containers. View, create, start, stop, restart, and remove containers from a single panel.
+
+## Container List
+
+The Containers page lists every container on the host — running and stopped. Each row shows:
+
+- Container name and ID
+- Image in use
+- Current state (running, stopped, paused)
+- Port mappings
+- Created time
+
+Use the search bar to filter by name or image.
+
+## Creating a Container
+
+1. Click **Create** on the Containers page
+2. Pick a base image from local images or pull a new one
+3. Configure container settings:
+   - Name
+   - Port mappings
+   - Volume mounts
+   - Environment variables
+   - Resource limits (CPU, memory)
+4. Click **Create** to launch the container
+
+## Container Actions
+
+Right-click a container or use the action buttons:
+
+- **Start** — start a stopped container
+- **Stop** — gracefully stop a running container
+- **Restart** — stop and restart the container
+- **Pause / Resume** — freeze or resume the container's processes
+- **Remove** — delete the container (must be stopped first)
+
+## Viewing Logs
+
+Click a container to open the detail view, then switch to the **Logs** tab. Features include:
+
+- Real-time log streaming
+- Timestamps
+- Search and filter within logs
+- Download log files
+
+## Inspecting a Container
+
+The **Inspect** tab shows the container's full configuration in JSON, including network settings, mounts, and environment variables.

--- a/apps/landing/content/docs/en/guides/file-browser.mdx
+++ b/apps/landing/content/docs/en/guides/file-browser.mdx
@@ -1,0 +1,34 @@
+---
+title: File Browser
+description: Browse and manage files inside Docker containers
+---
+
+## Overview
+
+Dockerman's file browser lets you navigate the filesystem of any running container — browse directories, view files, and transfer files between the host and the container.
+
+## Browsing Files
+
+1. Open a running container
+2. Click the **Files** tab
+3. The file browser shows the container's root filesystem
+
+Click a directory to navigate into it. Breadcrumbs show the current path.
+
+## Viewing Files
+
+Click a file to view its contents. Dockerman previews:
+
+- Text files (logs, configs, scripts)
+- JSON and YAML files with syntax highlighting
+
+## Uploading Files
+
+1. Navigate to the target directory in the container
+2. Click **Upload**
+3. Select files from the host
+4. The files are copied to the container's current path
+
+## Downloading Files
+
+Right-click a file or directory and choose **Download** to save it to the host. Directories are downloaded as a tar archive.

--- a/apps/landing/content/docs/en/guides/images.mdx
+++ b/apps/landing/content/docs/en/guides/images.mdx
@@ -1,0 +1,45 @@
+---
+title: Image Management
+description: Pull, build, and manage Docker images
+---
+
+## Overview
+
+The Images page manages every Docker image on your system — pulling new images, building from a Dockerfile, and cleaning up unused images.
+
+## Image List
+
+Every local image shows:
+
+- Repository and tag
+- Image ID
+- Size
+- Created time
+
+## Pulling an Image
+
+1. Click **Pull** on the Images page
+2. Enter the image name and tag (for example, `nginx:latest`)
+3. Click **Pull** to start the download
+
+Pull progress streams in real time, including per-layer download status.
+
+## Building an Image
+
+1. Click **Build** on the Images page
+2. Choose a Dockerfile or the build context directory
+3. Set the image tag
+4. Click **Build** to start
+
+Build output streams live so you can monitor each step.
+
+## Managing Images
+
+- **Remove** — delete an image (fails if a container depends on it)
+- **Tag** — add a new tag to an existing image
+- **History** — view the layer history
+- **Inspect** — see full image metadata in JSON
+
+## Pruning
+
+Use **Prune** to remove every dangling (untagged) image and reclaim disk space.

--- a/apps/landing/content/docs/en/guides/meta.json
+++ b/apps/landing/content/docs/en/guides/meta.json
@@ -1,0 +1,14 @@
+{
+  "title": "Feature Guides",
+  "pages": [
+    "containers",
+    "images",
+    "networks",
+    "volumes",
+    "compose",
+    "monitoring",
+    "terminal",
+    "file-browser"
+  ],
+  "defaultOpen": true
+}

--- a/apps/landing/content/docs/en/guides/monitoring.mdx
+++ b/apps/landing/content/docs/en/guides/monitoring.mdx
@@ -1,0 +1,40 @@
+---
+title: Real-Time Monitoring
+description: Monitor container resource usage in real time
+---
+
+## Overview
+
+Dockerman provides real-time monitoring of container resource usage. Track CPU, memory, network I/O, and disk I/O across running containers.
+
+## Dashboard
+
+The monitoring dashboard shows an overview of your Docker environment:
+
+- Total containers (running / stopped)
+- System CPU and memory usage
+- Network throughput
+
+## Container Stats
+
+Click a running container to view live stats:
+
+- **CPU** — usage percentage with a live chart
+- **Memory** — current usage, limit, and percentage
+- **Network I/O** — bytes sent and received per second
+- **Disk I/O** — read and write operations per second
+
+Stats refresh automatically every few seconds.
+
+## Resource Alerts
+
+Dockerman highlights containers approaching their resource limits:
+
+- High CPU usage is shown in yellow / red
+- Memory usage close to the limit raises a warning
+
+## Monitoring Tips
+
+- Set resource limits when creating containers to prevent runaway usage
+- Review the monitoring dashboard regularly to catch performance issues
+- Container stats are only available while the container is running

--- a/apps/landing/content/docs/en/guides/networks.mdx
+++ b/apps/landing/content/docs/en/guides/networks.mdx
@@ -1,0 +1,45 @@
+---
+title: Network Management
+description: Create and manage Docker networks
+---
+
+## Overview
+
+Dockerman provides a visual interface for managing Docker networks. View existing networks, create new ones, and connect or disconnect containers.
+
+## Network List
+
+The Networks page lists every Docker network with:
+
+- Network name and ID
+- Driver type (bridge, host, overlay, …)
+- Scope (local, swarm)
+- Number of connected containers
+
+## Creating a Network
+
+1. Click **Create** on the Networks page
+2. Configure:
+   - Network name
+   - Driver (bridge is the most common)
+   - Subnet and gateway (optional)
+   - Enable IPv6 (optional)
+3. Click **Create**
+
+## Connecting Containers
+
+1. Click a network to open its detail view
+2. Use **Connect** to add a container to the network
+3. Use **Disconnect** to remove a container
+
+## Inspecting a Network
+
+The detail view shows the full network configuration, including:
+
+- IPAM settings
+- Connected containers with their IP addresses
+- Network options and labels
+
+## Removing a Network
+
+Click **Remove** to delete a network. The network must have no connected containers.

--- a/apps/landing/content/docs/en/guides/terminal.mdx
+++ b/apps/landing/content/docs/en/guides/terminal.mdx
@@ -1,0 +1,34 @@
+---
+title: Built-in Terminal
+description: Open a container shell directly from Dockerman
+---
+
+## Overview
+
+Dockerman includes a built-in terminal that opens a shell inside any running container without leaving the app.
+
+## Opening a Terminal
+
+1. Open a running container
+2. Click the **Terminal** tab or button
+3. A terminal session opens inside the container
+
+## Shell Selection
+
+Dockerman tries to detect an available shell:
+
+- `/bin/bash` — used by default when available
+- `/bin/sh` — fallback for minimal containers
+
+You can also specify a custom shell command when opening the terminal.
+
+## Terminal Features
+
+- Full interactive terminal with keyboard input
+- Copy and paste support
+- Scrollback buffer for reviewing earlier output
+- Multiple terminal sessions per container
+
+## Closing the Terminal
+
+Close the terminal tab to end the session. The terminal process inside the container is terminated on disconnect.

--- a/apps/landing/content/docs/en/guides/volumes.mdx
+++ b/apps/landing/content/docs/en/guides/volumes.mdx
@@ -1,0 +1,49 @@
+---
+title: Volume Management
+description: Create and manage Docker volumes for persistent storage
+---
+
+## Overview
+
+Docker volumes provide persistent storage for container data. Dockerman lets you create, inspect, and manage volumes through a visual interface.
+
+## Volume List
+
+The Volumes page lists every Docker volume with:
+
+- Volume name
+- Driver
+- Mount point
+- Created time
+
+## Creating a Volume
+
+1. Click **Create** on the Volumes page
+2. Enter a volume name
+3. Choose a driver (defaults to `local`)
+4. Add labels as needed
+5. Click **Create**
+
+## Using a Volume
+
+You can mount volumes when creating a container:
+
+1. In the container create form, go to the **Volumes** section
+2. Click **Add Mount**
+3. Pick a volume and set the mount path inside the container
+4. Choose read/write or read-only access
+
+## Inspecting a Volume
+
+Click a volume to view:
+
+- Full configuration in JSON
+- Host mount point
+- Labels and options
+- Containers currently using the volume
+
+## Removing a Volume
+
+Click **Remove** to delete a volume. The volume must not be in use by any container.
+
+Use **Prune** to remove every unused volume and reclaim disk space.

--- a/apps/landing/content/docs/en/platform/meta.json
+++ b/apps/landing/content/docs/en/platform/meta.json
@@ -3,7 +3,8 @@
   "pages": [
     "windows",
     "macos",
-    "linux"
+    "linux",
+    "wsl"
   ],
   "defaultOpen": true
 }

--- a/apps/landing/content/docs/en/platform/wsl.mdx
+++ b/apps/landing/content/docs/en/platform/wsl.mdx
@@ -1,0 +1,59 @@
+---
+title: Windows WSL
+description: Use Dockerman with Docker running under Windows WSL
+---
+
+## Overview
+
+Dockerman supports Docker running under Windows Subsystem for Linux (WSL 2). This guide covers setup and common configurations.
+
+## Prerequisites
+
+- Windows 10 build 2004+ or Windows 11
+- WSL 2 enabled
+- Docker Desktop installed (with the WSL 2 backend) **or** Docker Engine running directly inside WSL 2
+
+## With Docker Desktop
+
+If you use Docker Desktop's WSL 2 backend:
+
+1. Open Docker Desktop settings
+2. Go to **Resources > WSL Integration**
+3. Enable integration for the WSL distributions you use
+4. Install and launch Dockerman on Windows
+5. Dockerman connects to Docker automatically
+
+## With Docker Engine in WSL 2
+
+If you run Docker Engine directly inside WSL 2 (without Docker Desktop):
+
+1. Start Docker Engine inside your WSL 2 distribution
+2. Make sure the Docker socket is reachable at `/var/run/docker.sock`
+3. Launch Dockerman — it detects the Docker socket automatically
+
+## Troubleshooting
+
+### Docker socket not found
+
+Make sure Docker is running inside your WSL 2 distribution:
+
+```bash
+sudo service docker start
+```
+
+### Slow performance
+
+WSL 2 runs inside a virtual machine. For best performance:
+
+- Keep project files on the WSL 2 filesystem (not on a Windows drive)
+- Allocate enough memory to WSL 2 in `.wslconfig`
+
+### Connection refused
+
+Verify Docker is reachable:
+
+```bash
+docker info
+```
+
+If it fails, restart the Docker service or review your WSL 2 configuration.

--- a/apps/landing/content/docs/es/platform/meta.json
+++ b/apps/landing/content/docs/es/platform/meta.json
@@ -3,7 +3,8 @@
   "pages": [
     "windows",
     "macos",
-    "linux"
+    "linux",
+    "wsl"
   ],
   "defaultOpen": true
 }

--- a/apps/landing/content/docs/ja/platform/meta.json
+++ b/apps/landing/content/docs/ja/platform/meta.json
@@ -3,7 +3,8 @@
   "pages": [
     "windows",
     "macos",
-    "linux"
+    "linux",
+    "wsl"
   ],
   "defaultOpen": true
 }

--- a/apps/landing/content/docs/zh/platform/meta.json
+++ b/apps/landing/content/docs/zh/platform/meta.json
@@ -3,7 +3,8 @@
   "pages": [
     "windows",
     "macos",
-    "linux"
+    "linux",
+    "wsl"
   ],
   "defaultOpen": true
 }

--- a/apps/landing/instrumentation-client.ts
+++ b/apps/landing/instrumentation-client.ts
@@ -1,10 +1,26 @@
 import posthog from 'posthog-js'
 
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-  api_host: '/ingest',
-  ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  defaults: '2025-11-30',
-  capture_exceptions: true,
-  capture_performance: { web_vitals: true },
-  debug: process.env.NODE_ENV === 'development'
-})
+const initPostHog = () => {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    api_host: '/ingest',
+    ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    defaults: '2025-11-30',
+    capture_exceptions: true,
+    // Vercel Speed Insights already captures Core Web Vitals; avoid double instrumentation.
+    capture_performance: false,
+    debug: process.env.NODE_ENV === 'development'
+  })
+}
+
+// Defer until the browser is idle so PostHog doesn't compete with first paint
+// or block input responsiveness during initial hydration.
+if (typeof window !== 'undefined') {
+  const w = window as Window & {
+    requestIdleCallback?: (cb: () => void, opts?: { timeout?: number }) => number
+  }
+  if (typeof w.requestIdleCallback === 'function') {
+    w.requestIdleCallback(initPostHog, { timeout: 4000 })
+  } else {
+    setTimeout(initPostHog, 2000)
+  }
+}

--- a/apps/landing/middleware.ts
+++ b/apps/landing/middleware.ts
@@ -1,6 +1,14 @@
 import { cookieName, defaultLocale, type Locale, locales } from '@repo/shared/i18n'
 import { type NextRequest, NextResponse } from 'next/server'
 
+const BOT_UA_REGEX =
+  /bot|crawler|spider|crawling|googlebot|bingbot|yandex|duckduckbot|baiduspider|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot/i
+
+function isBot(request: NextRequest): boolean {
+  const ua = request.headers.get('user-agent') || ''
+  return BOT_UA_REGEX.test(ua)
+}
+
 function getLocaleFromHeaders(request: NextRequest): Locale {
   const acceptLanguage = request.headers.get('accept-language') || ''
   const lang = acceptLanguage.toLowerCase()
@@ -17,6 +25,11 @@ function getLocaleFromPath(pathname: string): Locale | null {
     return potentialLocale as Locale
   }
   return null
+}
+
+function withLocaleHeader(response: NextResponse, locale: Locale): NextResponse {
+  response.headers.set('x-locale', locale)
+  return response
 }
 
 export function middleware(request: NextRequest) {
@@ -37,7 +50,7 @@ export function middleware(request: NextRequest) {
   if (pathLocale) {
     const existing = request.cookies.get(cookieName)?.value
     if (existing === pathLocale) {
-      return NextResponse.next()
+      return withLocaleHeader(NextResponse.next(), pathLocale)
     }
 
     const response = NextResponse.next()
@@ -45,13 +58,20 @@ export function middleware(request: NextRequest) {
       path: '/',
       maxAge: 60 * 60 * 24 * 365 // 1 year
     })
-    return response
+    return withLocaleHeader(response, pathLocale)
   }
 
-  // Get locale from cookie or headers
-  const cookieLocale = request.cookies.get(cookieName)?.value as Locale | undefined
-  const locale =
-    cookieLocale && locales.includes(cookieLocale) ? cookieLocale : getLocaleFromHeaders(request)
+  // For bots/crawlers, always redirect to defaultLocale so every locale URL stays
+  // independently crawlable and we don't gate non-default languages behind
+  // Accept-Language detection (Googlebot is always en-US).
+  const locale = isBot(request)
+    ? defaultLocale
+    : (() => {
+        const cookieLocale = request.cookies.get(cookieName)?.value as Locale | undefined
+        return cookieLocale && locales.includes(cookieLocale)
+          ? cookieLocale
+          : getLocaleFromHeaders(request)
+      })()
 
   // Redirect to localized path
   const url = request.nextUrl.clone()
@@ -62,7 +82,7 @@ export function middleware(request: NextRequest) {
     path: '/',
     maxAge: 60 * 60 * 24 * 365 // 1 year
   })
-  return response
+  return withLocaleHeader(response, locale)
 }
 
 export const config = {

--- a/apps/landing/middleware.ts
+++ b/apps/landing/middleware.ts
@@ -1,8 +1,10 @@
 import { cookieName, defaultLocale, type Locale, locales } from '@repo/shared/i18n'
 import { type NextRequest, NextResponse } from 'next/server'
 
+// `bot` already covers googlebot/bingbot/duckduckbot/discordbot/etc., so we
+// only add the crawlers that don't carry "bot" in their UA.
 const BOT_UA_REGEX =
-  /bot|crawler|spider|crawling|googlebot|bingbot|yandex|duckduckbot|baiduspider|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot/i
+  /bot|crawler|spider|yandex|baiduspider|facebookexternalhit|whatsapp|applebot/i
 
 function isBot(request: NextRequest): boolean {
   const ua = request.headers.get('user-agent') || ''
@@ -27,11 +29,6 @@ function getLocaleFromPath(pathname: string): Locale | null {
   return null
 }
 
-function withLocaleHeader(response: NextResponse, locale: Locale): NextResponse {
-  response.headers.set('x-locale', locale)
-  return response
-}
-
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
@@ -50,7 +47,7 @@ export function middleware(request: NextRequest) {
   if (pathLocale) {
     const existing = request.cookies.get(cookieName)?.value
     if (existing === pathLocale) {
-      return withLocaleHeader(NextResponse.next(), pathLocale)
+      return NextResponse.next()
     }
 
     const response = NextResponse.next()
@@ -58,7 +55,7 @@ export function middleware(request: NextRequest) {
       path: '/',
       maxAge: 60 * 60 * 24 * 365 // 1 year
     })
-    return withLocaleHeader(response, pathLocale)
+    return response
   }
 
   // For bots/crawlers, always redirect to defaultLocale so every locale URL stays
@@ -82,7 +79,7 @@ export function middleware(request: NextRequest) {
     path: '/',
     maxAge: 60 * 60 * 24 * 365 // 1 year
   })
-  return withLocaleHeader(response, locale)
+  return response
 }
 
 export const config = {

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -31,7 +31,6 @@
     "fumadocs-core": "^16.6.7",
     "fumadocs-mdx": "^14.2.8",
     "fumadocs-ui": "^16.6.7",
-    "cobe": "^0.6.3",
     "motion": "^12.0.11",
     "next": "16.1.6",
     "next-themes": "^0.4.4",
@@ -39,7 +38,6 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-wrap-balancer": "^1.1.1",
-    "react-zoom-pan-pinch": "^3.7.0",
     "tailwind-variants": "^0.3.0",
     "tailwindcss": "^4.2.1"
   },

--- a/apps/landing/src/app/[locale]/(main)/about/layout.tsx
+++ b/apps/landing/src/app/[locale]/(main)/about/layout.tsx
@@ -1,3 +1,25 @@
+import type { Locale } from '@repo/shared/i18n'
+import type { Metadata } from 'next'
+import { siteConfig } from '@/app/siteConfig'
+import { buildAlternates } from '@/lib/seo'
+
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const title = 'About Dockerman'
+  const description =
+    'The story and philosophy behind Dockerman — a local-first desktop UI for Docker, Podman, and Kubernetes, built in Rust and Tauri.'
+  return {
+    title,
+    description,
+    alternates: buildAlternates(locale as Locale, '/about'),
+    openGraph: { title, description, url: `${siteConfig.url}/${locale}/about` }
+  }
+}
+
 export default function Layout({
   children
 }: Readonly<{

--- a/apps/landing/src/app/[locale]/(main)/changelog/layout.tsx
+++ b/apps/landing/src/app/[locale]/(main)/changelog/layout.tsx
@@ -1,3 +1,25 @@
+import type { Locale } from '@repo/shared/i18n'
+import type { Metadata } from 'next'
+import { siteConfig } from '@/app/siteConfig'
+import { buildAlternates } from '@/lib/seo'
+
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const title = 'Changelog — Dockerman releases'
+  const description =
+    'Release notes for Dockerman, the local-first Docker, Podman, and Kubernetes desktop UI. Track new features, fixes, and platform support.'
+  return {
+    title,
+    description,
+    alternates: buildAlternates(locale as Locale, '/changelog'),
+    openGraph: { title, description, url: `${siteConfig.url}/${locale}/changelog` }
+  }
+}
+
 export default function Layout({
   children
 }: Readonly<{

--- a/apps/landing/src/app/[locale]/(main)/changelog/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/changelog/page.tsx
@@ -1,7 +1,10 @@
 import { defaultLocale, type Locale, locales } from '@repo/shared/i18n'
 import { getTranslation } from '@repo/shared/i18n/server'
+import { siteConfig } from '@/app/siteConfig'
 import ChangelogPageContent from '@/components/changelog/ChangelogPageContent'
+import { JsonLd } from '@/components/seo/JsonLd'
 import { getChangelogEntries } from '@/lib/changelog'
+import { SITE_URL } from '@/lib/seo'
 
 function isLocale(value: string): value is Locale {
   return locales.includes(value as Locale)
@@ -12,15 +15,41 @@ export default async function ChangelogPage({ params }: { params: Promise<{ loca
   const locale = isLocale(routeLocale) ? routeLocale : defaultLocale
   const [{ t }, entries] = await Promise.all([getTranslation(locale), getChangelogEntries(locale)])
 
+  const changelogUrl = `${SITE_URL}/${locale}/changelog`
+  const itemListLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: t('changelog.title'),
+    description: t('changelog.description'),
+    url: changelogUrl,
+    itemListElement: entries.map((entry, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      item: {
+        '@type': 'SoftwareApplication',
+        name: `${siteConfig.name} ${entry.version}`,
+        applicationCategory: 'DeveloperApplication',
+        operatingSystem: 'macOS, Windows, Linux',
+        softwareVersion: entry.version,
+        datePublished: entry.date,
+        releaseNotes: entry.summary,
+        url: `${changelogUrl}#${entry.id}`
+      }
+    }))
+  }
+
   return (
-    <ChangelogPageContent
-      copy={{
-        badge: t('changelog.badge'),
-        description: t('changelog.description'),
-        title: t('changelog.title')
-      }}
-      entries={entries}
-      locale={locale}
-    />
+    <>
+      <JsonLd data={itemListLd} />
+      <ChangelogPageContent
+        copy={{
+          badge: t('changelog.badge'),
+          description: t('changelog.description'),
+          title: t('changelog.title')
+        }}
+        entries={entries}
+        locale={locale}
+      />
+    </>
   )
 }

--- a/apps/landing/src/app/[locale]/(main)/download/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/download/page.tsx
@@ -2,6 +2,7 @@ import type { Locale } from '@repo/shared/i18n'
 import { getTranslation } from '@repo/shared/i18n/server'
 import type { Metadata } from 'next'
 import { headers } from 'next/headers'
+import { siteConfig } from '@/app/siteConfig'
 import { DownloadHero } from '@/components/download/DownloadHero'
 import { HomebrewBlock } from '@/components/download/HomebrewBlock'
 import { IntegrityBar } from '@/components/download/IntegrityBar'
@@ -9,6 +10,7 @@ import { PlatformCard } from '@/components/download/PlatformCard'
 import { ReleasesTable } from '@/components/download/ReleasesTable'
 import { CtaFinal } from '@/components/landing/CtaFinal'
 import { downloadsConfig } from '@/config/downloads'
+import { buildAlternates } from '@/lib/seo'
 
 export async function generateMetadata({
   params
@@ -17,9 +19,14 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale } = await params
   const { t } = await getTranslation(locale as Locale)
+  const title = t('meta.download.title')
+  const description = t('meta.download.description')
   return {
-    title: t('meta.download.title'),
-    description: t('meta.download.description')
+    title,
+    description,
+    alternates: buildAlternates(locale as Locale, '/download'),
+    openGraph: { title, description, url: `${siteConfig.url}/${locale}/download` },
+    twitter: { title, description }
   }
 }
 

--- a/apps/landing/src/app/[locale]/(main)/dpa/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/dpa/page.tsx
@@ -9,6 +9,7 @@ import {
   PolicySection,
   PolicySubheading
 } from '@/components/policy/PolicyShell'
+import { buildAlternates } from '@/lib/seo'
 
 export async function generateMetadata({
   params
@@ -19,7 +20,8 @@ export async function generateMetadata({
   const { t } = await getTranslation(locale as Locale)
   return {
     title: t('dpa.title'),
-    description: t('dpa.description')
+    description: t('dpa.description'),
+    alternates: buildAlternates(locale as Locale, '/dpa')
   }
 }
 

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -8,6 +8,7 @@ import { Hero } from '@/components/landing/Hero'
 import { LiveDashboard } from '@/components/landing/LiveDashboard'
 import { ModulesSection } from '@/components/landing/ModulesSection'
 import { RuntimeStrip } from '@/components/landing/RuntimeStrip'
+import { JsonLd } from '@/components/seo/JsonLd'
 import { buildAlternates } from '@/lib/seo'
 
 export async function generateMetadata({
@@ -31,8 +32,49 @@ export async function generateMetadata({
 export default async function LandingPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params
   const l = locale as Locale
+  const { t } = await getTranslation(l)
+  const description = t('meta.home.description')
+
+  const organizationLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: siteConfig.name,
+    url: siteConfig.url,
+    logo: `${siteConfig.url}/opengraph-image.png`,
+    sameAs: ['https://github.com/ZingerLittleBee', 'https://twitter.com/zinger_bee']
+  }
+
+  const websiteLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: siteConfig.name,
+    url: `${siteConfig.url}/${l}`,
+    description,
+    inLanguage: l,
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: `${siteConfig.url}/${l}/docs?q={search_term_string}`,
+      'query-input': 'required name=search_term_string'
+    }
+  }
+
+  const softwareLd = {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: siteConfig.name,
+    description,
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'macOS, Windows, Linux',
+    softwareVersion: siteConfig.latestVersion,
+    url: `${siteConfig.url}/${l}`,
+    downloadUrl: `${siteConfig.url}/${l}/download`,
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+    author: { '@type': 'Person', name: 'ZingerBee', url: 'https://github.com/ZingerLittleBee' }
+  }
+
   return (
     <main>
+      <JsonLd data={[organizationLd, websiteLd, softwareLd]} />
       <Hero locale={l} />
       <div className="relative hidden px-5 md:block md:px-8">
         <LiveDashboard locale={l} />

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -9,7 +9,7 @@ import { LiveDashboard } from '@/components/landing/LiveDashboard'
 import { ModulesSection } from '@/components/landing/ModulesSection'
 import { RuntimeStrip } from '@/components/landing/RuntimeStrip'
 import { JsonLd } from '@/components/seo/JsonLd'
-import { buildAlternates } from '@/lib/seo'
+import { buildAlternates, SITE_URL } from '@/lib/seo'
 
 export async function generateMetadata({
   params
@@ -24,7 +24,7 @@ export async function generateMetadata({
     title,
     description,
     alternates: buildAlternates(locale as Locale),
-    openGraph: { title, description, url: `${siteConfig.url}/${locale}` },
+    openGraph: { title, description, url: `${SITE_URL}/${locale}` },
     twitter: { title, description }
   }
 }
@@ -39,8 +39,8 @@ export default async function LandingPage({ params }: { params: Promise<{ locale
     '@context': 'https://schema.org',
     '@type': 'Organization',
     name: siteConfig.name,
-    url: siteConfig.url,
-    logo: `${siteConfig.url}/opengraph-image.png`,
+    url: SITE_URL,
+    logo: `${SITE_URL}/opengraph-image.png`,
     sameAs: ['https://github.com/ZingerLittleBee', 'https://twitter.com/zinger_bee']
   }
 
@@ -48,12 +48,12 @@ export default async function LandingPage({ params }: { params: Promise<{ locale
     '@context': 'https://schema.org',
     '@type': 'WebSite',
     name: siteConfig.name,
-    url: `${siteConfig.url}/${l}`,
+    url: `${SITE_URL}/${l}`,
     description,
     inLanguage: l,
     potentialAction: {
       '@type': 'SearchAction',
-      target: `${siteConfig.url}/${l}/docs?q={search_term_string}`,
+      target: `${SITE_URL}/${l}/docs?q={search_term_string}`,
       'query-input': 'required name=search_term_string'
     }
   }
@@ -66,8 +66,8 @@ export default async function LandingPage({ params }: { params: Promise<{ locale
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'macOS, Windows, Linux',
     softwareVersion: siteConfig.latestVersion,
-    url: `${siteConfig.url}/${l}`,
-    downloadUrl: `${siteConfig.url}/${l}/download`,
+    url: `${SITE_URL}/${l}`,
+    downloadUrl: `${SITE_URL}/${l}/download`,
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
     author: { '@type': 'Person', name: 'ZingerBee', url: 'https://github.com/ZingerLittleBee' }
   }

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -1,12 +1,14 @@
 import type { Locale } from '@repo/shared/i18n'
 import { getTranslation } from '@repo/shared/i18n/server'
 import type { Metadata } from 'next'
+import { siteConfig } from '@/app/siteConfig'
 import { CtaFinal } from '@/components/landing/CtaFinal'
 import { FeaturesGrid } from '@/components/landing/FeaturesGrid'
 import { Hero } from '@/components/landing/Hero'
 import { LiveDashboard } from '@/components/landing/LiveDashboard'
 import { ModulesSection } from '@/components/landing/ModulesSection'
 import { RuntimeStrip } from '@/components/landing/RuntimeStrip'
+import { buildAlternates } from '@/lib/seo'
 
 export async function generateMetadata({
   params
@@ -15,9 +17,14 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale } = await params
   const { t } = await getTranslation(locale as Locale)
+  const title = t('meta.home.title')
+  const description = t('meta.home.description')
   return {
-    title: t('meta.home.title'),
-    description: t('meta.home.description')
+    title,
+    description,
+    alternates: buildAlternates(locale as Locale),
+    openGraph: { title, description, url: `${siteConfig.url}/${locale}` },
+    twitter: { title, description }
   }
 }
 

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -232,7 +232,7 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
                   'radial-gradient(ellipse at 50% 0%, color-mix(in srgb, var(--color-dm-accent-2) 10%, transparent), transparent 55%)'
               }}
             />
-            <h3 className="relative m-0 font-bold text-[clamp(28px,3.6vw,40px)] text-dm-ink leading-[1.1] tracking-[-0.03em]">
+            <h2 className="relative m-0 font-bold text-[clamp(28px,3.6vw,40px)] text-dm-ink leading-[1.1] tracking-[-0.03em]">
               {t('pricing.finalCta.titleLead')}{' '}
               <em
                 className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
@@ -242,7 +242,7 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
               >
                 {t('pricing.finalCta.titleAccent')}
               </em>
-            </h3>
+            </h2>
             <p className="relative mx-auto mt-4 max-w-[52ch] text-[15px] text-dm-ink-3">
               {t('pricing.finalCta.description')}
             </p>

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -1,6 +1,7 @@
 import type { Locale } from '@repo/shared/i18n'
 import { getTranslation } from '@repo/shared/i18n/server'
 import type { Metadata } from 'next'
+import { siteConfig } from '@/app/siteConfig'
 import { ComparisonTable } from '@/components/pricing/ComparisonTable'
 import { Countdown } from '@/components/pricing/Countdown'
 import { PlanCard } from '@/components/pricing/PlanCard'
@@ -8,6 +9,7 @@ import { PricingFaq } from '@/components/pricing/PricingFaq'
 import { PricingHero } from '@/components/pricing/PricingHero'
 import { TrustBar } from '@/components/pricing/TrustBar'
 import { pricingConfig } from '@/config/pricing'
+import { buildAlternates } from '@/lib/seo'
 
 export async function generateMetadata({
   params
@@ -16,9 +18,14 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale } = await params
   const { t } = await getTranslation(locale as Locale)
+  const title = t('meta.pricing.title')
+  const description = t('meta.pricing.description')
   return {
-    title: t('meta.pricing.title'),
-    description: t('meta.pricing.description')
+    title,
+    description,
+    alternates: buildAlternates(locale as Locale, '/pricing'),
+    openGraph: { title, description, url: `${siteConfig.url}/${locale}/pricing` },
+    twitter: { title, description }
   }
 }
 

--- a/apps/landing/src/app/[locale]/(main)/privacy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/privacy/page.tsx
@@ -9,6 +9,7 @@ import {
   PolicySection,
   PolicySubheading
 } from '@/components/policy/PolicyShell'
+import { buildAlternates } from '@/lib/seo'
 
 export async function generateMetadata({
   params
@@ -19,7 +20,8 @@ export async function generateMetadata({
   const { t } = await getTranslation(locale as Locale)
   return {
     title: t('privacy.title'),
-    description: t('privacy.description')
+    description: t('privacy.description'),
+    alternates: buildAlternates(locale as Locale, '/privacy')
   }
 }
 

--- a/apps/landing/src/app/[locale]/(main)/snapshot/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/snapshot/page.tsx
@@ -1,10 +1,12 @@
 import type { Locale } from '@repo/shared/i18n'
 import { getTranslation } from '@repo/shared/i18n/server'
 import type { Metadata } from 'next'
+import { siteConfig } from '@/app/siteConfig'
 import { SnapshotFeaturesStrip } from '@/components/snapshot/SnapshotFeaturesStrip'
 import { SnapshotHero } from '@/components/snapshot/SnapshotHero'
 import { SnapshotShowcase } from '@/components/snapshot/SnapshotShowcase'
 import { resolveSnapshotModules } from '@/config/snapshot'
+import { buildAlternates } from '@/lib/seo'
 
 export async function generateMetadata({
   params
@@ -13,9 +15,14 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale } = await params
   const { t } = await getTranslation(locale as Locale)
+  const title = t('meta.snapshot.title')
+  const description = t('meta.snapshot.description')
   return {
-    title: t('meta.snapshot.title'),
-    description: t('meta.snapshot.description')
+    title,
+    description,
+    alternates: buildAlternates(locale as Locale, '/snapshot'),
+    openGraph: { title, description, url: `${siteConfig.url}/${locale}/snapshot` },
+    twitter: { title, description }
   }
 }
 

--- a/apps/landing/src/app/[locale]/(main)/terms/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/terms/page.tsx
@@ -8,6 +8,7 @@ import {
   PolicyList,
   PolicySection
 } from '@/components/policy/PolicyShell'
+import { buildAlternates } from '@/lib/seo'
 
 export async function generateMetadata({
   params
@@ -18,7 +19,8 @@ export async function generateMetadata({
   const { t } = await getTranslation(locale as Locale)
   return {
     title: t('terms.title'),
-    description: t('terms.description')
+    description: t('terms.description'),
+    alternates: buildAlternates(locale as Locale, '/terms')
   }
 }
 

--- a/apps/landing/src/app/[locale]/docs/[[...slug]]/page.tsx
+++ b/apps/landing/src/app/[locale]/docs/[[...slug]]/page.tsx
@@ -96,11 +96,8 @@ export async function generateMetadata({
   const path = buildDocPath(slug)
   const title = page.data.title
   const description = page.data.description
-  const ogParams = new URLSearchParams({
-    title: title ?? 'Dockerman Docs',
-    locale
-  })
-  if (description) ogParams.set('description', description)
+  const ogParams = new URLSearchParams({ locale })
+  if (slug && slug.length > 0) ogParams.set('slug', slug.join('/'))
   const ogImage = `${siteConfig.url}/api/og/docs?${ogParams.toString()}`
 
   return {

--- a/apps/landing/src/app/[locale]/docs/[[...slug]]/page.tsx
+++ b/apps/landing/src/app/[locale]/docs/[[...slug]]/page.tsx
@@ -96,6 +96,12 @@ export async function generateMetadata({
   const path = buildDocPath(slug)
   const title = page.data.title
   const description = page.data.description
+  const ogParams = new URLSearchParams({
+    title: title ?? 'Dockerman Docs',
+    locale
+  })
+  if (description) ogParams.set('description', description)
+  const ogImage = `${siteConfig.url}/api/og/docs?${ogParams.toString()}`
 
   return {
     title,
@@ -105,8 +111,9 @@ export async function generateMetadata({
       title,
       description,
       url: `${siteConfig.url}/${locale}${path}`,
-      type: 'article'
+      type: 'article',
+      images: [{ url: ogImage, width: 1200, height: 630, alt: title ?? 'Dockerman Docs' }]
     },
-    twitter: { title, description }
+    twitter: { title, description, images: [ogImage] }
   }
 }

--- a/apps/landing/src/app/[locale]/docs/[[...slug]]/page.tsx
+++ b/apps/landing/src/app/[locale]/docs/[[...slug]]/page.tsx
@@ -4,12 +4,41 @@ import { createRelativeLink } from 'fumadocs-ui/mdx'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { siteConfig } from '@/app/siteConfig'
+import { JsonLd } from '@/components/seo/JsonLd'
 import { buildAlternates } from '@/lib/seo'
 import { source } from '@/lib/source'
 import { getMDXComponents } from '../../../../../mdx-components'
 
 function buildDocPath(slug?: string[]): string {
   return slug && slug.length > 0 ? `/docs/${slug.join('/')}` : '/docs'
+}
+
+function buildBreadcrumb(locale: string, slug: string[] | undefined, title: string | undefined) {
+  const items: { '@type': 'ListItem'; position: number; name: string; item: string }[] = [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Docs',
+      item: `${siteConfig.url}/${locale}/docs`
+    }
+  ]
+  if (slug && slug.length > 0) {
+    slug.forEach((segment, index) => {
+      const isLast = index === slug.length - 1
+      const segName = segment.replace(/-/g, ' ')
+      items.push({
+        '@type': 'ListItem',
+        position: index + 2,
+        name: isLast ? (title ?? segName) : segName,
+        item: `${siteConfig.url}/${locale}/docs/${slug.slice(0, index + 1).join('/')}`
+      })
+    })
+  }
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items
+  }
 }
 
 export default async function Page({
@@ -22,9 +51,22 @@ export default async function Page({
   if (!page) notFound()
 
   const MDX = page.data.body
+  const path = buildDocPath(slug)
+
+  const articleLd = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: page.data.title,
+    description: page.data.description,
+    inLanguage: locale,
+    url: `${siteConfig.url}/${locale}${path}`,
+    isPartOf: { '@type': 'WebSite', name: siteConfig.name, url: siteConfig.url },
+    author: { '@type': 'Person', name: 'ZingerBee', url: 'https://github.com/ZingerLittleBee' }
+  }
 
   return (
     <DocsPage full={page.data.full} toc={page.data.toc}>
+      <JsonLd data={[articleLd, buildBreadcrumb(locale, slug, page.data.title)]} />
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>

--- a/apps/landing/src/app/[locale]/docs/[[...slug]]/page.tsx
+++ b/apps/landing/src/app/[locale]/docs/[[...slug]]/page.tsx
@@ -1,9 +1,16 @@
+import type { Locale } from '@repo/shared/i18n'
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/layouts/docs/page'
 import { createRelativeLink } from 'fumadocs-ui/mdx'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
+import { siteConfig } from '@/app/siteConfig'
+import { buildAlternates } from '@/lib/seo'
 import { source } from '@/lib/source'
 import { getMDXComponents } from '../../../../../mdx-components'
+
+function buildDocPath(slug?: string[]): string {
+  return slug && slug.length > 0 ? `/docs/${slug.join('/')}` : '/docs'
+}
 
 export default async function Page({
   params
@@ -44,8 +51,20 @@ export async function generateMetadata({
   const page = source.getPage(slug, locale)
   if (!page) notFound()
 
+  const path = buildDocPath(slug)
+  const title = page.data.title
+  const description = page.data.description
+
   return {
-    title: page.data.title,
-    description: page.data.description
+    title,
+    description,
+    alternates: buildAlternates(locale as Locale, path),
+    openGraph: {
+      title,
+      description,
+      url: `${siteConfig.url}/${locale}${path}`,
+      type: 'article'
+    },
+    twitter: { title, description }
   }
 }

--- a/apps/landing/src/app/[locale]/docs/[[...slug]]/page.tsx
+++ b/apps/landing/src/app/[locale]/docs/[[...slug]]/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { siteConfig } from '@/app/siteConfig'
 import { JsonLd } from '@/components/seo/JsonLd'
-import { buildAlternates } from '@/lib/seo'
+import { buildAlternates, SITE_URL } from '@/lib/seo'
 import { source } from '@/lib/source'
 import { getMDXComponents } from '../../../../../mdx-components'
 
@@ -19,7 +19,7 @@ function buildBreadcrumb(locale: string, slug: string[] | undefined, title: stri
       '@type': 'ListItem',
       position: 1,
       name: 'Docs',
-      item: `${siteConfig.url}/${locale}/docs`
+      item: `${SITE_URL}/${locale}/docs`
     }
   ]
   if (slug && slug.length > 0) {
@@ -30,7 +30,7 @@ function buildBreadcrumb(locale: string, slug: string[] | undefined, title: stri
         '@type': 'ListItem',
         position: index + 2,
         name: isLast ? (title ?? segName) : segName,
-        item: `${siteConfig.url}/${locale}/docs/${slug.slice(0, index + 1).join('/')}`
+        item: `${SITE_URL}/${locale}/docs/${slug.slice(0, index + 1).join('/')}`
       })
     })
   }
@@ -52,21 +52,34 @@ export default async function Page({
 
   const MDX = page.data.body
   const path = buildDocPath(slug)
+  const isDocsRoot = !slug || slug.length === 0
 
-  const articleLd = {
-    '@context': 'https://schema.org',
-    '@type': 'TechArticle',
-    headline: page.data.title,
-    description: page.data.description,
-    inLanguage: locale,
-    url: `${siteConfig.url}/${locale}${path}`,
-    isPartOf: { '@type': 'WebSite', name: siteConfig.name, url: siteConfig.url },
-    author: { '@type': 'Person', name: 'ZingerBee', url: 'https://github.com/ZingerLittleBee' }
-  }
+  // The docs landing page is a hub, not an article — model it as a
+  // CollectionPage so it isn't misreported as a single TechArticle.
+  const primaryLd = isDocsRoot
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: page.data.title,
+        description: page.data.description,
+        inLanguage: locale,
+        url: `${SITE_URL}/${locale}${path}`,
+        isPartOf: { '@type': 'WebSite', name: siteConfig.name, url: SITE_URL }
+      }
+    : {
+        '@context': 'https://schema.org',
+        '@type': 'TechArticle',
+        headline: page.data.title,
+        description: page.data.description,
+        inLanguage: locale,
+        url: `${SITE_URL}/${locale}${path}`,
+        isPartOf: { '@type': 'WebSite', name: siteConfig.name, url: SITE_URL },
+        author: { '@type': 'Person', name: 'ZingerBee', url: 'https://github.com/ZingerLittleBee' }
+      }
 
   return (
     <DocsPage full={page.data.full} toc={page.data.toc}>
-      <JsonLd data={[articleLd, buildBreadcrumb(locale, slug, page.data.title)]} />
+      <JsonLd data={[primaryLd, buildBreadcrumb(locale, slug, page.data.title)]} />
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>
@@ -98,7 +111,7 @@ export async function generateMetadata({
   const description = page.data.description
   const ogParams = new URLSearchParams({ locale })
   if (slug && slug.length > 0) ogParams.set('slug', slug.join('/'))
-  const ogImage = `${siteConfig.url}/api/og/docs?${ogParams.toString()}`
+  const ogImage = `${SITE_URL}/api/og/docs?${ogParams.toString()}`
 
   return {
     title,
@@ -107,7 +120,7 @@ export async function generateMetadata({
     openGraph: {
       title,
       description,
-      url: `${siteConfig.url}/${locale}${path}`,
+      url: `${SITE_URL}/${locale}${path}`,
       type: 'article',
       images: [{ url: ogImage, width: 1200, height: 630, alt: title ?? 'Dockerman Docs' }]
     },

--- a/apps/landing/src/app/[locale]/layout.tsx
+++ b/apps/landing/src/app/[locale]/layout.tsx
@@ -2,31 +2,31 @@ import { AnalyticsTracker } from '@repo/shared/components/AnalyticsTracker'
 import { I18nProvider } from '@repo/shared/components/I18nProvider'
 import { type Locale, locales } from '@repo/shared/i18n'
 import { RootProvider } from 'fumadocs-ui/provider/next'
-import { Geist_Mono, Instrument_Serif, Inter } from 'next/font/google'
+import { Geist_Mono, Instrument_Serif } from 'next/font/google'
 import { siteConfig } from '@/app/siteConfig'
 import { provider } from '@/lib/i18n/fumadocs-ui'
 import { buildAlternates } from '@/lib/seo'
 
-const inter = Inter({
-  subsets: ['latin'],
-  variable: '--font-inter',
-  display: 'swap',
-  weight: ['400', '500', '600', '700', '800']
-})
-
+// Geist_Mono is only used in code blocks and small UI labels (not above-the-fold
+// critical), so skip preload to free up the initial network budget for Inter +
+// Instrument_Serif (both used in the Hero H1).
 const geistMono = Geist_Mono({
   subsets: ['latin'],
   variable: '--font-geist-mono',
   display: 'swap',
-  weight: ['400', '500', '600', '700']
+  weight: ['400', '500', '600', '700'],
+  preload: false,
+  fallback: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace']
 })
 
+// Every usage is `<Accent>` italic in headlines — drop the normal style file.
 const instrumentSerif = Instrument_Serif({
   subsets: ['latin'],
   variable: '--font-instrument-serif',
   display: 'swap',
   weight: '400',
-  style: ['italic', 'normal']
+  style: 'italic',
+  fallback: ['ui-serif', 'Georgia', 'serif']
 })
 
 export async function generateStaticParams() {
@@ -88,9 +88,7 @@ export default async function LocaleLayout({
       theme={{ defaultTheme: 'dark', enableSystem: false, attribute: 'class' }}
     >
       <I18nProvider locale={locale}>
-        <div
-          className={`${inter.variable} ${geistMono.variable} ${instrumentSerif.variable} contents`}
-        >
+        <div className={`${geistMono.variable} ${instrumentSerif.variable} contents`}>
           <AnalyticsTracker />
           {children}
         </div>

--- a/apps/landing/src/app/[locale]/layout.tsx
+++ b/apps/landing/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { RootProvider } from 'fumadocs-ui/provider/next'
 import { Geist_Mono, Instrument_Serif, Inter } from 'next/font/google'
 import { siteConfig } from '@/app/siteConfig'
 import { provider } from '@/lib/i18n/fumadocs-ui'
+import { buildAlternates } from '@/lib/seo'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -57,11 +58,16 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     es: 'es_ES'
   }
 
+  const alternateLocales = locales.filter((l) => l !== locale).map((l) => localeMap[l])
+
   return {
     title: titles[locale],
     description: descriptions[locale],
+    alternates: buildAlternates(locale),
     openGraph: {
-      locale: localeMap[locale]
+      locale: localeMap[locale],
+      alternateLocale: alternateLocales,
+      url: `${siteConfig.url}/${locale}`
     }
   }
 }

--- a/apps/landing/src/app/api/og/docs/route.tsx
+++ b/apps/landing/src/app/api/og/docs/route.tsx
@@ -1,13 +1,33 @@
+import { locales } from '@repo/shared/i18n'
 import { ImageResponse } from 'next/og'
-import type { NextRequest } from 'next/server'
+import { type NextRequest, NextResponse } from 'next/server'
+import { source } from '@/lib/source'
 
-export const dynamic = 'force-static'
+// Cached for a day at the CDN. Not force-static: that would freeze the route
+// at build time with no search params, so every doc would share one image.
+export const revalidate = 86400
 
+// Resolve title/description from the docs source by slug instead of trusting
+// query params. Unknown slugs 404, so the cache surface is bounded to the
+// real set of doc pages and attacker-controlled text can't be baked in.
 export function GET(request: NextRequest) {
   const url = new URL(request.url)
-  const title = url.searchParams.get('title') ?? 'Dockerman Docs'
-  const description = url.searchParams.get('description') ?? ''
-  const locale = (url.searchParams.get('locale') ?? 'en').toUpperCase()
+  const localeParam = url.searchParams.get('locale') ?? 'en'
+  const slugParam = url.searchParams.get('slug') ?? ''
+
+  if (!(locales as readonly string[]).includes(localeParam)) {
+    return new NextResponse('Invalid locale', { status: 400 })
+  }
+
+  const slug = slugParam ? slugParam.split('/').filter(Boolean) : undefined
+  const page = source.getPage(slug, localeParam)
+  if (!page) {
+    return new NextResponse('Not found', { status: 404 })
+  }
+
+  const title = page.data.title ?? 'Dockerman Docs'
+  const description = page.data.description ?? ''
+  const locale = localeParam.toUpperCase()
 
   return new ImageResponse(
     <div

--- a/apps/landing/src/app/api/og/docs/route.tsx
+++ b/apps/landing/src/app/api/og/docs/route.tsx
@@ -1,0 +1,82 @@
+import { ImageResponse } from 'next/og'
+import type { NextRequest } from 'next/server'
+
+export const dynamic = 'force-static'
+
+export function GET(request: NextRequest) {
+  const url = new URL(request.url)
+  const title = url.searchParams.get('title') ?? 'Dockerman Docs'
+  const description = url.searchParams.get('description') ?? ''
+  const locale = (url.searchParams.get('locale') ?? 'en').toUpperCase()
+
+  return new ImageResponse(
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '80px',
+        backgroundColor: '#0a0a0a',
+        backgroundImage:
+          'radial-gradient(ellipse at top left, rgba(99, 102, 241, 0.25), transparent 55%), radial-gradient(ellipse at bottom right, rgba(139, 92, 246, 0.2), transparent 60%)',
+        color: 'white',
+        fontFamily: 'sans-serif'
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+        <div
+          style={{
+            width: 44,
+            height: 44,
+            borderRadius: 10,
+            background: 'linear-gradient(135deg, #6366f1, #8b5cf6)'
+          }}
+        />
+        <div style={{ fontSize: 28, fontWeight: 600, letterSpacing: '-0.02em' }}>
+          Dockerman Docs
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+        <div
+          style={{
+            fontSize: 72,
+            fontWeight: 700,
+            lineHeight: 1.05,
+            letterSpacing: '-0.04em',
+            maxWidth: 1040
+          }}
+        >
+          {title}
+        </div>
+        {description ? (
+          <div
+            style={{
+              fontSize: 28,
+              color: 'rgba(255,255,255,0.7)',
+              lineHeight: 1.35,
+              maxWidth: 980
+            }}
+          >
+            {description.length > 160 ? `${description.slice(0, 157)}…` : description}
+          </div>
+        ) : null}
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          fontSize: 22,
+          color: 'rgba(255,255,255,0.55)'
+        }}
+      >
+        <div>dockerman.app</div>
+        <div>{locale}</div>
+      </div>
+    </div>,
+    { width: 1200, height: 630 }
+  )
+}

--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -1,7 +1,9 @@
+import { defaultLocale, type Locale, locales } from '@repo/shared/i18n'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import { headers } from 'next/headers'
 import Script from 'next/script'
 import './globals.css'
 import AgentationClient from '@/components/AgentationClient'
@@ -15,30 +17,30 @@ const inter = Inter({
 })
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://dockerman.app'),
-  title: 'Dockerman - Modern Docker Management UI',
+  metadataBase: new URL(siteConfig.url),
+  title: {
+    default: siteConfig.title,
+    template: '%s — Dockerman'
+  },
   description: siteConfig.description,
   keywords: [
-    'Docker',
-    'UI',
-    'Management',
+    'Docker GUI',
+    'Docker Desktop alternative',
+    'Docker management',
+    'Kubernetes UI',
+    'Kubernetes GUI',
+    'Podman desktop',
+    'container manager',
+    'docker compose UI',
+    'remote docker host',
+    'docker over SSH',
+    'WSL2 docker',
+    'k3d GUI',
+    'Helm GUI',
+    'Trivy scan UI',
+    'homelab docker manager',
     'Tauri',
-    'Rust',
-    'Desktop',
-    'App',
-    'Container',
-    'Image',
-    'Monitoring',
-    'Terminal',
-    'Dashboard',
-    'Cross-platform',
-    'Resource Usage',
-    'Logs',
-    'Process',
-    'Statistics',
-    'Docker Management',
-    'Container Management',
-    'DevOps'
+    'Rust desktop app'
   ],
   authors: [
     {
@@ -47,9 +49,10 @@ export const metadata: Metadata = {
     }
   ],
   creator: 'ZingerBee',
+  applicationName: siteConfig.name,
+  category: 'developer tools',
   openGraph: {
     type: 'website',
-    locale: 'en_US',
     url: siteConfig.url,
     title: siteConfig.title,
     description: siteConfig.description,
@@ -59,7 +62,7 @@ export const metadata: Metadata = {
         url: '/opengraph-image.png',
         width: 1200,
         height: 630,
-        alt: 'Dockerman - Modern Docker Management UI'
+        alt: 'Dockerman — local-first Docker, Podman & Kubernetes UI'
       }
     ]
   },
@@ -67,21 +70,40 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: siteConfig.title,
     description: siteConfig.description,
+    site: '@zinger_bee',
     creator: '@zinger_bee',
     images: ['/opengraph-image.png']
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1
+    }
   },
   icons: {
     icon: '/favicon.ico'
   }
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const headerList = await headers()
+  const headerLocale = headerList.get('x-locale')
+  const lang: Locale =
+    headerLocale && (locales as readonly string[]).includes(headerLocale)
+      ? (headerLocale as Locale)
+      : defaultLocale
+
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang={lang} suppressHydrationWarning>
       <head>
         <ThemeScript />
         {process.env.NODE_ENV === 'development' && (

--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -13,7 +13,9 @@ import { siteConfig } from './siteConfig'
 const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
-  variable: '--font-inter'
+  variable: '--font-inter',
+  preload: true,
+  fallback: ['system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Arial', 'sans-serif']
 })
 
 export const metadata: Metadata = {

--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -1,12 +1,12 @@
-import { defaultLocale, type Locale, locales } from '@repo/shared/i18n'
+import { defaultLocale } from '@repo/shared/i18n'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
-import { headers } from 'next/headers'
 import Script from 'next/script'
 import './globals.css'
 import AgentationClient from '@/components/AgentationClient'
+import { LangScript } from '@/components/shell/LangScript'
 import { ThemeScript } from '@/components/shell/ThemeScript'
 import { siteConfig } from './siteConfig'
 
@@ -92,22 +92,16 @@ export const metadata: Metadata = {
   }
 }
 
-export default async function RootLayout({
+export default function RootLayout({
   children
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const headerList = await headers()
-  const headerLocale = headerList.get('x-locale')
-  const lang: Locale =
-    headerLocale && (locales as readonly string[]).includes(headerLocale)
-      ? (headerLocale as Locale)
-      : defaultLocale
-
   return (
-    <html lang={lang} suppressHydrationWarning>
+    <html lang={defaultLocale} suppressHydrationWarning>
       <head>
         <ThemeScript />
+        <LangScript />
         {process.env.NODE_ENV === 'development' && (
           <Script
             crossOrigin="anonymous"

--- a/apps/landing/src/app/robots.ts
+++ b/apps/landing/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from 'next'
+import { siteConfig } from './siteConfig'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/_next/']
+      }
+    ],
+    sitemap: `${siteConfig.url}/sitemap.xml`,
+    host: siteConfig.url
+  }
+}

--- a/apps/landing/src/app/sitemap.ts
+++ b/apps/landing/src/app/sitemap.ts
@@ -1,0 +1,51 @@
+import { locales } from '@repo/shared/i18n'
+import type { MetadataRoute } from 'next'
+import { source } from '@/lib/source'
+import { siteConfig } from './siteConfig'
+
+const SITE_URL = siteConfig.url
+
+const STATIC_ROUTES = ['', '/about', '/changelog', '/download', '/pricing', '/imprint', '/privacy', '/terms']
+
+function buildLanguageAlternates(path: string): Record<string, string> {
+  const languages: Record<string, string> = {}
+  for (const locale of locales) {
+    languages[locale] = `${SITE_URL}/${locale}${path}`
+  }
+  languages['x-default'] = `${SITE_URL}/en${path}`
+  return languages
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date()
+  const entries: MetadataRoute.Sitemap = []
+
+  for (const route of STATIC_ROUTES) {
+    for (const locale of locales) {
+      entries.push({
+        url: `${SITE_URL}/${locale}${route}`,
+        lastModified: now,
+        changeFrequency: route === '' ? 'weekly' : 'monthly',
+        priority: route === '' ? 1.0 : 0.7,
+        alternates: { languages: buildLanguageAlternates(route) }
+      })
+    }
+  }
+
+  for (const locale of locales) {
+    const pages = source.getPages(locale)
+    for (const page of pages) {
+      const slugPath = page.slugs.length > 0 ? `/${page.slugs.join('/')}` : ''
+      const path = `/docs${slugPath}`
+      entries.push({
+        url: `${SITE_URL}/${locale}${path}`,
+        lastModified: now,
+        changeFrequency: 'weekly',
+        priority: 0.6,
+        alternates: { languages: buildLanguageAlternates(path) }
+      })
+    }
+  }
+
+  return entries
+}

--- a/apps/landing/src/app/sitemap.ts
+++ b/apps/landing/src/app/sitemap.ts
@@ -1,18 +1,26 @@
-import { locales } from '@repo/shared/i18n'
+import { defaultLocale, locales } from '@repo/shared/i18n'
 import type { MetadataRoute } from 'next'
+import { SITE_URL } from '@/lib/seo'
 import { source } from '@/lib/source'
-import { siteConfig } from './siteConfig'
 
-const SITE_URL = siteConfig.url
-
-const STATIC_ROUTES = ['', '/about', '/changelog', '/download', '/pricing', '/imprint', '/privacy', '/terms']
+const STATIC_ROUTES = [
+  '',
+  '/about',
+  '/changelog',
+  '/download',
+  '/pricing',
+  '/snapshot',
+  '/privacy',
+  '/terms',
+  '/dpa'
+]
 
 function buildLanguageAlternates(path: string): Record<string, string> {
   const languages: Record<string, string> = {}
   for (const locale of locales) {
     languages[locale] = `${SITE_URL}/${locale}${path}`
   }
-  languages['x-default'] = `${SITE_URL}/en${path}`
+  languages['x-default'] = `${SITE_URL}/${defaultLocale}${path}`
   return languages
 }
 

--- a/apps/landing/src/components/seo/JsonLd.tsx
+++ b/apps/landing/src/components/seo/JsonLd.tsx
@@ -1,5 +1,11 @@
 type JsonLdData = Record<string, unknown>
 
+// Escape `<` so a value containing `</script>` (e.g. an MDX frontmatter
+// description) cannot break out of the script element.
+function serialize(item: JsonLdData): string {
+  return JSON.stringify(item).replace(/</g, '\\u003c')
+}
+
 export function JsonLd({ data }: { data: JsonLdData | JsonLdData[] }) {
   const items = Array.isArray(data) ? data : [data]
   return (
@@ -10,7 +16,7 @@ export function JsonLd({ data }: { data: JsonLdData | JsonLdData[] }) {
           // biome-ignore lint/suspicious/noArrayIndexKey: stable JSON-LD list per render
           key={i}
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(item) }}
+          dangerouslySetInnerHTML={{ __html: serialize(item) }}
         />
       ))}
     </>

--- a/apps/landing/src/components/seo/JsonLd.tsx
+++ b/apps/landing/src/components/seo/JsonLd.tsx
@@ -1,0 +1,18 @@
+type JsonLdData = Record<string, unknown>
+
+export function JsonLd({ data }: { data: JsonLdData | JsonLdData[] }) {
+  const items = Array.isArray(data) ? data : [data]
+  return (
+    <>
+      {items.map((item, i) => (
+        <script
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: required for JSON-LD structured data
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable JSON-LD list per render
+          key={i}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(item) }}
+        />
+      ))}
+    </>
+  )
+}

--- a/apps/landing/src/components/shell/LangScript.tsx
+++ b/apps/landing/src/components/shell/LangScript.tsx
@@ -1,0 +1,20 @@
+import { defaultLocale, locales } from '@repo/shared/i18n'
+
+// The root layout must stay statically rendered (no headers()/dynamic APIs),
+// otherwise every [locale] route opts out of SSG. We render lang={defaultLocale}
+// in the static HTML and correct it from the URL before paint. Googlebot runs
+// this script; the hreflang alternates in the static <head> remain the primary
+// language signal for crawlers that don't.
+export function LangScript() {
+  const script = `
+    try {
+      var seg = location.pathname.split('/')[1];
+      var locales = ${JSON.stringify(locales)};
+      if (locales.indexOf(seg) !== -1 && seg !== ${JSON.stringify(defaultLocale)}) {
+        document.documentElement.lang = seg;
+      }
+    } catch (e) {}
+  `
+  // biome-ignore lint/security/noDangerouslySetInnerHtml: inline script must run before paint to set <html lang> without losing SSG
+  return <script dangerouslySetInnerHTML={{ __html: script }} />
+}

--- a/apps/landing/src/lib/seo.ts
+++ b/apps/landing/src/lib/seo.ts
@@ -1,6 +1,10 @@
 import { defaultLocale, type Locale, locales } from '@repo/shared/i18n'
 import { siteConfig } from '@/app/siteConfig'
 
+// Single normalized origin (no trailing slash) so canonical/hreflang/sitemap
+// URLs never produce `//en/path` if siteConfig.url is edited to end with `/`.
+export const SITE_URL = siteConfig.url.replace(/\/+$/, '')
+
 export function buildAlternates(locale: Locale, pathWithoutLocale = '') {
   const path = pathWithoutLocale.startsWith('/') || pathWithoutLocale === ''
     ? pathWithoutLocale
@@ -8,12 +12,12 @@ export function buildAlternates(locale: Locale, pathWithoutLocale = '') {
 
   const languages: Record<string, string> = {}
   for (const l of locales) {
-    languages[l] = `${siteConfig.url}/${l}${path}`
+    languages[l] = `${SITE_URL}/${l}${path}`
   }
-  languages['x-default'] = `${siteConfig.url}/${defaultLocale}${path}`
+  languages['x-default'] = `${SITE_URL}/${defaultLocale}${path}`
 
   return {
-    canonical: `${siteConfig.url}/${locale}${path}`,
+    canonical: `${SITE_URL}/${locale}${path}`,
     languages
   }
 }

--- a/apps/landing/src/lib/seo.ts
+++ b/apps/landing/src/lib/seo.ts
@@ -1,0 +1,19 @@
+import { defaultLocale, type Locale, locales } from '@repo/shared/i18n'
+import { siteConfig } from '@/app/siteConfig'
+
+export function buildAlternates(locale: Locale, pathWithoutLocale = '') {
+  const path = pathWithoutLocale.startsWith('/') || pathWithoutLocale === ''
+    ? pathWithoutLocale
+    : `/${pathWithoutLocale}`
+
+  const languages: Record<string, string> = {}
+  for (const l of locales) {
+    languages[l] = `${siteConfig.url}/${l}${path}`
+  }
+  languages['x-default'] = `${siteConfig.url}/${defaultLocale}${path}`
+
+  return {
+    canonical: `${siteConfig.url}/${locale}${path}`,
+    languages
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,6 @@
         "@vercel/analytics": "^1.4.1",
         "@vercel/speed-insights": "^1.1.0",
         "clsx": "^2.1.1",
-        "cobe": "^0.6.3",
         "fumadocs-core": "^16.6.7",
         "fumadocs-mdx": "^14.2.8",
         "fumadocs-ui": "^16.6.7",
@@ -44,7 +43,6 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-wrap-balancer": "^1.1.1",
-        "react-zoom-pan-pinch": "^3.7.0",
         "tailwind-variants": "^0.3.0",
         "tailwindcss": "^4.2.1",
       },
@@ -524,8 +522,6 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
-    "cobe": ["cobe@0.6.5", "", { "dependencies": { "phenomenon": "^1.6.0" } }, "sha512-MA8bu81EFY6JjQpj+FovEuhyJ25khx2Q7Lh+ot/UkCJe5yKyDgzdc6u2lGZIOmsZTXK6Itg1i4lQZIJZbPWnAg=="],
-
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
@@ -844,8 +840,6 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "phenomenon": ["phenomenon@1.6.0", "", {}, "sha512-7h9/fjPD3qNlgggzm88cY58l9sudZ6Ey+UmZsizfhtawO6E3srZQXywaNm2lBwT72TbpHYRPy7ytIHeBUD/G0A=="],
-
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -881,8 +875,6 @@
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "react-wrap-balancer": ["react-wrap-balancer@1.1.1", "", { "peerDependencies": { "react": ">=16.8.0 || ^17.0.0 || ^18" } }, "sha512-AB+l7FPRWl6uZ28VcJ8skkwLn2+UC62bjiw8tQUrZPlEWDVnR9MG0lghyn7EyxuJSsFEpht4G+yh2WikEqQ/5Q=="],
-
-    "react-zoom-pan-pinch": ["react-zoom-pan-pinch@3.7.0", "", { "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 


### PR DESCRIPTION
## Summary

End-to-end SEO + performance pass on `apps/landing` (Next.js 16 App Router, 4 locales, Fumadocs). 17 commits.

### SEO infrastructure
- `app/sitemap.ts` + `app/robots.ts` — every (route × locale) URL with `hreflang` alternates + `x-default`
- `alternates.canonical` + `languages` on every locale-aware page via `lib/seo.ts`
- JSON-LD: `Organization` + `WebSite` + `SoftwareApplication` (home), `TechArticle` + `BreadcrumbList` (docs), `CollectionPage` (docs root), `ItemList` of releases (changelog)
- Per-locale `<html lang>` via inline script (keeps SSG — see below)
- Bot-aware middleware so Googlebot can reach zh/ja/es URLs
- Dynamic per-doc OG image via `/api/og/docs` (slug-resolved, not arbitrary text)
- Long-tail keyword set, expanded metadata, fixed heading hierarchy

### Content
- Translated 9 missing English docs (`guides/*`, `platform/wsl`) + registered `wsl` in all locale `platform/meta.json` so the hreflang chain isn't broken

### Performance
- Removed duplicate Inter load, trimmed font payload, explicit fallback stacks (CLS stays 0)
- Deferred PostHog init (`requestIdleCallback`), dropped double Web Vitals capture
- Dropped unused deps (`cobe`, `react-zoom-pan-pinch`)

### Review fixes folded in
- **SSG regression fixed**: root layout no longer calls `headers()`, so all `[locale]/*` routes are prerendered (`●`) again instead of dynamic (`ƒ`). Observed mobile LCP dropped 220ms → ~90ms; desktop Lighthouse perf = 100.
- OG route hardened (slug validation → bounded cache surface, no cache poisoning)
- JSON-LD escapes `<` (no `</script>` breakout)
- `SITE_URL` normalized (no `//en/path` if a trailing slash sneaks in)

## Measured (Lighthouse)

| Page | Device | Perf | SEO | LCP (observed) | CLS |
|---|---|---|---|---|---|
| Home | Desktop | 100 | 100 | 106ms | 0 |
| Home | Mobile | 87 | 100 | ~90ms | 0 |
| Docs | Mobile | 80 | 100 | 337ms | 0 |

Simulated (slow-4G) LCP stays high but that's a Lighthouse model artifact; observed render is <350ms everywhere. Field/CrUX is the real ranking signal post-deploy.

## Test plan

- [x] `bun x next build` — 281 static pages generated, `[locale]/*` shown as `●`
- [x] `/sitemap.xml` lists all routes × locales incl. `platform/wsl`, with hreflang
- [x] `/robots.txt` points to sitemap
- [x] `/api/og/docs?locale=en&slug=getting-started` → 200 image; invalid slug → 404; bad locale → 400
- [x] View source on `/zh` — hreflang alternates present; lang corrects to `zh` client-side
- [x] JSON-LD validates (Rich Results Test) for home / a doc / changelog
- [x] Visual smoke test of Hero, pricing, docs across locales