### PR TITLE
feat(landing): execute animation audit plans 001-009

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -117,8 +117,9 @@ Never hand-type a cubic-bezier in a component — use `var(--ease-out-strong)` /
 `ease-in-out-strong` utility classes).
 
 **Reduced motion is honored.** `@media (prefers-reduced-motion: reduce)`
-disables `.dm-animated` transitions/animations. If you author something
-animated that isn't critical to comprehension, gate it via `.dm-animated`.
+forces `.dm-animated` animations to complete instantly at their end state
+(and disables transitions). If you author something animated that isn't
+critical to comprehension, gate it via `.dm-animated`.
 
 ---
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -106,6 +106,16 @@ Keyframes live in `globals.css` `@theme`. The important ones:
 - `slide-down-fade` / `slide-up-fade` / `fade-in` — 150–200ms `ease-out`,
   for menu / tooltip / toast entry.
 
+Easing tokens live in the same `@theme` block:
+
+- `--ease-out-strong` — `cubic-bezier(0.22, 1, 0.36, 1)`. Entrances, exits,
+  and reveals.
+- `--ease-in-out-strong` — `cubic-bezier(0.77, 0, 0.175, 1)`. On-screen morphs.
+
+Never hand-type a cubic-bezier in a component — use `var(--ease-out-strong)` /
+`var(--ease-in-out-strong)` (or the generated `ease-out-strong` /
+`ease-in-out-strong` utility classes).
+
 **Reduced motion is honored.** `@media (prefers-reduced-motion: reduce)`
 disables `.dm-animated` transitions/animations. If you author something
 animated that isn't critical to comprehension, gate it via `.dm-animated`.

