### PR TITLE
fix(analytics): disable PostHog IP geolocation

### DIFF
--- a/apps/landing/instrumentation-client.ts
+++ b/apps/landing/instrumentation-client.ts
@@ -1,15 +1,15 @@
+import { createPostHogConfig } from './src/lib/analytics/posthogConfig'
+
 const initPostHog = async () => {
   const { default: posthog } = await import('posthog-js')
 
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-    api_host: '/ingest',
-    ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-    defaults: '2025-11-30',
-    capture_exceptions: true,
-    // Vercel Speed Insights already captures Core Web Vitals; avoid double instrumentation.
-    capture_performance: false,
-    debug: process.env.NODE_ENV === 'development'
-  })
+  posthog.init(
+    process.env.NEXT_PUBLIC_POSTHOG_KEY!,
+    createPostHogConfig(
+      process.env.NEXT_PUBLIC_POSTHOG_HOST,
+      process.env.NODE_ENV === 'development'
+    )
+  )
 }
 
 initPostHog()

--- a/apps/landing/src/app/api/checkout/route.test.ts
+++ b/apps/landing/src/app/api/checkout/route.test.ts
@@ -5,7 +5,8 @@ const originalFetch = globalThis.fetch
 const originalEnv = {
   CREEM_API_KEY: process.env.CREEM_API_KEY,
   CREEM_PRODUCT_ID_1_DEVICES: process.env.CREEM_PRODUCT_ID_1_DEVICES,
-  CREEM_PRODUCT_ID_3_DEVICES: process.env.CREEM_PRODUCT_ID_3_DEVICES
+  CREEM_PRODUCT_ID_3_DEVICES: process.env.CREEM_PRODUCT_ID_3_DEVICES,
+  NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY
 }
 
 process.env.CREEM_API_KEY = 'creem-test-key'
@@ -22,6 +23,7 @@ beforeEach(() => {
   process.env.CREEM_API_KEY = 'creem-test-key'
   process.env.CREEM_PRODUCT_ID_1_DEVICES = 'prod_one_device'
   process.env.CREEM_PRODUCT_ID_3_DEVICES = 'prod_three_devices'
+  process.env.NEXT_PUBLIC_POSTHOG_KEY = 'posthog-test-key'
 })
 
 afterEach(() => {
@@ -54,8 +56,16 @@ describe('checkout route', () => {
 
     expect(response.status).toBe(303)
     expect(response.headers.get('location')).toBe('https://checkout.test/pay')
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(fetchMock.mock.calls[0][0]).toBe('https://test-api.creem.io/v1/checkouts')
     expect(fetchMock.mock.calls[0][1]?.method).toBe('POST')
+    expect(fetchMock.mock.calls[1][0]).toBe('https://us.i.posthog.com/capture/')
+
+    const posthogBody = fetchMock.mock.calls[1][1]?.body
+    expect(typeof posthogBody).toBe('string')
+    if (typeof posthogBody !== 'string') {
+      throw new Error('Expected the PostHog request body to be a JSON string')
+    }
+    expect(posthogBody).toContain('"$geoip_disable":true')
   })
 })

--- a/apps/landing/src/app/api/checkout/route.ts
+++ b/apps/landing/src/app/api/checkout/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { siteConfig } from '@/app/siteConfig'
 import { pricingConfig } from '@/config/pricing'
+import { withGeoIpDisabled } from '@/lib/analytics/posthogConfig'
 
 const CREEM_BASE_URL =
   process.env.NODE_ENV === 'production' ? 'https://api.creem.io' : 'https://test-api.creem.io'
@@ -89,7 +90,7 @@ export async function POST(request: NextRequest) {
           api_key: posthogKey,
           event: 'checkout_redirected',
           distinct_id: body.request_id,
-          properties: { plan, locale }
+          properties: withGeoIpDisabled({ plan, locale })
         })
       }).catch(() => {
         // Non-blocking: don't fail checkout if analytics fails

--- a/apps/landing/src/lib/analytics/posthogConfig.test.ts
+++ b/apps/landing/src/lib/analytics/posthogConfig.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createPostHogConfig, withGeoIpDisabled } from './posthogConfig'
+
+describe('PostHog browser configuration', () => {
+  test('marks every event to skip GeoIP enrichment', () => {
+    const config = createPostHogConfig('https://us.i.posthog.com', false)
+    const captureResult = config.before_send?.({
+      uuid: 'event-id',
+      event: 'test_event',
+      properties: { existing_property: 'preserved' }
+    })
+
+    expect(captureResult?.properties).toEqual({
+      existing_property: 'preserved',
+      $geoip_disable: true
+    })
+  })
+
+  test('marks server event properties to skip GeoIP enrichment', () => {
+    expect(withGeoIpDisabled({ plan: '1-device', locale: 'en' })).toEqual({
+      plan: '1-device',
+      locale: 'en',
+      $geoip_disable: true
+    })
+  })
+})

--- a/apps/landing/src/lib/analytics/posthogConfig.ts
+++ b/apps/landing/src/lib/analytics/posthogConfig.ts
@@ -1,0 +1,32 @@
+import type { BeforeSendFn, PostHogConfig, Properties } from 'posthog-js'
+
+export function withGeoIpDisabled(properties: Properties) {
+  return {
+    ...properties,
+    $geoip_disable: true
+  }
+}
+
+const disableGeoIpEnrichment: BeforeSendFn = (captureResult) => {
+  if (!captureResult) {
+    return null
+  }
+
+  return {
+    ...captureResult,
+    properties: withGeoIpDisabled(captureResult.properties)
+  }
+}
+
+export function createPostHogConfig(uiHost: string | undefined, debug: boolean) {
+  return {
+    api_host: '/ingest',
+    ui_host: uiHost,
+    defaults: '2025-11-30',
+    capture_exceptions: true,
+    // Vercel Speed Insights already captures Core Web Vitals; avoid double instrumentation.
+    capture_performance: false,
+    before_send: disableGeoIpEnrichment,
+    debug
+  } satisfies Partial<PostHogConfig>
+}


### PR DESCRIPTION
## Summary

- add a shared PostHog privacy boundary that sets $geoip_disable on every browser event
- apply the same GeoIP suppression to server-side checkout events
- add regression coverage for both browser configuration and the checkout Capture API request

The PostHog project setting "Discard client IP data" was enabled separately and verified after reload. Historical event data is intentionally unchanged.

## Verification

- bun test src/lib/analytics/posthogConfig.test.ts src/app/api/checkout/route.test.ts
- bunx biome check on all touched files
- bun run build:landing
- Standards review: pass
- Spec review: pass