### PR TITLE
fix(analytics): restore PostHog event delivery

### DIFF
--- a/apps/landing/instrumentation-client.ts
+++ b/apps/landing/instrumentation-client.ts
@@ -12,15 +12,4 @@ const initPostHog = async () => {
   })
 }
 
-// Defer until the browser is idle so PostHog doesn't compete with first paint
-// or block input responsiveness during initial hydration.
-if (typeof window !== 'undefined') {
-  const w = window as Window & {
-    requestIdleCallback?: (cb: () => void, opts?: { timeout?: number }) => number
-  }
-  if (typeof w.requestIdleCallback === 'function') {
-    w.requestIdleCallback(initPostHog, { timeout: 4000 })
-  } else {
-    setTimeout(initPostHog, 2000)
-  }
-}
+initPostHog()

--- a/apps/landing/middleware.test.ts
+++ b/apps/landing/middleware.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test'
+import { NextRequest } from 'next/server'
+
+import { middleware } from './middleware'
+
+describe('landing middleware', () => {
+  test('lets PostHog proxy requests reach the rewrite layer', () => {
+    const request = new NextRequest('https://dockerman.app/ingest/e/', {
+      method: 'POST'
+    })
+
+    const response = middleware(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('location')).toBeNull()
+    expect(response.headers.get('x-middleware-next')).toBe('1')
+  })
+
+  test('keeps similarly prefixed pages in locale routing', () => {
+    const request = new NextRequest('https://dockerman.app/ingestion')
+
+    const response = middleware(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('https://dockerman.app/en/ingestion')
+  })
+})

--- a/apps/landing/middleware.ts
+++ b/apps/landing/middleware.ts
@@ -3,8 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 
 // `bot` already covers googlebot/bingbot/duckduckbot/discordbot/etc., so we
 // only add the crawlers that don't carry "bot" in their UA.
-const BOT_UA_REGEX =
-  /bot|crawler|spider|yandex|baiduspider|facebookexternalhit|whatsapp|applebot/i
+const BOT_UA_REGEX = /bot|crawler|spider|yandex|baiduspider|facebookexternalhit|whatsapp|applebot/i
 
 function isBot(request: NextRequest): boolean {
   const ua = request.headers.get('user-agent') || ''
@@ -32,10 +31,12 @@ function getLocaleFromPath(pathname: string): Locale | null {
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  // Skip static files and API routes
+  // Skip static files, API routes, and the PostHog reverse proxy.
   if (
     pathname.startsWith('/_next') ||
     pathname.startsWith('/api') ||
+    pathname === '/ingest' ||
+    pathname.startsWith('/ingest/') ||
     pathname.includes('.') ||
     pathname.startsWith('/images')
   ) {
@@ -83,5 +84,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!_next|api|images|favicon.ico|opengraph-image.png|.*\\..*).*)']
+  matcher: ['/((?!_next|api|ingest/|images|favicon.ico|opengraph-image.png|.*\\..*).*)']
 }

--- a/packages/shared/src/analytics/pageTracking.test.ts
+++ b/packages/shared/src/analytics/pageTracking.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createPageEngagementTracker, createScrollDepthTracker } from './pageTracking'
+
+describe('page analytics tracking', () => {
+  test('starts scroll thresholds over for each pathname', () => {
+    const events: Array<{ depth: number; pagePath: string }> = []
+    const capture = (depth: number, pagePath: string) => {
+      events.push({ depth, pagePath })
+    }
+
+    const home = createScrollDepthTracker('/en', capture)
+    home.record(30, 100)
+    home.record(35, 100)
+
+    const pricing = createScrollDepthTracker('/en/pricing', capture)
+    pricing.record(30, 100)
+
+    expect(events).toEqual([
+      { depth: 25, pagePath: '/en' },
+      { depth: 25, pagePath: '/en/pricing' }
+    ])
+  })
+
+  test('attributes engagement to the current pathname exactly once', () => {
+    const events: Array<{ durationSeconds: number; pagePath: string }> = []
+    const capture = (durationSeconds: number, pagePath: string) => {
+      events.push({ durationSeconds, pagePath })
+    }
+
+    const home = createPageEngagementTracker('/en', 0, capture)
+    home.interact(5000)
+    home.check(10_000)
+    home.check(12_000)
+
+    const pricing = createPageEngagementTracker('/en/pricing', 20_000, capture)
+    pricing.interact(31_000)
+    pricing.check(35_000)
+
+    expect(events).toEqual([
+      { durationSeconds: 10, pagePath: '/en' },
+      { durationSeconds: 11, pagePath: '/en/pricing' }
+    ])
+  })
+})