--- a/apps/landing/src/app/[locale]/(main)/about/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/about/page.tsx
@@ -41,14 +41,7 @@ export default function About() {
 
   return (
     <div className="mt-36 flex flex-col overflow-hidden px-3 pb-16">
-      <section
-        aria-labelledby="about-overview"
-        className="animate-slide-up-fade"
-        style={{
-          animationDuration: '600ms',
-          animationFillMode: 'backwards'
-        }}
-      >
+      <section aria-labelledby="about-overview" className="animate-slide-up-fade">
         <Badge>{t('about.badge')}</Badge>
         <h1
           className="mt-2 inline-block bg-gradient-to-br from-gray-900 to-gray-800 bg-clip-text py-2 font-bold text-4xl text-transparent tracking-tighter sm:text-6xl md:text-6xl dark:from-gray-50 dark:to-gray-300"

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -262,7 +262,7 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
                 target="_blank"
               >
                 <button
-                  className="inline-flex cursor-pointer items-center gap-2 rounded-[10px] border-0 px-[22px] py-[13px] font-semibold text-[14px] text-white no-underline transition-transform hover:-translate-y-px"
+                  className="inline-flex cursor-pointer items-center gap-2 rounded-[10px] border-0 px-[22px] py-[13px] font-semibold text-[14px] text-white no-underline transition-transform hover:-translate-y-px active:translate-y-0 active:scale-[0.97]"
                   style={{
                     background:
                       'linear-gradient(180deg, var(--color-dm-accent-2), color-mix(in srgb, var(--color-dm-accent-2) 80%, black))',
@@ -286,7 +286,7 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
                 </button>
               </form>
               <a
-                className="inline-flex items-center px-[22px] py-[13px] font-medium text-[14px] text-dm-ink-2 transition-colors hover:text-dm-ink"
+                className="inline-flex items-center px-[22px] py-[13px] font-medium text-[14px] text-dm-ink-2 transition-[color,background-color,border-color,transform] hover:text-dm-ink active:scale-[0.97]"
                 href={`/${l}/download`}
               >
                 {t('pricing.finalCta.ctaFree')}

--- a/apps/landing/src/app/[locale]/(main)/pricing/success/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/success/page.tsx
@@ -11,10 +11,7 @@ export default function PricingSuccess() {
 
   return (
     <div className="mt-36 flex flex-col items-center overflow-hidden px-3 pb-16">
-      <section
-        className="max-w-lg animate-slide-up-fade text-center"
-        style={{ animationDuration: '600ms', animationFillMode: 'backwards' }}
-      >
+      <section className="max-w-lg animate-slide-up-fade text-center">
         <div className="flex justify-center">
           <RiCheckboxCircleFill className="size-16 text-green-500" />
         </div>

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -25,8 +25,8 @@
   --animate-accordionClose: accordionClose 200ms cubic-bezier(0.33, 1, 0.68, 1);
   --animate-dialogOverlayShow: dialogOverlayShow 150ms var(--ease-out-strong);
   --animate-dialogContentShow: dialogContentShow 150ms var(--ease-out-strong);
-  --animate-slide-down-fade: slide-down-fade ease-in-out forwards;
-  --animate-slide-up-fade: slide-up-fade ease-in-out forwards;
+  --animate-slide-down-fade: slide-down-fade 600ms var(--ease-out-strong) both;
+  --animate-slide-up-fade: slide-up-fade 600ms var(--ease-out-strong) both;
   --animate-fade-in: fade-in 200ms ease-out;
 
   @keyframes hide {

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -13,21 +13,18 @@
   --font-sans-zh:
     "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "WenQuanYi Micro Hei",
     sans-serif;
+  --ease-out-strong: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-in-out-strong: cubic-bezier(0.77, 0, 0.175, 1);
 
-  --animate-hide: hide 150ms cubic-bezier(0.16, 1, 0.3, 1);
-  --animate-slideDownAndFade: slideDownAndFade 150ms
-    cubic-bezier(0.16, 1, 0.3, 1);
-  --animate-slideLeftAndFade: slideLeftAndFade 150ms
-    cubic-bezier(0.16, 1, 0.3, 1);
-  --animate-slideUpAndFade: slideUpAndFade 150ms cubic-bezier(0.16, 1, 0.3, 1);
-  --animate-slideRightAndFade: slideRightAndFade 150ms
-    cubic-bezier(0.16, 1, 0.3, 1);
+  --animate-hide: hide 150ms var(--ease-out-strong);
+  --animate-slideDownAndFade: slideDownAndFade 150ms var(--ease-out-strong);
+  --animate-slideLeftAndFade: slideLeftAndFade 150ms var(--ease-out-strong);
+  --animate-slideUpAndFade: slideUpAndFade 150ms var(--ease-out-strong);
+  --animate-slideRightAndFade: slideRightAndFade 150ms var(--ease-out-strong);
   --animate-accordionOpen: accordionOpen 250ms cubic-bezier(0.33, 1, 0.68, 1);
   --animate-accordionClose: accordionClose 200ms cubic-bezier(0.33, 1, 0.68, 1);
-  --animate-dialogOverlayShow: dialogOverlayShow 150ms
-    cubic-bezier(0.16, 1, 0.3, 1);
-  --animate-dialogContentShow: dialogContentShow 150ms
-    cubic-bezier(0.16, 1, 0.3, 1);
+  --animate-dialogOverlayShow: dialogOverlayShow 150ms var(--ease-out-strong);
+  --animate-dialogContentShow: dialogContentShow 150ms var(--ease-out-strong);
   --animate-slide-down-fade: slide-down-fade ease-in-out forwards;
   --animate-slide-up-fade: slide-up-fade ease-in-out forwards;
   --animate-fade-in: fade-in 200ms ease-out;

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -21,8 +21,6 @@
   --animate-slideLeftAndFade: slideLeftAndFade 150ms var(--ease-out-strong);
   --animate-slideUpAndFade: slideUpAndFade 150ms var(--ease-out-strong);
   --animate-slideRightAndFade: slideRightAndFade 150ms var(--ease-out-strong);
-  --animate-accordionOpen: accordionOpen 250ms cubic-bezier(0.33, 1, 0.68, 1);
-  --animate-accordionClose: accordionClose 200ms cubic-bezier(0.33, 1, 0.68, 1);
   --animate-dialogOverlayShow: dialogOverlayShow 150ms var(--ease-out-strong);
   --animate-dialogContentShow: dialogContentShow 150ms var(--ease-out-strong);
   --animate-slide-down-fade: slide-down-fade 600ms var(--ease-out-strong) both;
@@ -75,22 +73,6 @@
     to {
       opacity: 1;
       transform: translateX(0);
-    }
-  }
-  @keyframes accordionOpen {
-    from {
-      height: 0px;
-    }
-    to {
-      height: var(--radix-accordion-content-height);
-    }
-  }
-  @keyframes accordionClose {
-    from {
-      height: var(--radix-accordion-content-height);
-    }
-    to {
-      height: 0px;
     }
   }
   @keyframes dialogOverlayShow {

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -299,8 +299,10 @@ code .line::before {
   mask-image: radial-gradient(rgba(0, 0, 0, 1) 0%, transparent 80%);
 }
 
-a {
-  @apply scroll-my-24 decoration-gray-400 transition-[color,text-decoration-color];
+@layer base {
+  a {
+    @apply scroll-my-24 decoration-gray-400 transition-[color,text-decoration-color];
+  }
 }
 
 .anchor-link {

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -273,7 +273,9 @@
   @media (prefers-reduced-motion: reduce) {
     .dm-animated,
     .dm-animated * {
-      animation: none !important;
+      animation-duration: 0.01ms !important;
+      animation-delay: 0ms !important;
+      animation-iteration-count: 1 !important;
       transition: none !important;
     }
   }

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -316,7 +316,7 @@ code .line::before {
 }
 
 a {
-  @apply scroll-my-24 decoration-gray-400 transition-all;
+  @apply scroll-my-24 decoration-gray-400 transition-[color,text-decoration-color];
 }
 
 .anchor-link {

--- a/apps/landing/src/components/AccordionContent.tsx
+++ b/apps/landing/src/components/AccordionContent.tsx
@@ -9,20 +9,19 @@ interface AccordionContentProps
 
 export function AccordionContent({ className, children, ref, ...props }: AccordionContentProps) {
   return (
-    <AccordionPrimitives.Content
-      className={cx(
-        'grid grid-rows-[0fr] transition-[grid-template-rows,visibility] duration-200 ease-out-strong',
-        'data-[state=open]:grid-rows-[1fr] data-[state=open]:duration-250',
-        'data-[state=closed]:invisible',
-        'motion-reduce:transition-none'
-      )}
-      forceMount
-      ref={ref}
-      {...props}
-    >
-      <div className="min-h-0 overflow-hidden">
-        <div className={cx('pb-4 text-sm', 'text-gray-700 dark:text-gray-200', className)}>
-          {children}
+    <AccordionPrimitives.Content className="group" forceMount ref={ref} {...props}>
+      <div
+        className={cx(
+          'grid grid-rows-[0fr] transition-[grid-template-rows,visibility] duration-200 ease-out-strong',
+          'group-data-[state=open]:grid-rows-[1fr] group-data-[state=open]:duration-250',
+          'group-data-[state=closed]:invisible',
+          'motion-reduce:transition-none'
+        )}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className={cx('pb-4 text-sm', 'text-gray-700 dark:text-gray-200', className)}>
+            {children}
+          </div>
         </div>
       </div>
     </AccordionPrimitives.Content>

--- a/apps/landing/src/components/AccordionContent.tsx
+++ b/apps/landing/src/components/AccordionContent.tsx
@@ -11,14 +11,18 @@ export function AccordionContent({ className, children, ref, ...props }: Accordi
   return (
     <AccordionPrimitives.Content
       className={cx(
-        'transform-gpu data-[state=closed]:animate-accordionClose data-[state=open]:animate-accordionOpen'
+        'grid grid-rows-[0fr] transition-[grid-template-rows,visibility] duration-200 ease-out-strong',
+        'data-[state=open]:grid-rows-[1fr] data-[state=open]:duration-250',
+        'data-[state=closed]:invisible',
+        'motion-reduce:transition-none'
       )}
+      forceMount
       ref={ref}
       {...props}
     >
       <div
         className={cx(
-          'overflow-hidden pb-4 text-sm',
+          'min-h-0 overflow-hidden pb-4 text-sm',
           'text-gray-700 dark:text-gray-200',
           className
         )}

--- a/apps/landing/src/components/AccordionContent.tsx
+++ b/apps/landing/src/components/AccordionContent.tsx
@@ -20,14 +20,10 @@ export function AccordionContent({ className, children, ref, ...props }: Accordi
       ref={ref}
       {...props}
     >
-      <div
-        className={cx(
-          'min-h-0 overflow-hidden pb-4 text-sm',
-          'text-gray-700 dark:text-gray-200',
-          className
-        )}
-      >
-        {children}
+      <div className="min-h-0 overflow-hidden">
+        <div className={cx('pb-4 text-sm', 'text-gray-700 dark:text-gray-200', className)}>
+          {children}
+        </div>
       </div>
     </AccordionPrimitives.Content>
   )

--- a/apps/landing/src/components/AccordionTrigger.tsx
+++ b/apps/landing/src/components/AccordionTrigger.tsx
@@ -26,7 +26,8 @@ export function AccordionTrigger({ className, children, ref, ...props }: Accordi
         <RiAddLine
           aria-hidden="true"
           className={cx(
-            'size-5 shrink-0 transition-transform duration-150 ease-[cubic-bezier(0.87,_0,_0.13,_1)] group-data-[state=open]:-rotate-45',
+            'size-5 shrink-0 transition-transform duration-200 ease-out-strong group-data-[state=open]:-rotate-45 group-data-[state=open]:duration-250',
+            'motion-reduce:transition-none',
             'text-gray-400 dark:text-gray-600',
             'group-data-[disabled]:text-gray-300 group-data-[disabled]:dark:text-gray-700'
           )}

--- a/apps/landing/src/components/ThemeSwitch.tsx
+++ b/apps/landing/src/components/ThemeSwitch.tsx
@@ -65,7 +65,7 @@ function ThemeSwitch() {
       {OPTIONS.map(({ value, label, Icon }) => (
         <RadioGroupPrimitives.Item
           aria-label={`Switch to ${label} mode`}
-          className="group relative grid h-[26px] w-[26px] cursor-pointer place-items-center rounded-full text-dm-ink-3 outline-none transition-colors hover:text-dm-ink focus-visible:ring-2 focus-visible:ring-[var(--color-dm-accent-2)]/60 data-[state=checked]:text-dm-ink"
+          className="group relative grid h-[26px] w-[26px] cursor-pointer place-items-center rounded-full text-dm-ink-3 outline-none transition-[color,background-color,border-color,transform] hover:text-dm-ink focus-visible:ring-2 focus-visible:ring-[var(--color-dm-accent-2)]/60 active:scale-[0.97] data-[state=checked]:text-dm-ink"
           key={value}
           value={value}
         >

--- a/apps/landing/src/components/buttonVariants.ts
+++ b/apps/landing/src/components/buttonVariants.ts
@@ -3,7 +3,7 @@ import { tv } from 'tailwind-variants'
 
 export const buttonVariants = tv({
   base: [
-    'relative inline-flex items-center justify-center whitespace-nowrap rounded-lg border px-3 py-2 text-center font-medium text-sm shadow-sm transition-all duration-100 ease-in-out',
+    'relative inline-flex items-center justify-center whitespace-nowrap rounded-lg border px-3 py-2 text-center font-medium text-sm shadow-sm transition-[color,background-color,border-color,box-shadow] duration-100 ease-[ease]',
     'disabled:pointer-events-none disabled:shadow-none',
     focusRing
   ],

--- a/apps/landing/src/components/changelog/ChangelogToc.tsx
+++ b/apps/landing/src/components/changelog/ChangelogToc.tsx
@@ -14,12 +14,15 @@ function scrollLinkIntoView(nav: HTMLElement | null, id: string) {
   const viewTop = nav.scrollTop
   const viewBottom = viewTop + nav.clientHeight
   const margin = 24
+  const behavior: ScrollBehavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ? 'auto'
+    : 'smooth'
   if (linkTop < viewTop + margin) {
-    nav.scrollTo({ top: Math.max(0, linkTop - margin), behavior: 'smooth' })
+    nav.scrollTo({ top: Math.max(0, linkTop - margin), behavior })
   } else if (linkBottom > viewBottom - margin) {
     nav.scrollTo({
       top: linkBottom - nav.clientHeight + margin,
-      behavior: 'smooth'
+      behavior
     })
   }
 }

--- a/apps/landing/src/components/download/DownloadHero.tsx
+++ b/apps/landing/src/components/download/DownloadHero.tsx
@@ -20,7 +20,7 @@ export async function DownloadHero({ locale }: { locale: Locale }) {
       <div className="mx-auto max-w-[1140px]">
         <span className="inline-flex items-center gap-[10px] rounded-full border border-dm-line-strong bg-dm-bg-elev py-[5px] pr-[10px] pl-[6px] font-[var(--font-dm-mono)] text-[12px] text-dm-ink-2">
           <span
-            className="h-[6px] w-[6px] rounded-full"
+            className="dm-animated h-[6px] w-[6px] rounded-full"
             style={{
               background: 'var(--color-dm-ok)',
               boxShadow: '0 0 0 4px color-mix(in srgb, var(--color-dm-ok) 30%, transparent)',

--- a/apps/landing/src/components/download/HomebrewCopyButton.tsx
+++ b/apps/landing/src/components/download/HomebrewCopyButton.tsx
@@ -17,7 +17,7 @@ export function HomebrewCopyButton({ command }: { command: string }) {
 
   return (
     <button
-      className="flex w-full cursor-pointer items-center gap-2 rounded-[8px] border border-dm-line bg-dm-bg-soft px-3 py-[10px] text-left font-[var(--font-dm-mono)] text-[12px] text-dm-ink-2 transition-colors hover:border-dm-line-strong"
+      className="flex w-full cursor-pointer items-center gap-2 rounded-[8px] border border-dm-line bg-dm-bg-soft px-3 py-[10px] text-left font-[var(--font-dm-mono)] text-[12px] text-dm-ink-2 transition-[color,background-color,border-color,transform] hover:border-dm-line-strong active:scale-[0.97]"
       onClick={onCopy}
       type="button"
     >

--- a/apps/landing/src/components/download/PlatformCard.tsx
+++ b/apps/landing/src/components/download/PlatformCard.tsx
@@ -51,7 +51,7 @@ export function PlatformCard({
 }: PlatformCardProps) {
   return (
     <article
-      className="relative flex flex-col gap-[18px] overflow-hidden rounded-[14px] border p-6 transition-all hover:-translate-y-px"
+      className="relative flex flex-col gap-[18px] overflow-hidden rounded-[14px] border p-6 transition-transform hover:-translate-y-px"
       style={
         featured
           ? {
@@ -101,7 +101,7 @@ export function PlatformCard({
           const labelSub = parenMatch ? parenMatch[2] : null
           return (
             <a
-              className="group relative flex items-center gap-3 rounded-[10px] border border-dm-line bg-dm-bg px-[14px] py-3 text-dm-ink no-underline transition-all hover:translate-x-[2px] hover:border-[color:color-mix(in_srgb,var(--color-dm-accent-2)_40%,var(--color-dm-line-strong))] hover:bg-dm-bg-elev"
+              className="group relative flex items-center gap-3 rounded-[10px] border border-dm-line bg-dm-bg px-[14px] py-3 text-dm-ink no-underline transition-[transform,border-color,background-color] hover:translate-x-[2px] hover:border-[color:color-mix(in_srgb,var(--color-dm-accent-2)_40%,var(--color-dm-line-strong))] hover:bg-dm-bg-elev"
               download
               href={`${downloadsConfig.assetsBaseUrl}/${a.filename}`}
               key={a.filename}

--- a/apps/landing/src/components/download/PlatformCard.tsx
+++ b/apps/landing/src/components/download/PlatformCard.tsx
@@ -101,7 +101,7 @@ export function PlatformCard({
           const labelSub = parenMatch ? parenMatch[2] : null
           return (
             <a
-              className="group relative flex items-center gap-3 rounded-[10px] border border-dm-line bg-dm-bg px-[14px] py-3 text-dm-ink no-underline transition-[transform,border-color,background-color] hover:translate-x-[2px] hover:border-[color:color-mix(in_srgb,var(--color-dm-accent-2)_40%,var(--color-dm-line-strong))] hover:bg-dm-bg-elev"
+              className="group relative flex items-center gap-3 rounded-[10px] border border-dm-line bg-dm-bg px-[14px] py-3 text-dm-ink no-underline transition-[transform,border-color,background-color] hover:translate-x-[2px] hover:border-[color:color-mix(in_srgb,var(--color-dm-accent-2)_40%,var(--color-dm-line-strong))] hover:bg-dm-bg-elev active:translate-x-0 active:scale-[0.97]"
               download
               href={`${downloadsConfig.assetsBaseUrl}/${a.filename}`}
               key={a.filename}

--- a/apps/landing/src/components/landing/CtaFinal.tsx
+++ b/apps/landing/src/components/landing/CtaFinal.tsx
@@ -41,7 +41,7 @@ export async function CtaFinal({ locale }: { locale: Locale }) {
           </p>
           <div className="relative flex flex-wrap justify-center gap-3">
             <Link
-              className="inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-transform hover:-translate-y-px"
+              className="inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-transform hover:-translate-y-px active:translate-y-0 active:scale-[0.97]"
               href={`/${locale}/download`}
               style={{
                 background:
@@ -71,7 +71,7 @@ export async function CtaFinal({ locale }: { locale: Locale }) {
               </span>
             </Link>
             <a
-              className="inline-flex items-center gap-2 rounded-[10px] border border-dm-line-strong bg-transparent px-[18px] py-3 font-medium text-[14px] text-dm-ink-2 transition-colors hover:bg-dm-bg-soft hover:text-dm-ink"
+              className="inline-flex items-center gap-2 rounded-[10px] border border-dm-line-strong bg-transparent px-[18px] py-3 font-medium text-[14px] text-dm-ink-2 transition-[color,background-color,border-color,transform] hover:bg-dm-bg-soft hover:text-dm-ink active:scale-[0.97]"
               href="https://github.com/ZingerLittleBee/dockerman.app/issues/new"
               rel="noopener noreferrer"
               target="_blank"

--- a/apps/landing/src/components/landing/CtaFinal.tsx
+++ b/apps/landing/src/components/landing/CtaFinal.tsx
@@ -41,7 +41,7 @@ export async function CtaFinal({ locale }: { locale: Locale }) {
           </p>
           <div className="relative flex flex-wrap justify-center gap-3">
             <Link
-              className="inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-all hover:-translate-y-px"
+              className="inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-transform hover:-translate-y-px"
               href={`/${locale}/download`}
               style={{
                 background:

--- a/apps/landing/src/components/landing/FeaturesGrid.tsx
+++ b/apps/landing/src/components/landing/FeaturesGrid.tsx
@@ -100,7 +100,7 @@ function FeatCard({
 }) {
   return (
     <article
-      className={`relative flex flex-col overflow-hidden rounded-[14px] border border-dm-line bg-dm-bg-elev p-5 transition-all hover:-translate-y-px hover:border-dm-line-strong sm:p-6 ${SHAPE_CLASSES[shape]}`}
+      className={`relative flex flex-col overflow-hidden rounded-[14px] border border-dm-line bg-dm-bg-elev p-5 transition-[transform,border-color] hover:-translate-y-px hover:border-dm-line-strong sm:p-6 ${SHAPE_CLASSES[shape]}`}
     >
       <div
         className="mb-[14px] grid h-8 w-8 place-items-center rounded-[8px]"

--- a/apps/landing/src/components/landing/Hero.tsx
+++ b/apps/landing/src/components/landing/Hero.tsx
@@ -336,7 +336,7 @@ function TerminalCard({ locale }: { locale: Locale }) {
                   width: '0',
                   background:
                     'linear-gradient(90deg, var(--color-dm-accent), var(--color-dm-accent-2))',
-                  animation: 'dm-progress 900ms cubic-bezier(0.22, 1, 0.36, 1) forwards',
+                  animation: 'dm-progress 900ms var(--ease-out-strong) forwards',
                   animationDelay: `${STAGE_STEPS.progress}ms`,
                   ['--dm-progress' as string]: '100%'
                 }}
@@ -374,7 +374,7 @@ function StageLine({
       className={className}
       style={{
         opacity: 0,
-        animation: 'dm-reveal-up 420ms cubic-bezier(0.22, 1, 0.36, 1) forwards',
+        animation: 'dm-reveal-up 420ms var(--ease-out-strong) forwards',
         animationDelay: `${delayMs}ms`
       }}
     >
@@ -401,7 +401,7 @@ function ContainerMini({
       className="flex items-center gap-3 rounded-[10px] border border-dm-line bg-dm-bg-elev px-[14px] py-[10px]"
       style={{
         opacity: 0,
-        animation: 'dm-reveal-up 480ms cubic-bezier(0.22, 1, 0.36, 1) forwards',
+        animation: 'dm-reveal-up 480ms var(--ease-out-strong) forwards',
         animationDelay: `${delayMs}ms`
       }}
     >

--- a/apps/landing/src/components/landing/Hero.tsx
+++ b/apps/landing/src/components/landing/Hero.tsx
@@ -119,7 +119,7 @@ export function Hero({ locale }: { locale: Locale }) {
         <div className="mt-7 flex flex-wrap items-center gap-3">
           {/* Gradient download button */}
           <Link
-            className="inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-transform hover:-translate-y-px"
+            className="inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-transform hover:-translate-y-px active:translate-y-0 active:scale-[0.97]"
             href={`/${locale}/download`}
             style={{
               background:
@@ -146,7 +146,7 @@ export function Hero({ locale }: { locale: Locale }) {
           {/* Inline copy install command */}
           <button
             aria-label={copied ? t('hero.copied') : t('hero.copyAria', { cmd: INSTALL_CMD })}
-            className="inline-flex max-w-full cursor-pointer items-center gap-[10px] rounded-[10px] border border-dm-line bg-dm-bg-elev px-[12px] py-[10px] pr-3 font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-2 transition-colors hover:border-dm-line-strong sm:px-[14px] sm:text-[13px]"
+            className="inline-flex max-w-full cursor-pointer items-center gap-[10px] rounded-[10px] border border-dm-line bg-dm-bg-elev px-[12px] py-[10px] pr-3 font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-2 transition-[color,background-color,border-color,transform] hover:border-dm-line-strong active:scale-[0.97] sm:px-[14px] sm:text-[13px]"
             onClick={copyInstall}
             type="button"
           >

--- a/apps/landing/src/components/landing/Hero.tsx
+++ b/apps/landing/src/components/landing/Hero.tsx
@@ -93,7 +93,7 @@ export function Hero({ locale }: { locale: Locale }) {
         {/* Eyebrow: pulsing dot + version note + NEW tag */}
         <span className="inline-flex items-center gap-[10px] rounded-full border border-dm-line-strong bg-dm-bg-elev px-[10px] py-[5px] font-[var(--font-dm-mono)] text-[12px] text-dm-ink-2">
           <span
-            className="h-[6px] w-[6px] rounded-full"
+            className="dm-animated h-[6px] w-[6px] rounded-full"
             style={{
               background: 'var(--color-dm-ok)',
               boxShadow: '0 0 0 4px color-mix(in srgb, var(--color-dm-ok) 30%, transparent)',

--- a/apps/landing/src/components/landing/Hero.tsx
+++ b/apps/landing/src/components/landing/Hero.tsx
@@ -119,7 +119,7 @@ export function Hero({ locale }: { locale: Locale }) {
         <div className="mt-7 flex flex-wrap items-center gap-3">
           {/* Gradient download button */}
           <Link
-            className="inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-all hover:-translate-y-px"
+            className="inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-transform hover:-translate-y-px"
             href={`/${locale}/download`}
             style={{
               background:

--- a/apps/landing/src/components/landing/LiveDashboard.tsx
+++ b/apps/landing/src/components/landing/LiveDashboard.tsx
@@ -260,7 +260,7 @@ function Main({ t }: { t: TFn }) {
           </MainChip>
           <MainChip>
             <span
-              className="h-[6px] w-[6px] rounded-full"
+              className="dm-animated h-[6px] w-[6px] rounded-full"
               style={{
                 background: 'var(--color-dm-ok)',
                 animation: 'dm-pulse 900ms ease-in-out infinite'

--- a/apps/landing/src/components/pricing/PlanCard.tsx
+++ b/apps/landing/src/components/pricing/PlanCard.tsx
@@ -49,9 +49,9 @@ export function PlanCard(p: PlanCardProps) {
     ribbon
   } = p
 
-  const ctaClassName = `mt-auto inline-flex cursor-pointer items-center justify-center gap-2 rounded-[10px] px-[18px] py-[13px] font-semibold text-[14px] no-underline transition-[transform,background-color,border-color,color] ${
+  const ctaClassName = `mt-auto inline-flex cursor-pointer items-center justify-center gap-2 rounded-[10px] px-[18px] py-[13px] font-semibold text-[14px] no-underline transition-[transform,background-color,border-color,color] active:scale-[0.97] ${
     ctaVariant === 'primary'
-      ? 'text-white hover:-translate-y-px'
+      ? 'text-white hover:-translate-y-px active:translate-y-0'
       : ctaVariant === 'disabled'
         ? 'cursor-not-allowed border border-dm-line bg-dm-bg-soft text-dm-ink-3'
         : 'border border-dm-line-strong bg-transparent text-dm-ink hover:bg-dm-bg-soft'

--- a/apps/landing/src/components/pricing/PlanCard.tsx
+++ b/apps/landing/src/components/pricing/PlanCard.tsx
@@ -49,7 +49,7 @@ export function PlanCard(p: PlanCardProps) {
     ribbon
   } = p
 
-  const ctaClassName = `mt-auto inline-flex cursor-pointer items-center justify-center gap-2 rounded-[10px] px-[18px] py-[13px] font-semibold text-[14px] no-underline transition-all ${
+  const ctaClassName = `mt-auto inline-flex cursor-pointer items-center justify-center gap-2 rounded-[10px] px-[18px] py-[13px] font-semibold text-[14px] no-underline transition-[transform,background-color,border-color,color] ${
     ctaVariant === 'primary'
       ? 'text-white hover:-translate-y-px'
       : ctaVariant === 'disabled'

--- a/apps/landing/src/components/pricing/PricingHero.tsx
+++ b/apps/landing/src/components/pricing/PricingHero.tsx
@@ -23,7 +23,7 @@ export async function PricingHero({
         {earlyBirdActive ? (
           <span className="inline-flex items-center gap-[10px] rounded-full border border-dm-line-strong bg-dm-bg-elev py-[5px] pr-[10px] pl-[6px] font-[var(--font-dm-mono)] text-[12px] text-dm-ink-2">
             <span
-              className="h-[6px] w-[6px] rounded-full"
+              className="dm-animated h-[6px] w-[6px] rounded-full"
               style={{
                 background: 'var(--color-dm-warn)',
                 boxShadow: '0 0 0 4px color-mix(in srgb, var(--color-dm-warn) 30%, transparent)',

--- a/apps/landing/src/components/shell/LocaleSwitch.tsx
+++ b/apps/landing/src/components/shell/LocaleSwitch.tsx
@@ -52,7 +52,7 @@ export function LocaleSwitch({ locale }: { locale: Locale }) {
         aria-expanded={open}
         aria-haspopup="menu"
         aria-label={t('nav.changeLanguage')}
-        className="grid h-8 w-8 cursor-pointer place-items-center rounded-md text-dm-ink-2 transition-colors hover:bg-dm-bg-soft hover:text-dm-ink"
+        className="grid h-8 w-8 cursor-pointer place-items-center rounded-md text-dm-ink-2 transition-[color,background-color,border-color,transform] hover:bg-dm-bg-soft hover:text-dm-ink active:scale-[0.97]"
         onClick={() => setOpen((o) => !o)}
         type="button"
       >
@@ -84,7 +84,7 @@ export function LocaleSwitch({ locale }: { locale: Locale }) {
             return (
               <button
                 aria-current={isActive ? 'true' : undefined}
-                className={`flex w-full cursor-pointer items-center justify-between gap-2 rounded-md px-[10px] py-[7px] text-left text-[13px] transition-colors ${
+                className={`flex w-full cursor-pointer items-center justify-between gap-2 rounded-md px-[10px] py-[7px] text-left text-[13px] transition-[color,background-color,border-color,transform] active:scale-[0.97] ${
                   isActive ? 'text-dm-ink' : 'text-dm-ink-2 hover:bg-dm-bg-soft hover:text-dm-ink'
                 }`}
                 key={code}

--- a/apps/landing/src/components/shell/Navbar.tsx
+++ b/apps/landing/src/components/shell/Navbar.tsx
@@ -142,7 +142,7 @@ export function Navbar({ locale }: { locale: Locale }) {
         />
         {/* Panel */}
         <div
-          className={`absolute inset-x-0 top-full z-50 origin-top border-dm-line border-b bg-dm-bg shadow-[0_20px_40px_-20px_rgb(0_0_0/0.4)] transition-all duration-200 ${
+          className={`absolute inset-x-0 top-full z-50 origin-top border-dm-line border-b bg-dm-bg shadow-[0_20px_40px_-20px_rgb(0_0_0/0.4)] transition-[transform,opacity] duration-200 ease-out-strong ${
             menuOpen ? 'translate-y-0 opacity-100' : '-translate-y-2 opacity-0'
           }`}
           id="dm-mobile-menu"

--- a/apps/landing/src/components/shell/Navbar.tsx
+++ b/apps/landing/src/components/shell/Navbar.tsx
@@ -91,7 +91,7 @@ export function Navbar({ locale }: { locale: Locale }) {
             <RiGithubFill className="h-4 w-4" />
           </a>
           <Link
-            className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg border border-dm-ink bg-dm-ink px-[12px] py-[7px] font-medium text-[12.5px] text-dm-bg transition-transform hover:-translate-y-px sm:px-[14px] sm:py-2 sm:text-[13px]"
+            className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg border border-dm-ink bg-dm-ink px-[12px] py-[7px] font-medium text-[12.5px] text-dm-bg transition-transform hover:-translate-y-px active:translate-y-0 active:scale-[0.97] sm:px-[14px] sm:py-2 sm:text-[13px]"
             href={hrefFor('/download')}
           >
             {t('nav.download')}
@@ -100,7 +100,7 @@ export function Navbar({ locale }: { locale: Locale }) {
             aria-controls="dm-mobile-menu"
             aria-expanded={menuOpen}
             aria-label={menuOpen ? t('nav.closeMenu') : t('nav.openMenu')}
-            className="grid h-8 w-8 cursor-pointer place-items-center rounded-md border border-dm-line bg-dm-bg-elev text-dm-ink-2 transition-colors hover:border-dm-line-strong hover:text-dm-ink md:hidden"
+            className="grid h-8 w-8 cursor-pointer place-items-center rounded-md border border-dm-line bg-dm-bg-elev text-dm-ink-2 transition-[color,background-color,border-color,transform] hover:border-dm-line-strong hover:text-dm-ink active:scale-[0.97] md:hidden"
             onClick={() =>
               setMenu((current) => ({
                 open: current.pathname === pathname ? !current.open : true,

--- a/apps/landing/src/components/shell/Navbar.tsx
+++ b/apps/landing/src/components/shell/Navbar.tsx
@@ -143,7 +143,9 @@ export function Navbar({ locale }: { locale: Locale }) {
         {/* Panel */}
         <div
           className={`absolute inset-x-0 top-full z-50 origin-top border-dm-line border-b bg-dm-bg shadow-[0_20px_40px_-20px_rgb(0_0_0/0.4)] transition-[transform,opacity] duration-200 ease-out-strong ${
-            menuOpen ? 'translate-y-0 opacity-100' : '-translate-y-2 opacity-0'
+            menuOpen
+              ? 'translate-y-0 opacity-100'
+              : '-translate-y-2 opacity-0 motion-reduce:translate-y-0'
           }`}
           id="dm-mobile-menu"
         >

--- a/apps/landing/src/components/snapshot/SnapshotFeaturesStrip.tsx
+++ b/apps/landing/src/components/snapshot/SnapshotFeaturesStrip.tsx
@@ -40,7 +40,7 @@ export async function SnapshotFeaturesStrip({ locale }: { locale: Locale }) {
         <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4 lg:gap-7">
           {FEATURES.map((f) => (
             <article
-              className="rounded-[12px] border border-dm-line bg-dm-bg-elev p-5 pt-[22px] transition-all hover:-translate-y-[2px] hover:border-dm-line-strong"
+              className="rounded-[12px] border border-dm-line bg-dm-bg-elev p-5 pt-[22px] transition-[transform,border-color] hover:-translate-y-[2px] hover:border-dm-line-strong"
               key={f.num}
             >
               <div

--- a/apps/landing/src/components/snapshot/SnapshotShowcase.tsx
+++ b/apps/landing/src/components/snapshot/SnapshotShowcase.tsx
@@ -57,6 +57,21 @@ function getServerHashSnapshot() {
   return ''
 }
 
+function subscribeReducedMotion(listener: () => void) {
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+  mq.addEventListener('change', listener)
+  queueMicrotask(listener)
+  return () => mq.removeEventListener('change', listener)
+}
+
+function getReducedMotionSnapshot() {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function getServerReducedMotionSnapshot() {
+  return false
+}
+
 export interface ShowcaseStrings {
   allModules: string
   moduleTabsAria: string
@@ -89,6 +104,11 @@ export function SnapshotShowcase({
   const [selection, setSelection] = useState({ active: 0, prev: 0 })
   const [lightbox, setLightbox] = useState(false)
   const hash = useSyncExternalStore(subscribeHash, getHashSnapshot, getServerHashSnapshot)
+  const reduced = useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotionSnapshot,
+    getServerReducedMotionSnapshot
+  )
   const appliedHashRef = useRef('')
   const railRef = useRef<HTMLElement | null>(null)
   const mobRef = useRef<HTMLDivElement | null>(null)
@@ -101,32 +121,36 @@ export function SnapshotShowcase({
     stageRef.current?.blur()
   }, [])
 
-  const scrollActiveControls = useCallback((n: number) => {
-    requestAnimationFrame(() => {
-      const nav = railRef.current
-      if (nav && window.innerWidth > 1080) {
-        const link = nav.querySelector<HTMLButtonElement>(`button[data-i="${n}"]`)
-        if (link) {
-          const linkTop = link.offsetTop
-          const linkBottom = linkTop + link.offsetHeight
-          const viewTop = nav.scrollTop
-          const viewBottom = viewTop + nav.clientHeight
-          const margin = 24
-          if (linkTop < viewTop + margin) {
-            nav.scrollTo({ top: Math.max(0, linkTop - margin), behavior: 'smooth' })
-          } else if (linkBottom > viewBottom - margin) {
-            nav.scrollTo({ top: linkBottom - nav.clientHeight + margin, behavior: 'smooth' })
+  const scrollActiveControls = useCallback(
+    (n: number) => {
+      requestAnimationFrame(() => {
+        const behavior: ScrollBehavior = reduced ? 'auto' : 'smooth'
+        const nav = railRef.current
+        if (nav && window.innerWidth > 1080) {
+          const link = nav.querySelector<HTMLButtonElement>(`button[data-i="${n}"]`)
+          if (link) {
+            const linkTop = link.offsetTop
+            const linkBottom = linkTop + link.offsetHeight
+            const viewTop = nav.scrollTop
+            const viewBottom = viewTop + nav.clientHeight
+            const margin = 24
+            if (linkTop < viewTop + margin) {
+              nav.scrollTo({ top: Math.max(0, linkTop - margin), behavior })
+            } else if (linkBottom > viewBottom - margin) {
+              nav.scrollTo({ top: linkBottom - nav.clientHeight + margin, behavior })
+            }
           }
         }
-      }
 
-      const mob = mobRef.current
-      if (mob) {
-        const chip = mob.querySelector<HTMLButtonElement>(`button[data-i="${n}"]`)
-        chip?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' })
-      }
-    })
-  }, [])
+        const mob = mobRef.current
+        if (mob) {
+          const chip = mob.querySelector<HTMLButtonElement>(`button[data-i="${n}"]`)
+          chip?.scrollIntoView({ behavior, block: 'nearest', inline: 'center' })
+        }
+      })
+    },
+    [reduced]
+  )
 
   const setActiveSync = useCallback(
     (n: number) => {
@@ -153,12 +177,12 @@ export function SnapshotShowcase({
       const sentinel = sentinelRefs.current.at(n) ?? null
       const isDesktop = typeof window !== 'undefined' && window.matchMedia(DESKTOP_MQ).matches
       if (sentinel && isDesktop) {
-        sentinel.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        sentinel.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'center' })
         return
       }
       setActiveSync(n)
     },
-    [setActiveSync, total]
+    [reduced, setActiveSync, total]
   )
 
   const onWindowKey = useEffectEvent((e: KeyboardEvent) => {
@@ -294,6 +318,7 @@ export function SnapshotShowcase({
                     modules={modules}
                     onZoom={() => setLightbox(true)}
                     prev={prev}
+                    reduced={reduced}
                     screenshotMissing={strings.screenshotMissing}
                     stageOpenLabel={strings.openLightbox}
                     stageRef={stageRef}
@@ -471,6 +496,7 @@ function Stage({
   modules,
   onZoom,
   prev,
+  reduced,
   screenshotMissing,
   stageOpenLabel,
   stageRef
@@ -479,6 +505,7 @@ function Stage({
   modules: SnapshotModule[]
   onZoom: () => void
   prev: number
+  reduced: boolean
   screenshotMissing: string
   stageOpenLabel: string
   stageRef: React.RefObject<HTMLButtonElement | null>
@@ -502,6 +529,7 @@ function Stage({
             key={m.key}
             missing={screenshotMissing}
             prev={isPrev}
+            reduced={reduced}
             src={m.src}
           />
         )
@@ -515,21 +543,30 @@ function Slide({
   alt,
   missing,
   prev,
+  reduced,
   src
 }: {
   active: boolean
   alt: string
   missing: string
   prev: boolean
+  reduced: boolean
   src: string | null
 }) {
   const visible = active || prev
-  const style: React.CSSProperties = {
-    transition: 'opacity 0.45s var(--ease-out-strong), clip-path 0.55s var(--ease-out-strong)',
-    opacity: visible ? 1 : 0,
-    clipPath: active ? 'inset(0 0 0 0)' : prev ? 'inset(0 0 0 0)' : 'inset(0 0 0 100%)',
-    zIndex: active ? 2 : prev ? 1 : 0
-  }
+  const style: React.CSSProperties = reduced
+    ? {
+        transition: 'opacity 0.2s ease-out',
+        opacity: visible ? 1 : 0,
+        clipPath: 'inset(0 0 0 0)',
+        zIndex: active ? 2 : prev ? 1 : 0
+      }
+    : {
+        transition: 'opacity 0.45s var(--ease-out-strong), clip-path 0.55s var(--ease-out-strong)',
+        opacity: visible ? 1 : 0,
+        clipPath: active ? 'inset(0 0 0 0)' : prev ? 'inset(0 0 0 0)' : 'inset(0 0 0 100%)',
+        zIndex: active ? 2 : prev ? 1 : 0
+      }
   if (src) {
     return (
       <Image

--- a/apps/landing/src/components/snapshot/SnapshotShowcase.tsx
+++ b/apps/landing/src/components/snapshot/SnapshotShowcase.tsx
@@ -220,7 +220,7 @@ export function SnapshotShowcase({
           {modules.map((m, i) => (
             <button
               aria-label={m.showLabel}
-              className={`flex shrink-0 items-center gap-[7px] rounded-full border px-3 py-[8px] font-medium text-[13px] transition-colors ${
+              className={`flex shrink-0 items-center gap-[7px] rounded-full border px-3 py-[8px] font-medium text-[13px] transition-[color,background-color,border-color,transform] active:scale-[0.97] ${
                 i === active
                   ? 'border-dm-ink bg-dm-ink text-dm-bg'
                   : 'border-dm-line-strong bg-dm-bg-elev text-dm-ink-3'
@@ -346,7 +346,7 @@ function RailItem({
   return (
     <button
       aria-current={active ? 'true' : undefined}
-      className={`grid w-full cursor-pointer grid-cols-[28px_1fr_auto] items-center gap-3 rounded-[8px] border px-3 py-[10px] text-left font-[inherit] text-[13.5px] transition-colors ${
+      className={`grid w-full cursor-pointer grid-cols-[28px_1fr_auto] items-center gap-3 rounded-[8px] border px-3 py-[10px] text-left font-[inherit] text-[13.5px] transition-[color,background-color,border-color,transform] active:scale-[0.97] ${
         active
           ? 'border-dm-line-strong bg-dm-bg-elev text-dm-ink'
           : 'border-transparent text-dm-ink-3 hover:bg-dm-bg-soft hover:text-dm-ink-2'
@@ -447,7 +447,7 @@ function TopbarBtn({
   return (
     <button
       aria-label={ariaLabel}
-      className="grid h-[28px] w-[28px] cursor-pointer place-items-center rounded-[6px] border border-dm-line bg-dm-bg-soft text-dm-ink-3 transition-colors hover:border-dm-line-strong hover:bg-dm-bg-elev hover:text-dm-ink"
+      className="grid h-[28px] w-[28px] cursor-pointer place-items-center rounded-[6px] border border-dm-line bg-dm-bg-soft text-dm-ink-3 transition-[color,background-color,border-color,transform] hover:border-dm-line-strong hover:bg-dm-bg-elev hover:text-dm-ink active:scale-[0.97]"
       onClick={onClick}
       type="button"
     >
@@ -610,7 +610,7 @@ function CaptionStrip({
       </div>
       <div className="flex gap-2">
         <a
-          className="inline-flex cursor-pointer items-center gap-[7px] rounded-[8px] border border-dm-line bg-dm-bg-soft px-3 py-[7px] font-medium text-[12.5px] text-dm-ink-2 transition-colors hover:border-dm-line-strong hover:bg-dm-bg-elev hover:text-dm-ink"
+          className="inline-flex cursor-pointer items-center gap-[7px] rounded-[8px] border border-dm-line bg-dm-bg-soft px-3 py-[7px] font-medium text-[12.5px] text-dm-ink-2 transition-[color,background-color,border-color,transform] hover:border-dm-line-strong hover:bg-dm-bg-elev hover:text-dm-ink active:scale-[0.97]"
           href={strings.docsHref}
         >
           <svg
@@ -629,7 +629,7 @@ function CaptionStrip({
           {strings.docs}
         </a>
         <button
-          className="inline-flex cursor-pointer items-center gap-[7px] rounded-[8px] border border-dm-line bg-dm-bg-soft px-3 py-[7px] font-medium text-[12.5px] text-dm-ink-2 transition-colors hover:border-dm-line-strong hover:bg-dm-bg-elev hover:text-dm-ink"
+          className="inline-flex cursor-pointer items-center gap-[7px] rounded-[8px] border border-dm-line bg-dm-bg-soft px-3 py-[7px] font-medium text-[12.5px] text-dm-ink-2 transition-[color,background-color,border-color,transform] hover:border-dm-line-strong hover:bg-dm-bg-elev hover:text-dm-ink active:scale-[0.97]"
           onClick={() => {
             onCopyLink()
             setCopied(true)
@@ -680,7 +680,7 @@ function Lightbox({
     >
       <button
         aria-label={title}
-        className="absolute top-5 right-5 grid h-10 w-10 cursor-pointer place-items-center rounded-full border-0 text-white"
+        className="absolute top-5 right-5 grid h-10 w-10 cursor-pointer place-items-center rounded-full border-0 text-white transition-transform active:scale-[0.97]"
         onClick={(e) => {
           e.stopPropagation()
           onClose()

--- a/apps/landing/src/components/snapshot/SnapshotShowcase.tsx
+++ b/apps/landing/src/components/snapshot/SnapshotShowcase.tsx
@@ -525,8 +525,7 @@ function Slide({
 }) {
   const visible = active || prev
   const style: React.CSSProperties = {
-    transition:
-      'opacity 0.45s cubic-bezier(0.22, 1, 0.36, 1), clip-path 0.55s cubic-bezier(0.22, 1, 0.36, 1)',
+    transition: 'opacity 0.45s var(--ease-out-strong), clip-path 0.55s var(--ease-out-strong)',
     opacity: visible ? 1 : 0,
     clipPath: active ? 'inset(0 0 0 0)' : prev ? 'inset(0 0 0 0)' : 'inset(0 0 0 100%)',
     zIndex: active ? 2 : prev ? 1 : 0

--- a/apps/landing/src/components/ui/Sparkline.tsx
+++ b/apps/landing/src/components/ui/Sparkline.tsx
@@ -10,7 +10,7 @@ interface SparklineProps {
 }
 
 const PATH_TRANSITION = {
-  transition: 'd 1200ms cubic-bezier(0.22, 1, 0.36, 1)'
+  transition: 'd 1200ms var(--ease-out-strong)'
 } as const
 
 type Point = readonly [number, number]

--- a/packages/shared/src/components/LenisProvider.tsx
+++ b/packages/shared/src/components/LenisProvider.tsx
@@ -1,8 +1,33 @@
 'use client'
 
 import { ReactLenis } from 'lenis/react'
+import { useSyncExternalStore } from 'react'
+
+function subscribeReducedMotion(listener: () => void) {
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+  mq.addEventListener('change', listener)
+  return () => mq.removeEventListener('change', listener)
+}
+
+function getReducedMotionSnapshot() {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function getServerReducedMotionSnapshot() {
+  return false
+}
 
 export function LenisProvider({ children }: { children: React.ReactNode }) {
+  const reduced = useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotionSnapshot,
+    getServerReducedMotionSnapshot
+  )
+
+  if (reduced) {
+    return <>{children}</>
+  }
+
   return (
     <ReactLenis
       options={{

--- a/plans/001-motion-easing-tokens.md
+++ b/plans/001-motion-easing-tokens.md
@@ -1,0 +1,94 @@
+# 001 — Extract shared easing tokens and consolidate duplicate curves
+
+- **Status**: DONE (commit 305c4fc)
+- **Commit**: 7955cd6
+- **Severity**: MEDIUM
+- **Category**: Cohesion & tokens
+- **Estimated scope**: 4 files (globals.css, Hero.tsx, Sparkline.tsx, SnapshotShowcase.tsx) + DESIGN.md, ~15 line edits
+
+## Problem
+
+The codebase has no named easing token layer. Three near-identical "strong ease-out" curves coexist, splitting the motion vocabulary:
+
+- `cubic-bezier(0.16, 1, 0.3, 1)` — hand-typed 7× inside `--animate-*` strings in `apps/landing/src/app/globals.css:17-30`
+- `cubic-bezier(0.22, 1, 0.36, 1)` — hand-typed in `apps/landing/src/components/landing/Hero.tsx:339`, `Hero.tsx:377`, `Hero.tsx:404`, `apps/landing/src/components/ui/Sparkline.tsx:13`, `apps/landing/src/components/snapshot/SnapshotShowcase.tsx:529`
+- `cubic-bezier(0.33, 1, 0.68, 1)` — accordion tokens `globals.css:25-26` (out of scope here, see plan 007)
+
+```css
+/* apps/landing/src/app/globals.css:17-30 — current */
+--animate-hide: hide 150ms cubic-bezier(0.16, 1, 0.3, 1);
+--animate-slideDownAndFade: slideDownAndFade 150ms
+  cubic-bezier(0.16, 1, 0.3, 1);
+--animate-slideLeftAndFade: slideLeftAndFade 150ms
+  cubic-bezier(0.16, 1, 0.3, 1);
+--animate-slideUpAndFade: slideUpAndFade 150ms cubic-bezier(0.16, 1, 0.3, 1);
+--animate-slideRightAndFade: slideRightAndFade 150ms
+  cubic-bezier(0.16, 1, 0.3, 1);
+--animate-accordionOpen: accordionOpen 250ms cubic-bezier(0.33, 1, 0.68, 1);
+--animate-accordionClose: accordionClose 200ms cubic-bezier(0.33, 1, 0.68, 1);
+--animate-dialogOverlayShow: dialogOverlayShow 150ms
+  cubic-bezier(0.16, 1, 0.3, 1);
+--animate-dialogContentShow: dialogContentShow 150ms
+  cubic-bezier(0.16, 1, 0.3, 1);
+```
+
+```ts
+// apps/landing/src/components/ui/Sparkline.tsx:12-14 — current
+const PATH_TRANSITION = {
+  transition: 'd 1200ms cubic-bezier(0.22, 1, 0.36, 1)'
+} as const
+```
+
+```tsx
+// apps/landing/src/components/snapshot/SnapshotShowcase.tsx:528-529 — current
+transition:
+  'opacity 0.45s cubic-bezier(0.22, 1, 0.36, 1), clip-path 0.55s cubic-bezier(0.22, 1, 0.36, 1)',
+```
+
+Every future component re-invents the curve by hand; the two ease-out variants drift for no design reason.
+
+## Target
+
+One canonical strong ease-out and one strong ease-in-out, defined as Tailwind v4 `@theme` variables (which also generates `ease-out-strong` / `ease-in-out-strong` utility classes):
+
+```css
+/* add inside the FIRST @theme block in apps/landing/src/app/globals.css (the one starting at line 11), right after --font-sans-zh */
+--ease-out-strong: cubic-bezier(0.22, 1, 0.36, 1);
+--ease-in-out-strong: cubic-bezier(0.77, 0, 0.175, 1);
+```
+
+The canonical value is `0.22, 1, 0.36, 1` because DESIGN.md §5.1 already settles it for the sparkline; `0.16, 1, 0.3, 1` usages migrate onto it (visually near-identical). `--ease-in-out-strong` follows the audit reference value `cubic-bezier(0.77, 0, 0.175, 1)` and is consumed by later plans (007).
+
+All hand-typed occurrences of both ease-out curves become `var(--ease-out-strong)`.
+
+## Repo conventions to follow
+
+- All design tokens live in `apps/landing/src/app/globals.css` under `@theme` (see the `--animate-*` block at lines 17-33 and the `dm-*` color block at lines 150-174). Add the new tokens to the first `@theme` block.
+- Tailwind v4: a `--ease-<name>` theme variable automatically creates an `ease-<name>` utility.
+- `DESIGN.md` is the living design-language reference; token additions must be documented there (§1.7 Motion).
+
+## Steps
+
+1. `apps/landing/src/app/globals.css` — in the first `@theme` block, after the `--font-sans-zh` declaration, add the two token lines from Target.
+2. Same file, lines 17-30 — replace all seven occurrences of `cubic-bezier(0.16, 1, 0.3, 1)` with `var(--ease-out-strong)`. Do NOT touch the two accordion lines (25-26) or the `--animate-slide-down-fade`/`--animate-slide-up-fade` lines (31-32).
+3. `apps/landing/src/components/landing/Hero.tsx` — replace `cubic-bezier(0.22, 1, 0.36, 1)` with `var(--ease-out-strong)` at line 339 (`animation: 'dm-progress 900ms …'`), line 377 (StageLine `animation: 'dm-reveal-up 420ms …'`), line 404 (ContainerMini `animation: 'dm-reveal-up 480ms …'`).
+4. `apps/landing/src/components/ui/Sparkline.tsx:13` — change to `transition: 'd 1200ms var(--ease-out-strong)'`.
+5. `apps/landing/src/components/snapshot/SnapshotShowcase.tsx:528-529` — change to `'opacity 0.45s var(--ease-out-strong), clip-path 0.55s var(--ease-out-strong)'`.
+6. `DESIGN.md` §1.7 Motion — document the two tokens: name, value, and rule of use ("entrances/exits and reveals use `--ease-out-strong`; on-screen morphs use `--ease-in-out-strong`; never hand-type a cubic-bezier in a component").
+
+## Boundaries
+
+- Do NOT touch `--animate-accordionOpen/Close` or `AccordionTrigger.tsx` (plan 007 owns the accordion).
+- Do NOT touch `--animate-slide-down-fade` / `--animate-slide-up-fade` (plan 005 owns them).
+- Do NOT change any duration or keyframe definition — easing values only.
+- Do NOT add new dependencies.
+- If a cited line doesn't match the code you find (drift since commit 7955cd6), STOP and report instead of improvising.
+
+## Verification
+
+- **Mechanical**: `bun run check` from repo root passes (biome/ultracite). `cd apps/landing && bunx tsc --noEmit` passes. Grep proof: `grep -rn "cubic-bezier(0.16, 1, 0.3, 1)\|cubic-bezier(0.22, 1, 0.36, 1)" apps/landing/src` returns ONLY the token definition line.
+- **Feel check**: `bun run dev:landing`, then:
+  - Hover a tooltip on /pricing (TrustBar) — entrance still eases out crisply, no visible change from before.
+  - Watch the hero terminal animation on / — reveal timing unchanged.
+  - On / LiveDashboard, sparkline curves still morph smoothly on data ticks.
+- **Done when**: the greps above are clean, both tokens exist in `@theme`, DESIGN.md documents them, and the site renders with visually unchanged motion.

--- a/plans/002-lenis-reduced-motion.md
+++ b/plans/002-lenis-reduced-motion.md
@@ -1,0 +1,111 @@
+# 002 — Disable Lenis smooth scrolling for reduced-motion users
+
+- **Status**: DONE (commit d82fb14)
+- **Commit**: 7955cd6
+- **Severity**: HIGH
+- **Category**: Accessibility
+- **Estimated scope**: 1 file (LenisProvider.tsx), ~25 lines
+
+## Problem
+
+Lenis smooth scrolling is mounted app-wide with no `prefers-reduced-motion` handling. Lenis does not auto-disable for reduced motion, so users who asked the OS for less motion get inescapable scroll smoothing/inertia on every scroll of every page — the single highest-frequency motion on the site.
+
+```tsx
+// packages/shared/src/components/LenisProvider.tsx:1-18 — current (entire file)
+'use client'
+
+import { ReactLenis } from 'lenis/react'
+
+export function LenisProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <ReactLenis
+      options={{
+        lerp: 0.1,
+        duration: 1.2,
+        smoothWheel: true
+      }}
+      root
+    >
+      {children}
+    </ReactLenis>
+  )
+}
+```
+
+Mounted at `apps/landing/src/app/[locale]/(main)/layout.tsx:18-25`.
+
+## Target
+
+When `(prefers-reduced-motion: reduce)` matches, render children with native scrolling (no `ReactLenis` at all). React to live changes of the media query.
+
+```tsx
+// packages/shared/src/components/LenisProvider.tsx — target (entire file)
+'use client'
+
+import { ReactLenis } from 'lenis/react'
+import { useSyncExternalStore } from 'react'
+
+function subscribeReducedMotion(listener: () => void) {
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+  mq.addEventListener('change', listener)
+  return () => mq.removeEventListener('change', listener)
+}
+
+function getReducedMotionSnapshot() {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function getServerReducedMotionSnapshot() {
+  return false
+}
+
+export function LenisProvider({ children }: { children: React.ReactNode }) {
+  const reduced = useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotionSnapshot,
+    getServerReducedMotionSnapshot
+  )
+
+  if (reduced) {
+    return <>{children}</>
+  }
+
+  return (
+    <ReactLenis
+      options={{
+        lerp: 0.1,
+        duration: 1.2,
+        smoothWheel: true
+      }}
+      root
+    >
+      {children}
+    </ReactLenis>
+  )
+}
+```
+
+## Repo conventions to follow
+
+- The `useSyncExternalStore` + `matchMedia` reduced-motion pattern is the established convention — exemplar: `apps/landing/src/components/landing/PaletteViz.tsx:83-96` (`subscribeReducedMotion` / `getReducedMotionSnapshot` / `getServerReducedMotionSnapshot`).
+- Server snapshot returns `false` (SSR renders the animated variant; the client corrects on hydration) — same as PaletteViz.
+
+## Steps
+
+1. Replace the entire contents of `packages/shared/src/components/LenisProvider.tsx` with the Target code above.
+
+## Boundaries
+
+- Do NOT touch `apps/landing/src/app/[locale]/(main)/layout.tsx` — the provider stays mounted; it self-disables.
+- Do NOT change the Lenis options (`lerp`, `duration`, `smoothWheel`) for the non-reduced path.
+- Do NOT add new dependencies.
+- If the file differs from the excerpt above (drift since commit 7955cd6), STOP and report.
+
+## Verification
+
+- **Mechanical**: `bun run check` passes; `cd apps/landing && bunx tsc --noEmit` passes.
+- **Feel check**: `bun run dev:landing`, open / in Chrome:
+  - DevTools → Rendering panel → "Emulate CSS media feature prefers-reduced-motion: reduce" → scroll with the wheel: scrolling is native and immediate, no inertia/lerp tail.
+  - Turn emulation off, reload → scrolling is smooth again (Lenis active).
+  - Toggle the emulation WITHOUT reloading → behavior switches live (the `change` listener works).
+- **Done when**: both scroll behaviors are observable under emulation toggle and no hydration warning appears in the console.

--- a/plans/003-global-anchor-transition.md
+++ b/plans/003-global-anchor-transition.md
@@ -1,0 +1,52 @@
+# 003 — Scope the global anchor transition to color properties
+
+- **Status**: DONE (commit 03943ec)
+- **Commit**: 7955cd6
+- **Severity**: HIGH
+- **Category**: Performance
+- **Estimated scope**: 1 file (globals.css), 1 line
+
+## Problem
+
+Every `<a>` on the site carries `transition-all`, so the browser watches every animatable property (layout properties included) on every link, site-wide — docs, changelog, nav, footer, MDX body links. Only text color and underline color actually change on hover.
+
+```css
+/* apps/landing/src/app/globals.css:321-323 — current */
+a {
+  @apply scroll-my-24 decoration-gray-400 transition-all;
+}
+```
+
+`transition: all` is an unconditional performance finding: it animates unintended properties off-GPU (e.g. a link whose `padding`/`width` changes from a class toggle would animate layout).
+
+## Target
+
+```css
+/* apps/landing/src/app/globals.css:321-323 — target */
+a {
+  @apply scroll-my-24 decoration-gray-400 transition-[color,text-decoration-color];
+}
+```
+
+## Repo conventions to follow
+
+- This rule lives in plain CSS with `@apply` in `globals.css`; keep the `@apply` form.
+- Component-level links that need to animate transform (e.g. CTA buttons with `hover:-translate-y-px`) already declare their own `transition-*` utility on the element, which overrides this base rule — they are unaffected (their cleanup is plan 006).
+
+## Steps
+
+1. `apps/landing/src/app/globals.css:322` — replace `transition-all` with `transition-[color,text-decoration-color]`.
+
+## Boundaries
+
+- Do NOT touch any component file — this plan is exactly one line.
+- Do NOT remove `scroll-my-24` or `decoration-gray-400`.
+- If the line doesn't match the excerpt (drift since commit 7955cd6), STOP and report.
+
+## Verification
+
+- **Mechanical**: `bun run check` passes; `cd apps/landing && bun run build` succeeds. Grep proof: `grep -n "transition-all" apps/landing/src/app/globals.css` returns nothing.
+- **Feel check**: `bun run dev:landing`:
+  - Hover a nav link and a docs body link — color still eases (~150ms), identical to before.
+  - Hover the hero download CTA — the 1px lift still animates (it has its own transition utility).
+- **Done when**: the grep is clean and link hover color still transitions.

--- a/plans/004-reduced-motion-gate-end-state.md
+++ b/plans/004-reduced-motion-gate-end-state.md
@@ -1,0 +1,84 @@
+# 004 — Make the reduced-motion gate land animations at their end state
+
+- **Status**: DONE (commit 33067d2)
+- **Commit**: 7955cd6
+- **Severity**: MEDIUM
+- **Category**: Accessibility
+- **Estimated scope**: 1 file (globals.css), ~6 lines
+
+## Problem
+
+The reduced-motion gate kills animations with `animation: none`, but several elements inside the gated `.dm-animated` subtree (the hero terminal stage, `Hero.tsx:241`) depend on `animation-fill-mode: forwards` to ever REACH their visible state — they start at inline `opacity: 0` or `width: 0`:
+
+```css
+/* apps/landing/src/app/globals.css:276-282 — current */
+@media (prefers-reduced-motion: reduce) {
+  .dm-animated,
+  .dm-animated * {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+```
+
+```tsx
+// apps/landing/src/components/landing/Hero.tsx:375-379 — StageLine (current)
+style={{
+  opacity: 0,
+  animation: 'dm-reveal-up 420ms cubic-bezier(0.22, 1, 0.36, 1) forwards',
+  animationDelay: `${delayMs}ms`
+}}
+```
+
+Same pattern: `Hero.tsx:402-406` (ContainerMini, `opacity: 0`), `Hero.tsx:335-342` (progress bar, `width: '0'`), `Hero.tsx:300-309` (typewriter span, `width: '0'`).
+
+With `animation: none`, reduced-motion users on xl viewports see the hero right column permanently broken: invisible command text, empty log lines, blank container cards, a 0-width progress bar. Reduced motion should mean fewer/gentler animations, not a stranded initial state.
+
+## Target
+
+Instead of removing animations, force them to complete instantly — `forwards` fill then lands every element at its end state, and infinite loops freeze after one micro-iteration:
+
+```css
+/* apps/landing/src/app/globals.css:276-282 — target */
+@media (prefers-reduced-motion: reduce) {
+  .dm-animated,
+  .dm-animated * {
+    animation-duration: 0.01ms !important;
+    animation-delay: 0ms !important;
+    animation-iteration-count: 1 !important;
+    transition: none !important;
+  }
+}
+```
+
+End states this produces (all verified against the keyframes in globals.css):
+- `dm-reveal-up` → `opacity: 1; translateY(0)` — lines/cards visible ✔
+- `dm-type` → full command width ✔ (`dm-caret` → transparent caret, fine)
+- `dm-progress` → full-width bar ✔
+- `dm-pulse` → `opacity: 1` (its 0%/100% frame) — static dot ✔
+- `dm-spark` → `scaleY(0.4)` (its 0%/100% frame) — static short bars, acceptable ✔
+
+## Repo conventions to follow
+
+- The `.dm-animated` gating scheme itself is documented in DESIGN.md §1.7 and stays; only the mechanism inside the media query changes.
+- Update the DESIGN.md §1.7 sentence "disables `.dm-animated` transitions/animations" to say animations complete instantly at their end state instead.
+
+## Steps
+
+1. `apps/landing/src/app/globals.css:276-282` — replace `animation: none !important;` with the three `animation-*` lines from Target. Keep `transition: none !important;`.
+2. `DESIGN.md` §1.7 — adjust the reduced-motion sentence as described above.
+
+## Boundaries
+
+- Do NOT touch Hero.tsx or any component — the fix is entirely in the media query.
+- Do NOT remove `transition: none !important`.
+- Do NOT change the keyframes.
+- If the gate block differs from the excerpt (drift since commit 7955cd6), STOP and report.
+
+## Verification
+
+- **Mechanical**: `bun run check` passes.
+- **Feel check**: `bun run dev:landing`, open / at a viewport ≥1280px wide:
+  - DevTools → Rendering → emulate `prefers-reduced-motion: reduce` → reload. The hero right column shows the FULL terminal state immediately: complete command line, all `==>` log lines, full gradient progress bar, all three container cards visible. Nothing pulses or types.
+  - Turn emulation off → reload → the typing/reveal sequence plays as before.
+- **Done when**: under reduced-motion emulation the hero stage is fully rendered and static; without it, the animation sequence is unchanged.

--- a/plans/005-entrance-token-duration-easing.md
+++ b/plans/005-entrance-token-duration-easing.md
@@ -1,0 +1,82 @@
+# 005 — Fix the slide-fade entrance tokens: real duration, ease-out family
+
+- **Status**: DONE (commit fdd27be)
+- **Commit**: 7955cd6
+- **Severity**: MEDIUM
+- **Category**: Easing & duration / correctness
+- **Estimated scope**: 3 files (globals.css, about page, pricing success page), ~8 lines
+
+## Problem
+
+The two shared entrance tokens declare no duration — the CSS `animation` shorthand then defaults to `0s`, so the token is a no-op on its own — and use `ease-in-out`, the wrong easing family for an entrance (entrances should start fast: ease-out):
+
+```css
+/* apps/landing/src/app/globals.css:31-32 — current */
+--animate-slide-down-fade: slide-down-fade ease-in-out forwards;
+--animate-slide-up-fade: slide-up-fade ease-in-out forwards;
+```
+
+Both consumers are forced to patch the missing duration inline:
+
+```tsx
+// apps/landing/src/app/[locale]/(main)/about/page.tsx:44-51 — current
+<section
+  aria-labelledby="about-overview"
+  className="animate-slide-up-fade"
+  style={{
+    animationDuration: '600ms',
+    animationFillMode: 'backwards'
+  }}
+>
+```
+
+```tsx
+// apps/landing/src/app/[locale]/(main)/pricing/success/page.tsx:14-17 — current
+<section
+  className="max-w-lg animate-slide-up-fade text-center"
+  style={{ animationDuration: '600ms', animationFillMode: 'backwards' }}
+>
+```
+
+## Target
+
+Self-contained tokens with a real duration, a strong ease-out, and `both` fill (covers both the delay window and the end state); consumers drop their inline patches:
+
+```css
+/* apps/landing/src/app/globals.css:31-32 — target */
+--animate-slide-down-fade: slide-down-fade 600ms var(--ease-out-strong) both;
+--animate-slide-up-fade: slide-up-fade 600ms var(--ease-out-strong) both;
+```
+
+600ms is kept: these are rare, first-view marketing entrances (about page, checkout success), where longer-than-UI durations are allowed.
+
+`--ease-out-strong` is `cubic-bezier(0.22, 1, 0.36, 1)`. If plan 001 has not run yet and the token does not exist in globals.css, add it to the first `@theme` block (after `--font-sans-zh`):
+
+```css
+--ease-out-strong: cubic-bezier(0.22, 1, 0.36, 1);
+```
+
+## Repo conventions to follow
+
+- `--animate-*` tokens in the first `@theme` block of `apps/landing/src/app/globals.css` are the animation vocabulary; consumers use the generated `animate-<name>` utility with no inline style. Exemplar of a complete token: `--animate-fade-in: fade-in 200ms ease-out;` (globals.css:33).
+
+## Steps
+
+1. `apps/landing/src/app/globals.css:31-32` — replace with the two Target lines. Ensure `--ease-out-strong` exists (see Target; add if missing).
+2. `apps/landing/src/app/[locale]/(main)/about/page.tsx:44-51` — delete the whole `style={{ animationDuration: '600ms', animationFillMode: 'backwards' }}` prop; keep `className="animate-slide-up-fade"`.
+3. `apps/landing/src/app/[locale]/(main)/pricing/success/page.tsx:14-17` — same deletion; keep `className="max-w-lg animate-slide-up-fade text-center"`.
+
+## Boundaries
+
+- Do NOT change the keyframes `slide-up-fade` (globals.css:117-126) or `slide-down-fade` (globals.css:127-136).
+- Do NOT touch any other `--animate-*` token.
+- Do NOT add new dependencies.
+- If the cited lines differ (drift since commit 7955cd6), STOP and report.
+
+## Verification
+
+- **Mechanical**: `bun run check` passes; `cd apps/landing && bunx tsc --noEmit` passes. Grep proof: `grep -rn "animationDuration" apps/landing/src/app` returns nothing.
+- **Feel check**: `bun run dev:landing`:
+  - Open /en/about — the page content slides up 12px and fades in over ~600ms, starting FAST and settling gently (ease-out). Compare with DevTools Animations panel at 10% speed: the largest movement happens in the first third.
+  - The animation must actually play (before this fix the token alone was 0s — verify duration shows ~600ms in the Animations panel).
+- **Done when**: both pages animate identically to before (600ms) but via the token alone, with ease-out character, and no inline animation styles remain.

--- a/plans/006-transition-all-sweep.md
+++ b/plans/006-transition-all-sweep.md
@@ -1,0 +1,77 @@
+# 006 — Replace component-level transition-all with explicit property lists
+
+- **Status**: DONE (commit 68fd0e8)
+- **Commit**: 7955cd6
+- **Severity**: MEDIUM
+- **Category**: Performance (+ one easing-family fix)
+- **Estimated scope**: 9 files, 10 class-string edits
+
+## Problem
+
+Nine components use `transition-all`, which makes the browser watch every animatable property when only 1–3 actually change. One of them (`buttonVariants`) also uses `ease-in-out` for what is a hover color change (hover/color transitions should use plain `ease`). The mobile nav drawer entrance additionally inherits Tailwind's weak default easing where an ease-out belongs.
+
+Each current class string is quoted in the Steps table below, verbatim from commit 7955cd6.
+
+## Target
+
+Every `transition-all` becomes `transition-[<exact properties that change>]`. Durations are unchanged unless noted. `--ease-out-strong` is `cubic-bezier(0.22, 1, 0.36, 1)`; if it does not yet exist in `apps/landing/src/app/globals.css` (plan 001 not run), add to the first `@theme` block:
+
+```css
+--ease-out-strong: cubic-bezier(0.22, 1, 0.36, 1);
+```
+
+## Repo conventions to follow
+
+- Hover behavior is settled by DESIGN.md §3.3 (1px lift, border firming, ~150ms) — do not change what animates, only which properties are listed.
+- Tailwind arbitrary transition property lists use underscores for none — plain commas work: `transition-[transform,border-color]`.
+
+## Steps
+
+Apply each replacement exactly. Only the `transition-*`/`ease-*` fragment of the class string changes; everything else stays.
+
+1. `apps/landing/src/components/buttonVariants.ts:6`
+   - old fragment: `transition-all duration-100 ease-in-out`
+   - new fragment: `transition-[color,background-color,border-color,box-shadow] duration-100 ease-[ease]`
+   (hover here changes bg/border/text color and shadow; hover/color → plain `ease`)
+2. `apps/landing/src/components/landing/FeaturesGrid.tsx:103`
+   - old: `... p-5 transition-all hover:-translate-y-px hover:border-dm-line-strong sm:p-6 ...`
+   - new: `... p-5 transition-[transform,border-color] hover:-translate-y-px hover:border-dm-line-strong sm:p-6 ...`
+3. `apps/landing/src/components/snapshot/SnapshotFeaturesStrip.tsx:43`
+   - old: `... pt-[22px] transition-all hover:-translate-y-[2px] hover:border-dm-line-strong`
+   - new: `... pt-[22px] transition-[transform,border-color] hover:-translate-y-[2px] hover:border-dm-line-strong`
+4. `apps/landing/src/components/download/PlatformCard.tsx:54`
+   - old: `... rounded-[14px] border p-6 transition-all hover:-translate-y-px`
+   - new: `... rounded-[14px] border p-6 transition-transform hover:-translate-y-px`
+5. `apps/landing/src/components/download/PlatformCard.tsx:104`
+   - old: `... no-underline transition-all hover:translate-x-[2px] hover:border-[color:color-mix(in_srgb,var(--color-dm-accent-2)_40%,var(--color-dm-line-strong))] hover:bg-dm-bg-elev`
+   - new: `... no-underline transition-[transform,border-color,background-color] hover:translate-x-[2px] hover:border-[color:color-mix(in_srgb,var(--color-dm-accent-2)_40%,var(--color-dm-line-strong))] hover:bg-dm-bg-elev`
+6. `apps/landing/src/components/pricing/PlanCard.tsx:52` (the `ctaClassName` template literal)
+   - old fragment: `no-underline transition-all`
+   - new fragment: `no-underline transition-[transform,background-color,border-color,color]`
+7. `apps/landing/src/components/landing/Hero.tsx:122` (gradient download Link)
+   - old fragment: `no-underline transition-all hover:-translate-y-px`
+   - new fragment: `no-underline transition-transform hover:-translate-y-px`
+8. `apps/landing/src/components/landing/CtaFinal.tsx:44`
+   - old fragment: `no-underline transition-all hover:-translate-y-px`
+   - new fragment: `no-underline transition-transform hover:-translate-y-px`
+9. `apps/landing/src/components/shell/Navbar.tsx:145` (mobile menu panel)
+   - old fragment: `... shadow-[0_20px_40px_-20px_rgb(0_0_0/0.4)] transition-all duration-200`
+   - new fragment: `... shadow-[0_20px_40px_-20px_rgb(0_0_0/0.4)] transition-[transform,opacity] duration-200 ease-out-strong`
+   (entrance → strong ease-out; requires the `--ease-out-strong` token, see Target)
+
+## Boundaries
+
+- Do NOT touch `globals.css:322` (`a { transition-all }`) — that is plan 003.
+- Do NOT change which properties animate on hover, any duration except adding the Navbar easing, or any markup.
+- Do NOT touch `packages/shared` or fumadocs styling.
+- If any old fragment is not found verbatim (drift since commit 7955cd6), STOP and report that item; apply the rest.
+
+## Verification
+
+- **Mechanical**: `bun run check` passes; `cd apps/landing && bun run build` succeeds. Grep proof: `grep -rn "transition-all" apps/landing/src --include='*.tsx' --include='*.ts'` returns nothing.
+- **Feel check**: `bun run dev:landing`:
+  - Hover a features card on / — it still lifts 1px and firms its border, smoothly.
+  - Hover the hero download CTA and a pricing CTA — 1px lift unchanged.
+  - Hover a `buttonVariants` button (e.g. docs UI) — background color still eases, now with `ease`.
+  - On a narrow viewport, open the mobile menu — the panel slides down/fades with a fast-start (ease-out) character; at 10% speed in the Animations panel the movement front-loads.
+- **Done when**: the grep is clean and every hover/entrance behaves visually as before (only the watched property set and two easings changed).

--- a/plans/007-accordion-interruptible.md
+++ b/plans/007-accordion-interruptible.md
@@ -1,0 +1,124 @@
+# 007 — Make the FAQ accordion interruptible and sync its chevron
+
+- **Status**: DONE (commit 9d5c80f)
+- **Commit**: 7955cd6
+- **Severity**: MEDIUM
+- **Category**: Interruptibility (+ cohesion, accessibility)
+- **Estimated scope**: 3 files (AccordionContent.tsx, AccordionTrigger.tsx, globals.css), ~20 lines
+
+## Problem
+
+The accordion (used by `apps/landing/src/components/pricing/PricingFaq.tsx`) animates with `@keyframes`. Keyframes restart from zero — toggling a panel while it is still opening snaps it to full height and replays the close from there instead of reversing from the current position. CSS transitions retarget mid-flight; expand/collapse UI must use them.
+
+```tsx
+// apps/landing/src/components/AccordionContent.tsx:10-30 — current
+export function AccordionContent({ className, children, ref, ...props }: AccordionContentProps) {
+  return (
+    <AccordionPrimitives.Content
+      className={cx(
+        'transform-gpu data-[state=closed]:animate-accordionClose data-[state=open]:animate-accordionOpen'
+      )}
+      ref={ref}
+      {...props}
+    >
+      <div
+        className={cx(
+          'overflow-hidden pb-4 text-sm',
+          'text-gray-700 dark:text-gray-200',
+          className
+        )}
+      >
+        {children}
+      </div>
+    </AccordionPrimitives.Content>
+  )
+}
+```
+
+```css
+/* apps/landing/src/app/globals.css:25-26 — current tokens */
+--animate-accordionOpen: accordionOpen 250ms cubic-bezier(0.33, 1, 0.68, 1);
+--animate-accordionClose: accordionClose 200ms cubic-bezier(0.33, 1, 0.68, 1);
+/* globals.css:83-98 — keyframes animating height: 0 ↔ var(--radix-accordion-content-height) */
+```
+
+Two more defects in the same widget:
+
+- The chevron rotates on a one-off curve and shorter duration than its own panel — two halves of one motion disagree:
+
+```tsx
+// apps/landing/src/components/AccordionTrigger.tsx:29 — current
+'size-5 shrink-0 transition-transform duration-150 ease-[cubic-bezier(0.87,_0,_0.13,_1)] group-data-[state=open]:-rotate-45',
+```
+
+- Neither panel nor chevron has any `prefers-reduced-motion` handling.
+
+## Target
+
+Replace the keyframe height animation with a `grid-template-rows: 0fr → 1fr` transition (interruptible, retargets on reversal). Radix only keeps closing content mounted while an *animation* runs — transitions are not detected — so the content must be `forceMount`ed, with `visibility` handling accessibility/focus (`visibility` transitions discretely: it flips to `hidden` only at the END of the closing transition, and to `visible` immediately on open).
+
+```tsx
+// apps/landing/src/components/AccordionContent.tsx — target render
+<AccordionPrimitives.Content
+  forceMount
+  className={cx(
+    'grid grid-rows-[0fr] transition-[grid-template-rows,visibility] duration-200 ease-out-strong',
+    'data-[state=open]:grid-rows-[1fr] data-[state=open]:duration-250',
+    'data-[state=closed]:invisible',
+    'motion-reduce:transition-none'
+  )}
+  ref={ref}
+  {...props}
+>
+  <div
+    className={cx(
+      'min-h-0 overflow-hidden pb-4 text-sm',
+      'text-gray-700 dark:text-gray-200',
+      className
+    )}
+  >
+    {children}
+  </div>
+</AccordionPrimitives.Content>
+```
+
+```tsx
+// apps/landing/src/components/AccordionTrigger.tsx:29 — target (same curve + duration as the panel)
+'size-5 shrink-0 transition-transform duration-200 ease-out-strong group-data-[state=open]:-rotate-45 group-data-[state=open]:duration-250',
+'motion-reduce:transition-none',
+```
+
+Timing preserved from today: 250ms open, 200ms close. `--ease-out-strong` is `cubic-bezier(0.22, 1, 0.36, 1)`; if it does not exist in globals.css (plan 001 not run), add it to the first `@theme` block:
+
+```css
+--ease-out-strong: cubic-bezier(0.22, 1, 0.36, 1);
+```
+
+## Repo conventions to follow
+
+- Radix primitives are wrapped in thin components under `apps/landing/src/components/` using `cx` from `@repo/shared/utils` — keep that structure.
+- Utility-class styling only; no new CSS files.
+
+## Steps
+
+1. `apps/landing/src/components/AccordionContent.tsx` — replace the render with the Target markup above (adds `forceMount`, swaps animation classes for the grid transition, moves `min-h-0` onto the inner div).
+2. `apps/landing/src/components/AccordionTrigger.tsx:29` — replace the chevron transition classes as in Target (add the `motion-reduce:transition-none` entry as an adjacent string in the same `cx` call).
+3. Ensure `--ease-out-strong` exists in `apps/landing/src/app/globals.css` (see Target).
+4. `apps/landing/src/app/globals.css` — after confirming with `grep -rn "accordionOpen\|accordionClose" apps/landing/src --include='*.tsx'` that no other consumer exists, delete the two tokens (lines 25-26) and the `accordionOpen`/`accordionClose` keyframes (lines 83-98).
+
+## Boundaries
+
+- Do NOT touch `PricingFaq.tsx` or any other accordion consumer — the wrappers absorb the change.
+- Do NOT touch fumadocs' own accordion styling.
+- Do NOT change the 250/200ms timing or the rotate-45 chevron behavior.
+- If the files differ from the excerpts (drift since commit 7955cd6), STOP and report.
+
+## Verification
+
+- **Mechanical**: `bun run check` passes; `cd apps/landing && bunx tsc --noEmit` passes; `grep -rn "accordionOpen\|accordionClose" apps/landing/src` returns nothing.
+- **Feel check**: `bun run dev:landing`, open /en/pricing, scroll to the FAQ:
+  - Click a question open, then click again MID-OPEN: the panel must reverse smoothly from its current height — no snap to full height, no jump to zero. Spam-click 5×: motion always continues from where it is.
+  - The plus icon rotates in step with the panel — at 10% speed (DevTools Animations panel) icon and panel start and stop together.
+  - Closed panels: tab through the page — no focus lands inside a closed answer (visibility works); the closed answer text is not visible.
+  - Emulate `prefers-reduced-motion: reduce`: panels snap open/closed instantly, icon snaps, content still readable.
+- **Done when**: mid-toggle reversal is smooth, chevron and panel share one timing, reduced motion snaps, and the old keyframes are gone.

--- a/plans/007-accordion-interruptible.md
+++ b/plans/007-accordion-interruptible.md
@@ -122,3 +122,10 @@ Timing preserved from today: 250ms open, 200ms close. `--ease-out-strong` is `cu
   - Closed panels: tab through the page — no focus lands inside a closed answer (visibility works); the closed answer text is not visible.
   - Emulate `prefers-reduced-motion: reduce`: panels snap open/closed instantly, icon snaps, content still readable.
 - **Done when**: mid-toggle reversal is smooth, chevron and panel share one timing, reduced motion snaps, and the old keyframes are gone.
+
+## Post-execution notes (browser verification)
+
+Two follow-up fixes were required after the initial implementation:
+
+1. **Padding floors the 0fr track** (`2e1ef90`): `pb-4` on the grid item kept the closed row at 16px (border-box padding sets the track's minimum contribution). The clipping wrapper must be padding-free (`min-h-0 overflow-hidden` only); padding lives on a nested div.
+2. **Radix zeroes transitions on its Content node**: Radix Collapsible sets `transitionDuration = '0s'` + forces reflow on the Content element to measure height on every toggle, which instantly completes any CSS transition declared there. The animated grid layer must live on a CHILD div (driven via `group` on Content + `group-data-[state=*]` variants), never on the Content element itself.

--- a/plans/008-press-feedback.md
+++ b/plans/008-press-feedback.md
@@ -1,0 +1,69 @@
+# 008 — Add press feedback to interactive controls
+
+- **Status**: DONE (commit 3957021)
+- **Commit**: 7955cd6
+- **Severity**: MEDIUM
+- **Category**: Physicality & origin
+- **Estimated scope**: ~10 files, one class-string edit per control (~18 sites)
+
+## Problem
+
+No element on the site has any `:active` press state (grep for `active:` across `apps/landing/src` and `packages/shared/src` returns zero Tailwind active-variants). Buttons, tabs, and copy controls respond to hover but give nothing back at the moment of the click — the interface feels inert exactly when the user acts on it.
+
+Reference values (from the audit playbook): press feedback is `transform: scale(0.97)` on `:active`, transitioned over 100–160ms with ease-out; keep it subtle (0.95–0.98).
+
+## Target
+
+Uniform recipe applied per control:
+
+1. Add `active:scale-[0.97]` to the element's className.
+2. Ensure `transform` is in the element's transition property list (extend `transition-colors` to `transition-[color,background-color,border-color,transform]`; elements already transitioning transform need no change).
+3. If the element has a hover translate (`hover:-translate-y-px` / `hover:translate-x-[2px]`), also add `active:translate-y-0` / `active:translate-x-0` so the press replaces the lift instead of fighting it.
+
+Press feedback stays on under reduced motion (it is comprehension feedback, gentle, and user-initiated) — do NOT add `motion-reduce` gates here.
+
+Note on drift: plan 006 rewrites several of these elements' `transition-*` utilities. If it has already run, the fragments below will differ — that is expected; keep 006's property list, append `transform` to it if missing, and add the `active:` classes. Any OTHER mismatch: STOP and report.
+
+## Repo conventions to follow
+
+- Styling is Tailwind utilities inline in the component; no shared CSS class, no new files.
+- DESIGN.md §3.3 settles hover (1px lift, never scale) — press (`:active`) is a separate state and may scale.
+
+## Steps
+
+For each control, apply the Target recipe. Locations and current identifying fragments at commit 7955cd6:
+
+1. `apps/landing/src/components/landing/Hero.tsx:122` — gradient download Link (`transition-all hover:-translate-y-px`): add `active:translate-y-0 active:scale-[0.97]`, ensure transform transitioned.
+2. `apps/landing/src/components/landing/Hero.tsx:151` — copy-install button (`transition-colors hover:border-dm-line-strong`): extend transition list, add `active:scale-[0.97]`.
+3. `apps/landing/src/components/landing/CtaFinal.tsx:44` — primary CTA (`transition-all hover:-translate-y-px`): as site 1.
+4. `apps/landing/src/components/landing/CtaFinal.tsx:73` — secondary CTA link: extend transition list, add `active:scale-[0.97]`.
+5. `apps/landing/src/components/shell/Navbar.tsx:94` — download Link (`transition-transform hover:-translate-y-px`): add `active:translate-y-0 active:scale-[0.97]`.
+6. `apps/landing/src/components/shell/Navbar.tsx:103` — mobile menu toggle (`transition-colors hover:border-dm-line-strong`): extend transition list, add `active:scale-[0.97]`.
+7. `apps/landing/src/components/ThemeSwitch.tsx:68` — radio items (`transition-colors hover:text-dm-ink`): extend transition list, add `active:scale-[0.97]`.
+8. `apps/landing/src/components/shell/LocaleSwitch.tsx:55` — globe trigger (`transition-colors hover:bg-dm-bg-soft`): extend transition list, add `active:scale-[0.97]`.
+9. `apps/landing/src/components/shell/LocaleSwitch.tsx` — locale menu items (the `role="menuitem"` buttons, `transition-colors`): extend transition list, add `active:scale-[0.97]`.
+10. `apps/landing/src/components/snapshot/SnapshotShowcase.tsx:223` — mobile tab chips (`transition-colors`): extend transition list, add `active:scale-[0.97]`.
+11. `apps/landing/src/components/snapshot/SnapshotShowcase.tsx:349` — RailItem (`transition-colors`): extend transition list, add `active:scale-[0.97]`.
+12. `apps/landing/src/components/snapshot/SnapshotShowcase.tsx:450` — TopbarBtn prev/next/zoom (`transition-colors`): extend transition list, add `active:scale-[0.97]`.
+13. `apps/landing/src/components/snapshot/SnapshotShowcase.tsx:614` and `:633` — CaptionStrip docs link and copy-link button (`transition-colors`): extend transition list, add `active:scale-[0.97]`.
+14. `apps/landing/src/components/snapshot/SnapshotShowcase.tsx:684` — Lightbox close button (no transition today): add `transition-transform active:scale-[0.97]`.
+15. `apps/landing/src/components/download/HomebrewCopyButton.tsx:20` — copy row (`transition-colors hover:border-dm-line-strong`): extend transition list, add `active:scale-[0.97]`.
+16. `apps/landing/src/components/download/PlatformCard.tsx:104` — asset rows (`hover:translate-x-[2px]`): add `active:translate-x-0 active:scale-[0.97]`, ensure transform transitioned.
+17. `apps/landing/src/components/pricing/PlanCard.tsx:52` — `ctaClassName` base string: add `active:scale-[0.97]` (primary variant also gets `active:translate-y-0`).
+18. `apps/landing/src/app/[locale]/(main)/pricing/page.tsx:264` and `:288` — final CTA button/link: add `active:scale-[0.97]`, ensure transform transitioned.
+
+## Boundaries
+
+- Do NOT add press feedback to plain text navigation links (Navbar LINKS, footer links, TOC links) or to `AccordionTrigger` (a full-width text row — scaling it reads as layout wobble).
+- Do NOT add it to the SnapshotShowcase `Stage` zoom button (`:487`) — it is a full-bleed screenshot surface; scaling it looks like a glitch, not feedback.
+- Do NOT change hover behavior, colors, or markup.
+- Do NOT introduce a shared CSS class or new dependency — utilities per element only.
+
+## Verification
+
+- **Mechanical**: `bun run check` passes; `cd apps/landing && bun run build` succeeds. Grep proof: `grep -rn "active:scale" apps/landing/src --include='*.tsx' --include='*.ts' | wc -l` ≥ 17.
+- **Feel check**: `bun run dev:landing`:
+  - Press and HOLD the hero download CTA: it sinks to 97% and stays there; release: it returns smoothly (~150ms, no snap). The sink must replace the hover lift, not stack under it.
+  - Click the Homebrew copy row and a snapshot rail item on a touch device or with DevTools device emulation: the press is visible on tap.
+  - Rapid-click a TopbarBtn arrow 5×: feedback tracks every press without stutter (transitions retarget).
+- **Done when**: every listed control visibly sinks on press, nothing in the Boundaries list scales, and hover behavior is unchanged.

--- a/plans/009-reduced-motion-coverage.md
+++ b/plans/009-reduced-motion-coverage.md
@@ -1,0 +1,79 @@
+# 009 — Extend reduced-motion coverage beyond the hero stage
+
+- **Status**: DONE (commit c43b7fa)
+- **Commit**: 7955cd6
+- **Severity**: MEDIUM
+- **Category**: Accessibility
+- **Estimated scope**: 6 files, ~40 lines
+
+## Problem
+
+The `.dm-animated` reduced-motion gate is applied to exactly ONE element in the codebase (`Hero.tsx:241`, the decorative hero stage). Everything else that moves ignores `prefers-reduced-motion`:
+
+1. **Snapshot slide wipe** — `apps/landing/src/components/snapshot/SnapshotShowcase.tsx:527-533`:
+
+```tsx
+const style: React.CSSProperties = {
+  transition:
+    'opacity 0.45s cubic-bezier(0.22, 1, 0.36, 1), clip-path 0.55s cubic-bezier(0.22, 1, 0.36, 1)',
+  opacity: visible ? 1 : 0,
+  clipPath: active ? 'inset(0 0 0 0)' : prev ? 'inset(0 0 0 0)' : 'inset(0 0 0 100%)',
+  zIndex: active ? 2 : prev ? 1 : 0
+}
+```
+
+The clip-path wipe is positional movement, triggered on every module change (click, keyboard j/k/arrows, and scroll-driven via IntersectionObserver).
+
+2. **Programmatic smooth scrolling** — `SnapshotShowcase.tsx:116`, `:118`, `:126` (`scrollTo`/`scrollIntoView` with `behavior: 'smooth'`), `:156` (`sentinel.scrollIntoView({ behavior: 'smooth', block: 'center' })`); `apps/landing/src/components/changelog/ChangelogToc.tsx:18` and `:20` (`nav.scrollTo({ ..., behavior: 'smooth' })`).
+
+3. **Mobile nav drawer translate** — `apps/landing/src/components/shell/Navbar.tsx:145-147`:
+
+```tsx
+className={`absolute inset-x-0 top-full z-50 origin-top ... transition-all duration-200 ${
+  menuOpen ? 'translate-y-0 opacity-100' : '-translate-y-2 opacity-0'
+}`}
+```
+
+4. **Ungated infinite pulse dots** (the gated ones inside HeroStage are fine): `apps/landing/src/components/landing/Hero.tsx:96-102` (eyebrow "live" dot), `apps/landing/src/components/landing/LiveDashboard.tsx:262-268` ("connected" chip dot), `apps/landing/src/components/download/DownloadHero.tsx:27`, `apps/landing/src/components/pricing/PricingHero.tsx:30` — all `animation: 'dm-pulse 900ms ease-in-out infinite'` with no gate.
+
+Reduced motion means fewer and gentler animations, not zero: keep opacity fades, drop positional movement and perpetual loops.
+
+## Target
+
+- Slide under reduced motion: crossfade only — `transition: 'opacity 0.2s ease-out'`, `clipPath` always `'inset(0 0 0 0)'`, same `opacity`/`zIndex` logic.
+- All programmatic scrolls: `behavior: reduced ? 'auto' : 'smooth'`.
+- Nav drawer: keep the opacity fade, drop the translate (`motion-reduce:translate-y-0` on the closed state so both states sit at translate-y 0 when reduced).
+- Pulse dots: add the `dm-animated` class to each dot's className — the existing global gate then freezes them (static, fully visible, since `dm-pulse`'s 0%/100% frame is `opacity: 1`).
+
+## Repo conventions to follow
+
+- Reduced-motion detection in client components uses `useSyncExternalStore` + `matchMedia` — exemplar: `apps/landing/src/components/landing/PaletteViz.tsx:83-96` (`subscribeReducedMotion`, `getReducedMotionSnapshot`, `getServerReducedMotionSnapshot`). Copy that trio module-level into SnapshotShowcase.tsx.
+- One-shot reads at call time may use bare `window.matchMedia('(prefers-reduced-motion: reduce)').matches` — exemplar: `apps/landing/src/components/landing/hooks/useSparkline.ts:30-34`.
+- The `dm-animated` gating class is documented in DESIGN.md §1.7.
+
+## Steps
+
+1. `SnapshotShowcase.tsx` — add the PaletteViz reduced-motion trio at module level; inside `SnapshotShowcase()` read `const reduced = useSyncExternalStore(subscribeReducedMotion, getReducedMotionSnapshot, getServerReducedMotionSnapshot)`.
+2. Thread `reduced` through `Stage` to `Slide` as a prop. In `Slide`, build the style per Target when `reduced` is true, otherwise keep the current object.
+3. In `scrollActiveControls` (`:104-129`) and `go` (`:150-162`), replace each `behavior: 'smooth'` with `behavior: reduced ? 'auto' : 'smooth'` (add `reduced` to the `useCallback` deps).
+4. `ChangelogToc.tsx` — before the two `scrollTo` calls (`:18`, `:20`), compute `const behavior: ScrollBehavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth'` and use it in both calls.
+5. `Navbar.tsx:146` — change the closed-state branch from `'-translate-y-2 opacity-0'` to `'-translate-y-2 opacity-0 motion-reduce:translate-y-0'`.
+6. Add `dm-animated` to the four pulse-dot classNames: `Hero.tsx:96-102` eyebrow dot, `LiveDashboard.tsx:262-268` connected dot, `DownloadHero.tsx:27` dot, `PricingHero.tsx:30` dot (each is a `<span className="h-[6px] w-[6px] rounded-full">`-style element with the inline `dm-pulse` animation — append `dm-animated` to its className).
+
+## Boundaries
+
+- Do NOT change any behavior when reduced motion is OFF — every default-path value stays byte-identical.
+- Do NOT touch the `.dm-animated` media query itself (plan 004 owns it) — this plan only ADDS the class to elements.
+- Do NOT gate the hover micro-movements (`hover:-translate-y-px`) — out of scope, user-initiated.
+- Do NOT add dependencies or extract new shared hooks — follow the existing local-trio pattern.
+- If cited lines differ (drift since commit 7955cd6), STOP and report.
+
+## Verification
+
+- **Mechanical**: `bun run check` passes; `cd apps/landing && bunx tsc --noEmit` passes.
+- **Feel check**: `bun run dev:landing`, DevTools → Rendering → emulate `prefers-reduced-motion: reduce`:
+  - /en/snapshot: switch modules with click and with j/k — screenshots crossfade (~200ms), NO left-edge wipe; the rail jumps instantly (no smooth scroll). Emulation off: wipe and smooth scroll return.
+  - /en/changelog: click a TOC entry — instant jump under reduce, smooth without.
+  - Narrow viewport, open the mobile menu — panel fades in place, no downward slide.
+  - / (homepage): the eyebrow "live" dot and LiveDashboard "connected" dot are static and fully visible; without emulation they pulse.
+- **Done when**: every listed surface passes both emulation states with zero visual change in the non-reduced path.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,49 @@
+# Animation Improvement Plans
+
+Produced by an `improve-animations` audit of `apps/landing` + `packages/shared` at commit `7955cd6` (2026-07-11). Each plan is self-contained — an executor needs no context beyond the plan file.
+
+## Plans
+
+| # | Plan | Severity | Category | Status |
+| --- | --- | --- | --- | --- |
+| 001 | [Extract shared easing tokens](001-motion-easing-tokens.md) | MEDIUM | Cohesion & tokens | DONE |
+| 002 | [Disable Lenis for reduced motion](002-lenis-reduced-motion.md) | HIGH | Accessibility | DONE |
+| 003 | [Scope global anchor transition](003-global-anchor-transition.md) | HIGH | Performance | DONE |
+| 004 | [Reduced-motion gate lands at end state](004-reduced-motion-gate-end-state.md) | MEDIUM | Accessibility | DONE |
+| 005 | [Fix slide-fade entrance tokens](005-entrance-token-duration-easing.md) | MEDIUM | Easing & duration | DONE |
+| 006 | [Replace transition-all with property lists](006-transition-all-sweep.md) | MEDIUM | Performance | DONE |
+| 007 | [Interruptible accordion + synced chevron](007-accordion-interruptible.md) | MEDIUM | Interruptibility | DONE |
+| 008 | [Press feedback on interactive controls](008-press-feedback.md) | MEDIUM | Physicality | DONE |
+| 009 | [Reduced-motion coverage sweep](009-reduced-motion-coverage.md) | MEDIUM | Accessibility | DONE |
+
+## Recommended execution order
+
+1. **001** first — it creates the `--ease-out-strong` / `--ease-in-out-strong` tokens that 005, 006, 007 consume. (Each of those plans carries an add-if-missing fallback, so they don't hard-fail without 001, but running 001 first avoids duplicate token definitions.)
+2. **002, 003, 004** in any order — independent, and 002/003 are the two HIGH findings.
+3. **005, 006, 007** in any order after 001.
+4. **008 after 006** — both edit the same `transition-*` class fragments; 008 explains how to reconcile if 006 already ran, but running 006 first keeps 008's edits clean.
+5. **009 last** — its pulse-dot step composes with 004's gate semantics (works either way, best after 004).
+
+## Dependencies
+
+- 005/006/007 → 001 (soft: shared easing tokens; each has an inline fallback).
+- 008 → 006 (soft: overlapping class strings; 008 documents the reconciliation).
+- 009 → 004 (soft: `dm-animated` freeze behavior is nicer with 004's end-state gate).
+
+## Audit backlog (vetted, not yet planned)
+
+LOW-severity findings confirmed during the audit, available for future plans:
+
+- Tooltip doesn't scale from its trigger and uses restart-from-zero keyframes (`Tooltip.tsx:59`).
+- Snapshot rail active-item gradient/shadow snaps while its text eases (`SnapshotShowcase.tsx:362-371`).
+- Hero MiniBars: 7 decorative CPU bars bounce forever (`Hero.tsx:452`) — delete or play once.
+- `dm-pulse` runs at 900ms everywhere but DESIGN.md §2.7 documents 2.2s — code/doc drift.
+- Dead motion infrastructure: `motion` v12 dependency has zero imports; `::view-transition` rules + stale comment (`globals.css:342-352`) outlive the removed clip-path theme reveal; `dialogOverlayShow`/`dialogContentShow` tokens are unused.
+
+Missed opportunities (additive, need design sign-off):
+
+- Lightbox opens/closes with zero animation (`SnapshotShowcase.tsx:675`) — the unused dialog tokens fit here.
+- Copy-button copied-state swaps teleport (`HomebrewCopyButton.tsx:30-55`, `SnapshotShowcase.tsx:652`).
+- ThemeSwitch pill crossfades per item instead of sliding between positions (`ThemeSwitch.tsx:72-80`).
+- LocaleSwitch dropdown appears with no entrance at all (`LocaleSwitch.tsx:77-83`).
+- Feature/platform grids could take a 30–80ms in-view stagger (`FeaturesGrid.tsx:102`, `PlatformCard.tsx:54`).


### PR DESCRIPTION
## Summary

Full animation/motion audit of `apps/landing` + `packages/shared` (from commit 7955cd6), executed as nine self-contained plans. The plans themselves, execution status, and post-execution notes live in `plans/`.

### Fixes (2 HIGH)
- **Lenis smooth scrolling now respects `prefers-reduced-motion`** — previously applied page-wide with no opt-out (`d82fb14`)
- **Global `a { transition-all }` scoped to `color, text-decoration-color`** — every link site-wide watched all animatable properties (`03943ec`)

### Improvements (7 MEDIUM)
- Shared easing tokens `--ease-out-strong` / `--ease-in-out-strong`; consolidated three near-duplicate hand-typed curves (`305c4fc`)
- Reduced-motion gate now lands animations at their end state instead of stranding forwards-fill elements at `opacity:0`/`width:0` (hero terminal was blank for reduced-motion users) (`33067d2`)
- `--animate-slide-up/down-fade` tokens gained a real duration (600ms) and ease-out; consumers dropped inline patches (`fdd27be`)
- Nine component-level `transition-all` replaced with explicit property lists; button hover easing fixed (`68fd0e8`)
- FAQ accordion rebuilt on an interruptible `grid-template-rows` transition — mid-toggle reversal retargets instead of snapping; chevron synced to the panel's curve and timing (`9d5c80f`)
- Press feedback (`active:scale-[0.97]`) on 20 interactive controls (`3957021`)
- Reduced-motion coverage extended beyond the hero stage: snapshot clip-path wipe becomes an opacity crossfade, programmatic scrolls use `behavior:auto`, mobile drawer drops its translate, ungated pulse dots gated (`c43b7fa`)

### Follow-up fixes from browser verification
- Base anchor rule wrapped in `@layer base` so element utilities can override it (`156c0a5`)
- Accordion closed state collapses to a true 0 — padding moved off the 0fr grid item (`2e1ef90`)
- Accordion transition moved off the Radix-managed Content node, which zeroes `transitionDuration` to measure height on every toggle (`9b7c854`)

## Verification
- `bun run build:landing` green
- Browser-verified (Chrome DevTools) in both normal and reduced-motion states: easing tokens resolve end-to-end, Lenis mounts conditionally, accordion interpolates with ease-out character (sampled 0→18.7→24.9→…→37) and reverses smoothly mid-flight, snapshot slides crossfade without the wipe under reduced motion, non-reduced paths byte-identical
- Known pre-existing failures unrelated to this PR: `bun run check` (ultracite config missing) and `tsc --noEmit` (`bun:test` module resolution in test files)