### PR TITLE
Optimize landing performance

### DIFF
--- a/apps/landing/instrumentation-client.ts
+++ b/apps/landing/instrumentation-client.ts
@@ -1,6 +1,6 @@
-import posthog from 'posthog-js'
+const initPostHog = async () => {
+  const { default: posthog } = await import('posthog-js')
 
-const initPostHog = () => {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
     api_host: '/ingest',
     ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,

--- a/apps/landing/src/app/[locale]/(main)/changelog/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/changelog/page.tsx
@@ -45,6 +45,8 @@ export default async function ChangelogPage({ params }: { params: Promise<{ loca
         copy={{
           badge: t('changelog.badge'),
           description: t('changelog.description'),
+          searchAriaLabel: t('changelog.search.ariaLabel'),
+          searchPlaceholder: t('changelog.search.placeholder'),
           title: t('changelog.title')
         }}
         entries={entries}

--- a/apps/landing/src/app/[locale]/(main)/download/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/download/page.tsx
@@ -1,7 +1,6 @@
 import type { Locale } from '@repo/shared/i18n'
 import { getTranslation } from '@repo/shared/i18n/server'
 import type { Metadata } from 'next'
-import { headers } from 'next/headers'
 import { siteConfig } from '@/app/siteConfig'
 import { DownloadHero } from '@/components/download/DownloadHero'
 import { HomebrewBlock } from '@/components/download/HomebrewBlock'
@@ -11,6 +10,14 @@ import { ReleasesTable } from '@/components/download/ReleasesTable'
 import { CtaFinal } from '@/components/landing/CtaFinal'
 import { downloadsConfig } from '@/config/downloads'
 import { buildAlternates } from '@/lib/seo'
+
+export const dynamic = 'error'
+
+type PlatformId = 'macos' | 'windows' | 'linux'
+
+function getFeaturedPlatform(): PlatformId {
+  return 'macos'
+}
 
 export async function generateMetadata({
   params
@@ -48,20 +55,11 @@ const LinuxIcon = (
   </svg>
 )
 
-async function detectPlatform(): Promise<'macos' | 'windows' | 'linux'> {
-  const h = await headers()
-  const ua = h.get('user-agent') ?? ''
-  if (/Windows/i.test(ua)) return 'windows'
-  if (/Mac OS X|Macintosh|iPhone|iPad/i.test(ua)) return 'macos'
-  if (/Linux/i.test(ua) && !/Android/i.test(ua)) return 'linux'
-  return 'macos'
-}
-
 export default async function DownloadPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params
   const l = locale as Locale
   const { t } = await getTranslation(l)
-  const resolveAssets = (platform: 'macos' | 'windows' | 'linux') =>
+  const resolveAssets = (platform: PlatformId) =>
     downloadsConfig.latest.installers[platform].map((a) => ({
       filename: a.filename,
       label: t(a.labelKey),
@@ -78,7 +76,7 @@ export default async function DownloadPage({ params }: { params: Promise<{ local
     appleNotarized: t('download.verification.appleNotarized'),
     tauriSig: t('download.verification.tauriSig')
   }
-  const detectedPlatform = await detectPlatform()
+  const featuredPlatform = getFeaturedPlatform()
 
   return (
     <main>
@@ -91,7 +89,7 @@ export default async function DownloadPage({ params }: { params: Promise<{ local
               className="font-[var(--font-dm-mono)] text-[12px] tracking-[0.04em]"
               style={{ color: 'var(--color-dm-accent-2)' }}
             >
-              <span className="text-dm-ink-4">// </span>
+              <span className="text-dm-ink-4">{'// '}</span>
               {t('download.platforms.kicker')}
             </div>
             <h2 className="mx-0 mt-[10px] mb-3 font-bold text-[clamp(28px,3.6vw,40px)] text-dm-ink leading-[1.05] tracking-[-0.03em]">
@@ -113,7 +111,7 @@ export default async function DownloadPage({ params }: { params: Promise<{ local
           <div className="grid grid-cols-1 gap-[14px] md:grid-cols-2 lg:grid-cols-3">
             <PlatformCard
               assets={installers.macos}
-              featured={detectedPlatform === 'macos'}
+              featured={featuredPlatform === 'macos'}
               icon={MacIcon}
               minSpec={t('download.platforms.macos.minSpec')}
               strings={platformStrings}
@@ -121,7 +119,7 @@ export default async function DownloadPage({ params }: { params: Promise<{ local
             />
             <PlatformCard
               assets={installers.windows}
-              featured={detectedPlatform === 'windows'}
+              featured={featuredPlatform === 'windows'}
               icon={WindowsIcon}
               minSpec={t('download.platforms.windows.minSpec')}
               strings={platformStrings}
@@ -129,7 +127,7 @@ export default async function DownloadPage({ params }: { params: Promise<{ local
             />
             <PlatformCard
               assets={installers.linux}
-              featured={detectedPlatform === 'linux'}
+              featured={featuredPlatform === 'linux'}
               icon={LinuxIcon}
               minSpec={t('download.platforms.linux.minSpec')}
               strings={platformStrings}

--- a/apps/landing/src/app/performance-contracts.test.ts
+++ b/apps/landing/src/app/performance-contracts.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const appDir = process.cwd()
+
+function readAppFile(path: string) {
+  return readFileSync(join(appDir, path), 'utf8')
+}
+
+describe('landing performance contracts', () => {
+  test('download page stays statically renderable', () => {
+    const source = readAppFile('src/app/[locale]/(main)/download/page.tsx')
+
+    expect(source).not.toContain("from 'next/headers'")
+    expect(source).toContain("export const dynamic = 'error'")
+  })
+
+  test('changelog shell remains a server component', () => {
+    const source = readAppFile('src/components/changelog/ChangelogPageContent.tsx')
+
+    expect(source.trimStart()).not.toStartWith("'use client'")
+  })
+
+  test('browser instrumentation defers PostHog out of the initial module graph', () => {
+    const source = readAppFile('instrumentation-client.ts')
+
+    expect(source).not.toContain("import posthog from 'posthog-js'")
+    expect(source).toContain("import('posthog-js')")
+  })
+
+  test('download homebrew block keeps locale resources out of the client bundle', () => {
+    const source = readAppFile('src/components/download/HomebrewBlock.tsx')
+
+    expect(source.trimStart()).not.toStartWith("'use client'")
+    expect(source).not.toContain("from '@repo/shared/i18n/client'")
+  })
+})

--- a/apps/landing/src/components/changelog/ChangelogPageContent.test.tsx
+++ b/apps/landing/src/components/changelog/ChangelogPageContent.test.tsx
@@ -24,6 +24,8 @@ const entry: ChangelogEntryData = {
 const copy = {
   badge: '更新日志',
   description: '关注产品更新。',
+  searchAriaLabel: '搜索更新日志',
+  searchPlaceholder: '搜索版本、功能、修复...',
   title: '产品更新'
 }
 

--- a/apps/landing/src/components/changelog/ChangelogPageContent.tsx
+++ b/apps/landing/src/components/changelog/ChangelogPageContent.tsx
@@ -1,42 +1,26 @@
-'use client'
-
 import type { Locale } from '@repo/shared/i18n'
-import { useMemo, useState } from 'react'
 import type { ChangelogEntryData } from '@/lib/changelog'
 import { ChangelogSearch } from './ChangelogSearch'
 import { ChangelogTimeline } from './ChangelogTimeline'
 import { ChangelogToc } from './ChangelogToc'
 
 interface Props {
-  copy: { badge: string; title: string; description: string }
+  copy: {
+    badge: string
+    title: string
+    description: string
+    searchAriaLabel: string
+    searchPlaceholder: string
+  }
   entries: ChangelogEntryData[]
   locale: Locale
 }
 
 export default function ChangelogPageContent({ copy, entries, locale }: Props) {
-  const [query, setQuery] = useState('')
-
-  const filtered = useMemo(() => {
-    if (!query) return entries
-    return entries.filter((e) => {
-      const hay = [
-        e.version,
-        e.title,
-        e.summary,
-        ...e.sections.flatMap((s) => s.items.map((i) => i.content))
-      ]
-        .join(' ')
-        .toLowerCase()
-      return hay.includes(query)
-    })
-  }, [entries, query])
-
   return (
     <>
-      {/* page-head: kicker + italic-accent title + sub + toolbar */}
       <section className="relative overflow-hidden px-5 pt-12 pb-6 sm:px-8 sm:pt-16 sm:pb-7">
         <div className="mx-auto max-w-[1280px]">
-          {/* kicker */}
           <span className="inline-flex items-center gap-2 rounded-full border border-dm-line-strong bg-dm-bg-elev px-[11px] py-[5px] font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-2 tracking-[0.02em]">
             <span
               className="h-[6px] w-[6px] rounded-full"
@@ -56,9 +40,11 @@ export default function ChangelogPageContent({ copy, entries, locale }: Props) {
             {copy.description}
           </p>
 
-          {/* toolbar */}
           <div className="mt-7 flex flex-wrap items-center gap-[10px] border-dm-line border-b pb-7">
-            <ChangelogSearch locale={locale} onQuery={setQuery} />
+            <ChangelogSearch
+              ariaLabel={copy.searchAriaLabel}
+              placeholder={copy.searchPlaceholder}
+            />
             <a
               className="ml-auto inline-flex items-center gap-[6px] rounded-[8px] border border-dm-line bg-dm-bg-elev px-[10px] py-2 font-[var(--font-dm-mono)] text-[12px] text-dm-ink-3 no-underline hover:border-[var(--color-dm-warn)] hover:text-[var(--color-dm-warn)]"
               href={`/api/changelog/rss?locale=${locale}`}
@@ -80,7 +66,6 @@ export default function ChangelogPageContent({ copy, entries, locale }: Props) {
         </div>
       </section>
 
-      {/* Layout: 220px TOC + releases */}
       <section className="px-5 pb-16 sm:px-8 sm:pb-20">
         <div className="mx-auto max-w-[1280px]">
           <div className="grid gap-6 pt-8 md:grid-cols-[240px_minmax(0,1fr)] md:gap-[80px]">
@@ -88,9 +73,9 @@ export default function ChangelogPageContent({ copy, entries, locale }: Props) {
               <div className="mb-[14px] pl-[14px] font-[var(--font-dm-mono)] text-[11px] text-dm-ink-4 uppercase tracking-[0.08em]">
                 Releases
               </div>
-              <ChangelogToc entries={filtered} />
+              <ChangelogToc entries={entries} />
             </aside>
-            <ChangelogTimeline entries={filtered} locale={locale} />
+            <ChangelogTimeline entries={entries} locale={locale} />
           </div>
         </div>
       </section>
@@ -98,10 +83,6 @@ export default function ChangelogPageContent({ copy, entries, locale }: Props) {
   )
 }
 
-/**
- * Best-effort: render the portion after a comma in italic-serif accent.
- * Original design uses "Every commit, <em>in plain English.</em>".
- */
 function TitleWithAccent({ title }: { title: string }) {
   const idx = title.indexOf(',')
   if (idx === -1) return <>{title}</>

--- a/apps/landing/src/components/changelog/ChangelogSearch.tsx
+++ b/apps/landing/src/components/changelog/ChangelogSearch.tsx
@@ -1,17 +1,18 @@
 'use client'
 
-import type { Locale } from '@repo/shared/i18n'
-import { useTranslation } from '@repo/shared/i18n/client'
 import { useEffect } from 'react'
 
+interface ChangelogFilterDetail {
+  visibleIds: string[]
+}
+
 export function ChangelogSearch({
-  locale,
-  onQuery
+  ariaLabel,
+  placeholder
 }: {
-  locale: Locale
-  onQuery: (query: string) => void
+  ariaLabel: string
+  placeholder: string
 }) {
-  const { t } = useTranslation(locale)
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
@@ -22,6 +23,23 @@ export function ChangelogSearch({
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [])
+
+  const onSearch = (query: string) => {
+    const normalized = query.trim().toLowerCase()
+    const entries = Array.from(document.querySelectorAll<HTMLElement>('[data-changelog-entry]'))
+    const visibleIds: string[] = []
+
+    for (const entry of entries) {
+      const matches =
+        normalized.length === 0 || (entry.textContent ?? '').toLowerCase().includes(normalized)
+      entry.hidden = !matches
+      if (matches) visibleIds.push(entry.id)
+    }
+
+    window.dispatchEvent(
+      new CustomEvent<ChangelogFilterDetail>('changelog:filtered', { detail: { visibleIds } })
+    )
+  }
 
   return (
     <label className="flex min-w-[280px] max-w-[480px] flex-1 items-center gap-[10px] rounded-[10px] border border-dm-line-strong bg-dm-bg-elev px-[14px] py-[9px] font-[var(--font-dm-mono)] text-[13px] text-dm-ink-2 focus-within:border-[var(--color-dm-accent-2)] focus-within:shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-dm-accent-2)_18%,transparent)]">
@@ -39,11 +57,11 @@ export function ChangelogSearch({
         <path d="M21 21l-4.35-4.35" />
       </svg>
       <input
-        aria-label={t('changelog.search.ariaLabel')}
+        aria-label={ariaLabel}
         className="flex-1 border-0 bg-transparent font-[var(--font-dm-mono)] text-[13px] text-dm-ink outline-none placeholder:text-dm-ink-4"
         id="changelog-search"
-        onChange={(e) => onQuery(e.currentTarget.value.toLowerCase())}
-        placeholder={t('changelog.search.placeholder')}
+        onChange={(e) => onSearch(e.currentTarget.value)}
+        placeholder={placeholder}
         type="search"
       />
       <span className="rounded border border-dm-line bg-dm-bg-soft px-[6px] py-[2px] font-[var(--font-dm-mono)] text-[10.5px] text-dm-ink-3">

--- a/apps/landing/src/components/changelog/ChangelogTimeline.test.tsx
+++ b/apps/landing/src/components/changelog/ChangelogTimeline.test.tsx
@@ -28,6 +28,11 @@ describe('ChangelogTimeline', () => {
     expect(markup).toContain('Version 4.7.0')
   })
 
+  test('marks entries as DOM-filterable without hydrating the timeline', () => {
+    const markup = renderToStaticMarkup(<ChangelogTimeline entries={[entry]} locale="zh" />)
+    expect(markup).toContain('data-changelog-entry="release-v4-7-0"')
+  })
+
   test('renders v<version> in the header', () => {
     const markup = renderToStaticMarkup(<ChangelogTimeline entries={[entry]} locale="zh" />)
     expect(markup).toContain('v4.7.0')

--- a/apps/landing/src/components/changelog/ChangelogTimeline.tsx
+++ b/apps/landing/src/components/changelog/ChangelogTimeline.tsx
@@ -3,6 +3,8 @@ import type { ChangelogBlock, ChangelogEntryData, ChangelogSection } from '@/lib
 import { ChangelogCallout } from './ChangelogCallout'
 import { ChangelogFigure } from './ChangelogFigure'
 
+const DIGIT_PATTERN = /\d/
+
 interface ChangelogTimelineProps {
   entries: ChangelogEntryData[]
   locale: Locale
@@ -42,7 +44,11 @@ function ReleaseArticle({
   // Extract major version for the circle badge: "5.1.0" -> "5".
   const major = entry.version.split('.')[0] ?? ''
   return (
-    <article className="scroll-mt-[100px]" id={entry.id}>
+    <article
+      className="scroll-mt-[100px] [contain-intrinsic-size:900px] [content-visibility:auto]"
+      data-changelog-entry={entry.id}
+      id={entry.id}
+    >
       <div className="mb-5 flex flex-wrap items-center gap-3 font-[var(--font-dm-mono)] text-[12px]">
         <VersionPill highlighted={isLatest} major={major} version={entry.version} />
         <span className="text-dm-ink-3">{entry.date}</span>
@@ -132,7 +138,7 @@ function TitleMaybeAccent({ title }: { title: string }) {
   for (let idx = 0; idx < title.length; idx++) {
     if (title[idx] !== '.') continue
     const prev = title[idx - 1] ?? ''
-    if (/\d/.test(prev)) continue
+    if (DIGIT_PATTERN.test(prev)) continue
     if (idx === title.length - 1) continue
     const tail = title.slice(idx + 1).trim()
     if (tail.length === 0) continue

--- a/apps/landing/src/components/changelog/ChangelogToc.tsx
+++ b/apps/landing/src/components/changelog/ChangelogToc.tsx
@@ -1,12 +1,44 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ChangelogEntryData } from '@/lib/changelog'
+
+interface ChangelogFilterDetail {
+  visibleIds: string[]
+}
+
+function isChangelogFilterEvent(event: Event): event is CustomEvent<ChangelogFilterDetail> {
+  return event instanceof CustomEvent && Array.isArray(event.detail?.visibleIds)
+}
 
 export function ChangelogToc({ entries }: { entries: ChangelogEntryData[] }) {
   const [active, setActive] = useState(entries[0]?.id ?? '')
+  const [visibleIds, setVisibleIds] = useState<string[] | null>(null)
   const navRef = useRef<HTMLElement | null>(null)
+  const visibleEntries = useMemo(() => {
+    if (!visibleIds) return entries
+    return entries.filter((entry) => visibleIds.includes(entry.id))
+  }, [entries, visibleIds])
+
+  useEffect(() => {
+    const onFiltered = (event: Event) => {
+      if (!isChangelogFilterEvent(event)) return
+      setVisibleIds(event.detail.visibleIds)
+    }
+    window.addEventListener('changelog:filtered', onFiltered)
+    return () => window.removeEventListener('changelog:filtered', onFiltered)
+  }, [])
+
+  useEffect(() => {
+    if (visibleEntries.length === 0) {
+      setActive('')
+      return
+    }
+    if (!visibleEntries.some((entry) => entry.id === active)) {
+      setActive(visibleEntries[0]?.id ?? '')
+    }
+  }, [active, visibleEntries])
 
   useEffect(() => {
     const obs = new IntersectionObserver(
@@ -19,12 +51,12 @@ export function ChangelogToc({ entries }: { entries: ChangelogEntryData[] }) {
       },
       { rootMargin: '-20% 0px -60% 0px' }
     )
-    for (const e of entries) {
+    for (const e of visibleEntries) {
       const el = document.getElementById(e.id)
       if (el) obs.observe(el)
     }
     return () => obs.disconnect()
-  }, [entries])
+  }, [visibleEntries])
 
   // Keep the active entry inside the nav's own scroll viewport so long
   // release lists don't leave the current version off-screen.
@@ -54,7 +86,7 @@ export function ChangelogToc({ entries }: { entries: ChangelogEntryData[] }) {
       ref={navRef}
     >
       <ul className="m-0 list-none border-dm-line border-l p-0">
-        {entries.map((e) => {
+        {visibleEntries.map((e) => {
           const isActive = active === e.id
           return (
             <li key={e.id}>

--- a/apps/landing/src/components/download/HomebrewBlock.tsx
+++ b/apps/landing/src/components/download/HomebrewBlock.tsx
@@ -1,24 +1,11 @@
-'use client'
-
 import type { Locale } from '@repo/shared/i18n'
-import { useTranslation } from '@repo/shared/i18n/client'
-import { useState } from 'react'
+import { getTranslation } from '@repo/shared/i18n/server'
 import { downloadsConfig } from '@/config/downloads'
+import { HomebrewCopyButton } from './HomebrewCopyButton'
 
-export function HomebrewBlock({ locale }: { locale: Locale }) {
-  const { t } = useTranslation(locale)
-  const [copied, setCopied] = useState(false)
+export async function HomebrewBlock({ locale }: { locale: Locale }) {
+  const { t } = await getTranslation(locale)
   const cmd = downloadsConfig.homebrewCommand
-
-  const onCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(cmd)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1400)
-    } catch {
-      // ignore
-    }
-  }
 
   return (
     <section className="px-5 sm:px-8">
@@ -41,45 +28,7 @@ export function HomebrewBlock({ locale }: { locale: Locale }) {
                 {t('download.homebrew.tag')}
               </div>
             </div>
-            <button
-              className="flex w-full cursor-pointer items-center gap-2 rounded-[8px] border border-dm-line bg-dm-bg-soft px-3 py-[10px] text-left font-[var(--font-dm-mono)] text-[12px] text-dm-ink-2 transition-colors hover:border-dm-line-strong"
-              onClick={onCopy}
-              type="button"
-            >
-              <span style={{ color: 'var(--color-dm-accent-2)' }}>$</span>
-              <code className="min-w-0 flex-1 overflow-hidden truncate text-dm-ink">{cmd}</code>
-              <span
-                aria-hidden="true"
-                className="grid h-[22px] w-[22px] flex-shrink-0 place-items-center rounded bg-dm-bg-elev text-dm-ink-3"
-              >
-                {copied ? (
-                  <svg
-                    fill="none"
-                    height="11"
-                    stroke="var(--color-dm-ok)"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2.5"
-                    viewBox="0 0 24 24"
-                    width="11"
-                  >
-                    <polyline points="20 6 9 17 4 12" />
-                  </svg>
-                ) : (
-                  <svg
-                    fill="none"
-                    height="11"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    viewBox="0 0 24 24"
-                    width="11"
-                  >
-                    <rect height="13" rx="2" width="13" x="9" y="9" />
-                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-                  </svg>
-                )}
-              </span>
-            </button>
+            <HomebrewCopyButton command={cmd} />
           </div>
         </div>
       </div>

--- a/apps/landing/src/components/download/HomebrewCopyButton.tsx
+++ b/apps/landing/src/components/download/HomebrewCopyButton.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useState } from 'react'
+
+export function HomebrewCopyButton({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const onCopy = () => {
+    navigator.clipboard.writeText(command).then(
+      () => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1400)
+      },
+      () => undefined
+    )
+  }
+
+  return (
+    <button
+      className="flex w-full cursor-pointer items-center gap-2 rounded-[8px] border border-dm-line bg-dm-bg-soft px-3 py-[10px] text-left font-[var(--font-dm-mono)] text-[12px] text-dm-ink-2 transition-colors hover:border-dm-line-strong"
+      onClick={onCopy}
+      type="button"
+    >
+      <span style={{ color: 'var(--color-dm-accent-2)' }}>$</span>
+      <code className="min-w-0 flex-1 overflow-hidden truncate text-dm-ink">{command}</code>
+      <span
+        aria-hidden="true"
+        className="grid h-[22px] w-[22px] flex-shrink-0 place-items-center rounded bg-dm-bg-elev text-dm-ink-3"
+      >
+        {copied ? (
+          <svg
+            fill="none"
+            height="11"
+            stroke="var(--color-dm-ok)"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2.5"
+            viewBox="0 0 24 24"
+            width="11"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        ) : (
+          <svg
+            fill="none"
+            height="11"
+            stroke="currentColor"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            width="11"
+          >
+            <rect height="13" rx="2" width="13" x="9" y="9" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+        )}
+      </span>
+    </button>
+  )
+}

--- a/apps/landing/src/components/download/PlatformCard.test.tsx
+++ b/apps/landing/src/components/download/PlatformCard.test.tsx
@@ -22,6 +22,7 @@ describe('PlatformCard', () => {
     )
 
     expect(markup).toContain('recommended')
+    expect(markup).toContain('ml-auto')
     expect(markup).toContain('normal-case')
     expect(markup).not.toContain('uppercase')
   })

--- a/apps/landing/src/components/download/PlatformCard.test.tsx
+++ b/apps/landing/src/components/download/PlatformCard.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { PlatformCard } from './PlatformCard'
+
+const strings = {
+  appleNotarized: 'Apple notarized',
+  recommended: 'recommended',
+  tauriSig: 'Tauri signature'
+}
+
+describe('PlatformCard', () => {
+  test('keeps long recommended labels in their badge', () => {
+    const markup = renderToStaticMarkup(
+      <PlatformCard
+        assets={[]}
+        featured
+        icon={<span aria-hidden="true">icon</span>}
+        minSpec="macOS 11 Big Sur or later"
+        strings={strings}
+        title="macOS"
+      />
+    )
+
+    expect(markup).toContain('recommended')
+    expect(markup).toContain('normal-case')
+    expect(markup).not.toContain('uppercase')
+  })
+})

--- a/apps/landing/src/components/download/PlatformCard.tsx
+++ b/apps/landing/src/components/download/PlatformCard.tsx
@@ -1,5 +1,7 @@
 import { downloadsConfig, type Verification } from '@/config/downloads'
 
+const INSTALLER_LABEL_WITH_SUBTITLE = /^(.+?)\s*\((.+)\)\s*$/
+
 export interface ResolvedInstallerAsset {
   filename: string
   label: string
@@ -64,33 +66,35 @@ export function PlatformCard({
           : { borderColor: 'var(--color-dm-line)', backgroundColor: 'var(--color-dm-bg-elev)' }
       }
     >
-      <div className="flex items-center gap-[14px]">
+      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-[14px]">
         <div className="grid h-12 w-12 flex-shrink-0 place-items-center rounded-[12px] border border-dm-line bg-dm-bg-soft text-dm-ink">
           {icon}
         </div>
-        <div>
-          <div className="font-bold text-[20px] text-dm-ink tracking-[-0.02em]">{title}</div>
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+            <div className="font-bold text-[20px] text-dm-ink tracking-[-0.02em]">{title}</div>
+            {featured ? (
+              <span
+                className="inline-flex max-w-full shrink-0 items-center justify-center whitespace-nowrap rounded-full px-2.5 py-[3px] text-center font-[var(--font-dm-mono)] font-semibold text-[10.5px] normal-case leading-none tracking-normal"
+                style={{
+                  background: 'color-mix(in srgb, var(--color-dm-accent-2) 14%, transparent)',
+                  color: 'var(--color-dm-accent-2)'
+                }}
+              >
+                {strings.recommended}
+              </span>
+            ) : null}
+          </div>
           <div className="mt-[2px] font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-4">
             {minSpec}
           </div>
         </div>
-        {featured ? (
-          <span
-            className="ml-auto inline-block min-w-[72px] rounded-full px-2 py-[3px] text-center font-[var(--font-dm-mono)] font-semibold text-[10.5px] uppercase tracking-[0.02em]"
-            style={{
-              background: 'color-mix(in srgb, var(--color-dm-accent-2) 14%, transparent)',
-              color: 'var(--color-dm-accent-2)'
-            }}
-          >
-            {strings.recommended}
-          </span>
-        ) : null}
       </div>
 
       <div className="flex flex-col gap-2">
         {assets.map((a) => {
           const vLabel = verificationLabel(a.verification, strings)
-          const parenMatch = a.label.match(/^(.+?)\s*\((.+)\)\s*$/)
+          const parenMatch = a.label.match(INSTALLER_LABEL_WITH_SUBTITLE)
           const labelMain = parenMatch ? parenMatch[1] : a.label
           const labelSub = parenMatch ? parenMatch[2] : null
           return (

--- a/apps/landing/src/components/download/PlatformCard.tsx
+++ b/apps/landing/src/components/download/PlatformCard.tsx
@@ -71,11 +71,13 @@ export function PlatformCard({
           {icon}
         </div>
         <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-            <div className="font-bold text-[20px] text-dm-ink tracking-[-0.02em]">{title}</div>
+          <div className="flex min-w-0 flex-wrap items-start gap-x-3 gap-y-2">
+            <div className="min-w-0 font-bold text-[20px] text-dm-ink tracking-[-0.02em]">
+              {title}
+            </div>
             {featured ? (
               <span
-                className="inline-flex max-w-full shrink-0 items-center justify-center whitespace-nowrap rounded-full px-2.5 py-[3px] text-center font-[var(--font-dm-mono)] font-semibold text-[10.5px] normal-case leading-none tracking-normal"
+                className="ml-auto inline-flex max-w-full shrink-0 items-center justify-center whitespace-nowrap rounded-full px-2.5 py-[3px] text-center font-[var(--font-dm-mono)] font-semibold text-[10.5px] normal-case leading-none tracking-normal"
                 style={{
                   background: 'color-mix(in srgb, var(--color-dm-accent-2) 14%, transparent)',
                   color: 'var(--color-dm-accent-2)'

--- a/apps/landing/src/lib/source.ts
+++ b/apps/landing/src/lib/source.ts
@@ -1,6 +1,6 @@
-import { docs } from 'fumadocs-mdx:collections/server'
 import { loader } from 'fumadocs-core/source'
 import { i18n } from '@/lib/i18n/fumadocs'
+import { docs } from '../../.source/server'
 
 export const source = loader({
   baseUrl: '/docs',


### PR DESCRIPTION
## Summary
- make the download route statically renderable by removing request-header platform detection
- reduce changelog hydration by keeping the shell/timeline server-rendered and filtering entries in the DOM
- defer PostHog loading until idle and keep the Homebrew copy interaction as a small client island
- fix the landing build by importing the generated Fumadocs source directly

## Verification
- bun test src/app/performance-contracts.test.ts src/components/changelog/ChangelogPageContent.test.tsx src/components/changelog/ChangelogTimeline.test.tsx
- bunx biome check --no-errors-on-unmatched apps/landing/instrumentation-client.ts apps/landing/src/app/[locale]/(main)/changelog/page.tsx apps/landing/src/app/[locale]/(main)/download/page.tsx apps/landing/src/app/performance-contracts.test.ts apps/landing/src/components/changelog/ChangelogPageContent.test.tsx apps/landing/src/components/changelog/ChangelogPageContent.tsx apps/landing/src/components/changelog/ChangelogSearch.tsx apps/landing/src/components/changelog/ChangelogTimeline.test.tsx apps/landing/src/components/changelog/ChangelogTimeline.tsx apps/landing/src/components/changelog/ChangelogToc.tsx apps/landing/src/components/download/HomebrewBlock.tsx apps/landing/src/components/download/HomebrewCopyButton.tsx apps/landing/src/lib/source.ts
- git diff --check
- bun run build:landing
- Chrome smoke test for /en/download and /en/changelog search