### PR TITLE
fix(checkout): redirect POST submissions with GET semantics

### DIFF
--- a/apps/landing/src/app/api/checkout/route.test.ts
+++ b/apps/landing/src/app/api/checkout/route.test.ts
@@ -46,13 +46,13 @@ describe('checkout route', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  test('creates checkout sessions from POST requests', async () => {
+  test('redirects POST requests to checkout with GET semantics', async () => {
     const fetchMock = mock(async () => Response.json({ checkout_url: 'https://checkout.test/pay' }))
     globalThis.fetch = fetchMock
 
     const response = await POST(checkoutRequest('POST'))
 
-    expect(response.status).toBe(307)
+    expect(response.status).toBe(303)
     expect(response.headers.get('location')).toBe('https://checkout.test/pay')
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0][0]).toBe('https://test-api.creem.io/v1/checkouts')

--- a/apps/landing/src/app/api/checkout/route.ts
+++ b/apps/landing/src/app/api/checkout/route.ts
@@ -96,7 +96,7 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    return NextResponse.redirect(checkout.checkout_url)
+    return NextResponse.redirect(checkout.checkout_url, 303)
   } catch (error) {
     console.error('Creem checkout error:', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })


### PR DESCRIPTION
## Summary

- return a 303 redirect after creating a Creem checkout session
- ensure browsers load the hosted checkout page with GET instead of preserving POST
- update the checkout route regression test to enforce the redirect semantics

## Root cause

`NextResponse.redirect()` defaults to HTTP 307. Because the pricing form submits with POST, browsers preserved POST when following the redirect to Creem. The hosted checkout page expects GET, so the initial navigation could render a 400 Bad Request until the user refreshed the page.

## Verification

- `bun test src/app/api/checkout/route.test.ts`
- `bunx --bun @biomejs/biome check apps/landing/src/app/api/checkout/route.ts apps/landing/src/app/api/checkout/route.test.ts`
- `git diff --check`

## Known repository issue

- `bun run check` cannot complete because `@repo/landing` reports `No linter configuration found` from Ultracite; this is unrelated to the checkout change.