--- a/packages/shared/src/analytics/pageTracking.ts
+++ b/packages/shared/src/analytics/pageTracking.ts
@@ -1,0 +1,52 @@
+export const ENGAGE_THRESHOLD_MS = 10_000
+
+const SCROLL_DEPTH_THRESHOLDS = [25, 50, 75, 100] as const
+
+type ScrollDepth = (typeof SCROLL_DEPTH_THRESHOLDS)[number]
+type CaptureScrollDepth = (depth: ScrollDepth, pagePath: string) => void
+type CapturePageEngagement = (durationSeconds: number, pagePath: string) => void
+
+export function createScrollDepthTracker(pagePath: string, capture: CaptureScrollDepth) {
+  const fired = new Set<ScrollDepth>()
+
+  return {
+    record(scrollY: number, scrollableHeight: number) {
+      if (scrollableHeight <= 0) return
+
+      const scrollPercent = (scrollY / scrollableHeight) * 100
+      for (const threshold of SCROLL_DEPTH_THRESHOLDS) {
+        if (scrollPercent >= threshold && !fired.has(threshold)) {
+          fired.add(threshold)
+          capture(threshold, pagePath)
+        }
+      }
+    }
+  }
+}
+
+export function createPageEngagementTracker(
+  pagePath: string,
+  startTime: number,
+  capture: CapturePageEngagement
+) {
+  let hasInteracted = false
+  let hasFired = false
+
+  const check = (now: number) => {
+    if (hasFired || !hasInteracted) return
+
+    const elapsed = now - startTime
+    if (elapsed < ENGAGE_THRESHOLD_MS) return
+
+    hasFired = true
+    capture(Math.round(elapsed / 1000), pagePath)
+  }
+
+  return {
+    interact(now: number) {
+      hasInteracted = true
+      check(now)
+    },
+    check
+  }
+}

--- a/packages/shared/src/components/AnalyticsTracker.tsx
+++ b/packages/shared/src/components/AnalyticsTracker.tsx
@@ -1,10 +1,14 @@
 'use client'
 
+import { usePathname } from 'next/navigation'
+
 import { usePageEngaged } from '../hooks/usePageEngaged'
 import { useScrollDepth } from '../hooks/useScrollDepth'
 
 export function AnalyticsTracker() {
-  useScrollDepth()
-  usePageEngaged()
+  const pagePath = usePathname()
+
+  useScrollDepth(pagePath)
+  usePageEngaged(pagePath)
   return null
 }

--- a/packages/shared/src/hooks/usePageEngaged.ts
+++ b/packages/shared/src/hooks/usePageEngaged.ts
@@ -2,57 +2,38 @@
 
 import { useEffect } from 'react'
 
-const ENGAGE_THRESHOLD_MS = 10_000
+import { createPageEngagementTracker, ENGAGE_THRESHOLD_MS } from '../analytics/pageTracking'
 
-export function usePageEngaged() {
+export function usePageEngaged(pagePath: string) {
   useEffect(() => {
-    let hasInteracted = false
-    let hasFired = false
-    const pagePath = window.location.pathname
-    const startTime = Date.now()
-
-    const markInteracted = () => {
-      hasInteracted = true
-    }
-
-    const tryFire = () => {
-      if (hasFired || !hasInteracted) return
-      const elapsed = Date.now() - startTime
-      if (elapsed < ENGAGE_THRESHOLD_MS) return
-
-      hasFired = true
-      import('posthog-js').then(({ default: posthog }) => {
-        posthog.capture('page_engaged', {
-          page_path: pagePath,
-          duration_seconds: Math.round(elapsed / 1000)
+    const tracker = createPageEngagementTracker(
+      pagePath,
+      Date.now(),
+      (duration, trackedPagePath) => {
+        import('posthog-js').then(({ default: posthog }) => {
+          posthog.capture('page_engaged', {
+            page_path: trackedPagePath,
+            duration_seconds: duration
+          })
         })
-      })
+      }
+    )
+
+    const handleInteraction = () => {
+      tracker.interact(Date.now())
     }
 
-    window.addEventListener('click', markInteracted, { passive: true, once: true })
-    window.addEventListener('scroll', markInteracted, { passive: true, once: true })
-    window.addEventListener('keydown', markInteracted, { passive: true, once: true })
+    window.addEventListener('click', handleInteraction, { passive: true, once: true })
+    window.addEventListener('scroll', handleInteraction, { passive: true, once: true })
+    window.addEventListener('keydown', handleInteraction, { passive: true, once: true })
 
-    const timer = setTimeout(() => {
-      tryFire()
-      if (!hasInteracted) {
-        const onLateInteract = () => {
-          tryFire()
-          window.removeEventListener('click', onLateInteract)
-          window.removeEventListener('scroll', onLateInteract)
-          window.removeEventListener('keydown', onLateInteract)
-        }
-        window.addEventListener('click', onLateInteract, { passive: true, once: true })
-        window.addEventListener('scroll', onLateInteract, { passive: true, once: true })
-        window.addEventListener('keydown', onLateInteract, { passive: true, once: true })
-      }
-    }, ENGAGE_THRESHOLD_MS)
+    const timer = setTimeout(() => tracker.check(Date.now()), ENGAGE_THRESHOLD_MS)
 
     return () => {
       clearTimeout(timer)
-      window.removeEventListener('click', markInteracted)
-      window.removeEventListener('scroll', markInteracted)
-      window.removeEventListener('keydown', markInteracted)
+      window.removeEventListener('click', handleInteraction)
+      window.removeEventListener('scroll', handleInteraction)
+      window.removeEventListener('keydown', handleInteraction)
     }
-  }, [])
+  }, [pagePath])
 }

--- a/packages/shared/src/hooks/useScrollDepth.ts
+++ b/packages/shared/src/hooks/useScrollDepth.ts
@@ -2,33 +2,25 @@
 
 import { useEffect } from 'react'
 
-const THRESHOLDS = [25, 50, 75, 100] as const
+import { createScrollDepthTracker } from '../analytics/pageTracking'
 
-export function useScrollDepth() {
+export function useScrollDepth(pagePath: string) {
   useEffect(() => {
-    const fired = new Set<number>()
-    const pagePath = window.location.pathname
+    const tracker = createScrollDepthTracker(pagePath, (depth, trackedPagePath) => {
+      import('posthog-js').then(({ default: posthog }) => {
+        posthog.capture('page_scroll_depth', {
+          depth,
+          page_path: trackedPagePath
+        })
+      })
+    })
 
     const handleScroll = () => {
-      const scrollHeight = document.documentElement.scrollHeight - window.innerHeight
-      if (scrollHeight <= 0) return
-
-      const scrollPercent = (window.scrollY / scrollHeight) * 100
-
-      for (const threshold of THRESHOLDS) {
-        if (scrollPercent >= threshold && !fired.has(threshold)) {
-          fired.add(threshold)
-          import('posthog-js').then(({ default: posthog }) => {
-            posthog.capture('page_scroll_depth', {
-              depth: threshold,
-              page_path: pagePath
-            })
-          })
-        }
-      }
+      const scrollableHeight = document.documentElement.scrollHeight - window.innerHeight
+      tracker.record(window.scrollY, scrollableHeight)
     }
 
     window.addEventListener('scroll', handleScroll, { passive: true })
     return () => window.removeEventListener('scroll', handleScroll)
-  }, [])
+  }, [pagePath])
 }


### PR DESCRIPTION
## Summary

- bypass locale middleware for exact PostHog /ingest paths while preserving similarly prefixed localized routes
- start the dynamically imported PostHog client immediately so early events are not dropped
- reset scroll-depth and page-engagement state on client-side pathname changes
- add executable routing and page-tracking regression tests

## User-facing impact

- no page, UI, interaction, or copy changes
- analytics events are delivered and attributed to the correct page

## Testing

- bun test in apps/landing: 46 passed
- bun test in packages/shared: 2 passed
- focused Biome check passed
- bun run build:landing passed, including Next.js TypeScript validation
- built runtime check: /ingest/e/ reached PostHog instead of returning a locale 307
- built runtime check: /ingestion still returned the expected locale 307

## Follow-up

After deployment, verify production pageview, theme, scroll-depth, engagement, and pathname attribution events in PostHog before updating dashboard filters.