### PR TITLE
feat(analytics): add privacy-safe purchase tracking

### DIFF
--- a/apps/landing/src/app/api/checkout/route.test.ts
+++ b/apps/landing/src/app/api/checkout/route.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { NextRequest } from 'next/server'
+import { parseJsonRequestBody } from '@/test/parseJsonRequestBody'
 
 const originalFetch = globalThis.fetch
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const originalEnv = {
   CREEM_API_KEY: process.env.CREEM_API_KEY,
   CREEM_PRODUCT_ID_1_DEVICES: process.env.CREEM_PRODUCT_ID_1_DEVICES,
@@ -15,8 +17,10 @@ process.env.CREEM_PRODUCT_ID_3_DEVICES = 'prod_three_devices'
 
 const { GET, POST } = await import('./route')
 
-function checkoutRequest(method: 'GET' | 'POST', plan = '1-device') {
-  return new NextRequest(`https://dockerman.app/api/checkout?plan=${plan}&locale=en`, { method })
+function checkoutRequest(method: 'GET' | 'POST', plan = '1-device', locale = 'en') {
+  return new NextRequest(`https://dockerman.app/api/checkout?plan=${plan}&locale=${locale}`, {
+    method
+  })
 }
 
 beforeEach(() => {
@@ -38,11 +42,11 @@ afterEach(() => {
 })
 
 describe('checkout route', () => {
-  test('does not create checkout sessions from GET requests', async () => {
+  test('does not create checkout sessions from GET requests', () => {
     const fetchMock = mock(async () => Response.json({ checkout_url: 'https://checkout.test/pay' }))
     globalThis.fetch = fetchMock
 
-    const response = await GET(checkoutRequest('GET'))
+    const response = GET()
 
     expect(response.status).toBe(405)
     expect(fetchMock).not.toHaveBeenCalled()
@@ -61,11 +65,69 @@ describe('checkout route', () => {
     expect(fetchMock.mock.calls[0][1]?.method).toBe('POST')
     expect(fetchMock.mock.calls[1][0]).toBe('https://us.i.posthog.com/capture/')
 
-    const posthogBody = fetchMock.mock.calls[1][1]?.body
-    expect(typeof posthogBody).toBe('string')
-    if (typeof posthogBody !== 'string') {
-      throw new Error('Expected the PostHog request body to be a JSON string')
+    const creemBody = parseJsonRequestBody(fetchMock.mock.calls[0][1]?.body)
+    const requestId = creemBody.request_id
+    expect(typeof requestId).toBe('string')
+    if (typeof requestId !== 'string') {
+      throw new Error('Expected an opaque Creem request ID')
     }
-    expect(posthogBody).toContain('"$geoip_disable":true')
+    expect(requestId).toMatch(UUID_PATTERN)
+    expect(creemBody.metadata).toEqual({ plan: '1-device', locale: 'en' })
+
+    expect(parseJsonRequestBody(fetchMock.mock.calls[1][1]?.body)).toEqual({
+      api_key: 'posthog-test-key',
+      event: 'checkout_redirected',
+      properties: {
+        distinct_id: requestId,
+        plan: '1-device',
+        locale: 'en',
+        source: 'website',
+        $host: 'dockerman.app',
+        $geoip_disable: true
+      }
+    })
+  })
+
+  test('keeps the checkout redirect when analytics delivery fails', async () => {
+    const fetchMock = mock((input: string | URL | Request) => {
+      if (input === 'https://test-api.creem.io/v1/checkouts') {
+        return Promise.resolve(Response.json({ checkout_url: 'https://checkout.test/pay' }))
+      }
+
+      return Promise.reject(new Error('PostHog unavailable'))
+    })
+    globalThis.fetch = fetchMock
+
+    const response = await POST(checkoutRequest('POST'))
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get('location')).toBe('https://checkout.test/pay')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('normalizes untrusted locale values before sending them to external services', async () => {
+    const fetchMock = mock(async () => Response.json({ checkout_url: 'https://checkout.test/pay' }))
+    globalThis.fetch = fetchMock
+
+    const response = await POST(checkoutRequest('POST', '1-device', 'private@example.com'))
+
+    expect(response.status).toBe(303)
+    const creemBody = parseJsonRequestBody(fetchMock.mock.calls[0][1]?.body)
+    expect(creemBody.success_url).toBe('https://dockerman.app/en/pricing/success')
+    expect(creemBody.metadata).toEqual({ plan: '1-device', locale: 'en' })
+
+    const posthogBody = parseJsonRequestBody(fetchMock.mock.calls[1][1]?.body)
+    expect(posthogBody).toEqual({
+      api_key: 'posthog-test-key',
+      event: 'checkout_redirected',
+      properties: {
+        distinct_id: creemBody.request_id,
+        plan: '1-device',
+        locale: 'en',
+        source: 'website',
+        $host: 'dockerman.app',
+        $geoip_disable: true
+      }
+    })
   })
 })

--- a/apps/landing/src/app/api/checkout/route.ts
+++ b/apps/landing/src/app/api/checkout/route.ts
@@ -1,21 +1,11 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { siteConfig } from '@/app/siteConfig'
-import { pricingConfig } from '@/config/pricing'
-import { withGeoIpDisabled } from '@/lib/analytics/posthogConfig'
+import { captureWebsiteEvent } from '@/lib/analytics/serverPostHog'
+import { getPaidPlanConfig, normalizeLocale, parsePaidPlan } from '@/lib/creem/checkoutMetadata'
+import { isRecord } from '@/lib/typeGuards'
 
 const CREEM_BASE_URL =
   process.env.NODE_ENV === 'production' ? 'https://api.creem.io' : 'https://test-api.creem.io'
-
-const PLAN_CONFIG: Record<string, { productId?: string; discountCode?: string }> = {
-  '1-device': {
-    productId: process.env.CREEM_PRODUCT_ID_1_DEVICES,
-    discountCode: pricingConfig.discountCodes['1-device']
-  },
-  '3-devices': {
-    productId: process.env.CREEM_PRODUCT_ID_3_DEVICES,
-    discountCode: pricingConfig.discountCodes['3-devices']
-  }
-}
 
 export function GET() {
   return NextResponse.json(
@@ -26,14 +16,14 @@ export function GET() {
 
 export async function POST(request: NextRequest) {
   const { searchParams } = request.nextUrl
-  const plan = searchParams.get('plan')
-  const locale = searchParams.get('locale') ?? 'en'
+  const plan = parsePaidPlan(searchParams.get('plan'))
+  const locale = normalizeLocale(searchParams.get('locale'))
 
-  if (!(plan && PLAN_CONFIG[plan])) {
+  if (!plan) {
     return NextResponse.json({ error: 'Invalid plan parameter' }, { status: 400 })
   }
 
-  const { productId, discountCode } = PLAN_CONFIG[plan]
+  const { productId, discountCode } = getPaidPlanConfig(plan)
   if (!productId) {
     return NextResponse.json({ error: 'Product ID not configured' }, { status: 500 })
   }
@@ -45,14 +35,13 @@ export async function POST(request: NextRequest) {
 
   const successUrl = `${siteConfig.url}/${locale}/pricing/success`
 
-  const body: Record<string, unknown> = {
+  const requestId = crypto.randomUUID()
+  const body = {
     product_id: productId,
     success_url: successUrl,
-    request_id: `${plan}-${Date.now()}`
-  }
-
-  if (discountCode) {
-    body.discount_code = discountCode
+    request_id: requestId,
+    metadata: { plan, locale },
+    ...(discountCode ? { discount_code: discountCode } : {})
   }
 
   try {
@@ -66,40 +55,28 @@ export async function POST(request: NextRequest) {
     })
 
     if (!response.ok) {
-      const error = await response.text()
-      console.error('Creem checkout error:', response.status, error)
+      console.error('Creem checkout failed with status:', response.status)
       return NextResponse.json(
         { error: 'Failed to create checkout session' },
         { status: response.status }
       )
     }
 
-    const checkout = await response.json()
+    const checkout: unknown = await response.json()
 
-    if (!checkout.checkout_url) {
+    if (!isRecord(checkout) || typeof checkout.checkout_url !== 'string') {
       return NextResponse.json({ error: 'No checkout URL returned' }, { status: 500 })
     }
 
-    // Fire checkout_redirected event via PostHog HTTP API
-    const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY
-    if (posthogKey) {
-      fetch('https://us.i.posthog.com/capture/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          api_key: posthogKey,
-          event: 'checkout_redirected',
-          distinct_id: body.request_id,
-          properties: withGeoIpDisabled({ plan, locale })
-        })
-      }).catch(() => {
-        // Non-blocking: don't fail checkout if analytics fails
-      })
-    }
+    await captureWebsiteEvent({
+      event: 'checkout_redirected',
+      distinctId: requestId,
+      properties: { plan, locale }
+    })
 
     return NextResponse.redirect(checkout.checkout_url, 303)
-  } catch (error) {
-    console.error('Creem checkout error:', error)
+  } catch {
+    console.error('Creem checkout failed before receiving a response')
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }

--- a/apps/landing/src/app/api/webhooks/creem/route.test.ts
+++ b/apps/landing/src/app/api/webhooks/creem/route.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { createHmac } from 'node:crypto'
+import { parseJsonRequestBody } from '@/test/parseJsonRequestBody'
+
+const originalFetch = globalThis.fetch
+const originalEnv = {
+  CREEM_WEBHOOK_SECRET: process.env.CREEM_WEBHOOK_SECRET,
+  NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY
+}
+
+const WEBHOOK_SECRET = 'creem-test-secret'
+const REQUEST_ID = '018f3b4c-5d6e-7f80-9123-a456789bcdef'
+const COMPLETED_CHECKOUT =
+  '{"id":"evt_test_123","eventType":"checkout.completed","created_at":1783877000000,"object":{"id":"ch_private","request_id":"018f3b4c-5d6e-7f80-9123-a456789bcdef","status":"completed","metadata":{"plan":"3-devices","locale":"zh"},"order":{"id":"ord_private","amount":799,"currency":"USD","status":"paid"},"customer":{"id":"cus_private","name":"Private Person","email":"private@example.com","country":"US"}}}'
+
+process.env.CREEM_WEBHOOK_SECRET = WEBHOOK_SECRET
+process.env.NEXT_PUBLIC_POSTHOG_KEY = 'posthog-test-key'
+
+const { POST } = await import('./route')
+
+function signature(body: string) {
+  return createHmac('sha256', WEBHOOK_SECRET).update(body).digest('hex')
+}
+
+function webhookRequest(body: string, webhookSignature = signature(body)) {
+  return new Request('https://dockerman.app/api/webhooks/creem', {
+    method: 'POST',
+    headers: { 'creem-signature': webhookSignature },
+    body
+  })
+}
+
+beforeEach(() => {
+  process.env.CREEM_WEBHOOK_SECRET = WEBHOOK_SECRET
+  process.env.NEXT_PUBLIC_POSTHOG_KEY = 'posthog-test-key'
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+})
+
+describe('Creem webhook route', () => {
+  test('captures one privacy-safe purchase event from a valid completed checkout', async () => {
+    const fetchMock = mock(async () => Response.json({ status: 'ok' }))
+    globalThis.fetch = fetchMock
+
+    const response = await POST(webhookRequest(COMPLETED_CHECKOUT))
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe('https://us.i.posthog.com/capture/')
+    expect(parseJsonRequestBody(fetchMock.mock.calls[0][1]?.body)).toEqual({
+      api_key: 'posthog-test-key',
+      event: 'purchase_completed',
+      properties: {
+        distinct_id: REQUEST_ID,
+        plan: '3-devices',
+        locale: 'zh',
+        amount_minor: 799,
+        currency: 'USD',
+        source: 'website',
+        $host: 'dockerman.app',
+        $geoip_disable: true,
+        $insert_id: `purchase:${REQUEST_ID}`
+      }
+    })
+  })
+
+  test('rejects invalid signatures without sending analytics', async () => {
+    const fetchMock = mock(async () => Response.json({ status: 'ok' }))
+    globalThis.fetch = fetchMock
+
+    const response = await POST(webhookRequest(COMPLETED_CHECKOUT, 'invalid-signature'))
+
+    expect(response.status).toBe(401)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test('acknowledges unrelated signed events without sending analytics', async () => {
+    const fetchMock = mock(async () => Response.json({ status: 'ok' }))
+    globalThis.fetch = fetchMock
+    const unrelatedEvent = COMPLETED_CHECKOUT.replace(
+      '"eventType":"checkout.completed"',
+      '"eventType":"subscription.active"'
+    )
+
+    const response = await POST(webhookRequest(unrelatedEvent))
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test('requests a Creem retry when purchase analytics delivery fails', async () => {
+    const fetchMock = mock(async () => new Response(null, { status: 503 }))
+    globalThis.fetch = fetchMock
+
+    const response = await POST(webhookRequest(COMPLETED_CHECKOUT))
+
+    expect(response.status).toBe(503)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/landing/src/app/api/webhooks/creem/route.ts
+++ b/apps/landing/src/app/api/webhooks/creem/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server'
+
+import { captureWebsiteEvent } from '@/lib/analytics/serverPostHog'
+import { parseVerifiedCreemWebhook } from '@/lib/creem/webhook'
+
+export async function POST(request: Request) {
+  const secret = process.env.CREEM_WEBHOOK_SECRET
+  if (!secret) {
+    return NextResponse.json({ error: 'Webhook not configured' }, { status: 503 })
+  }
+
+  const signature = request.headers.get('creem-signature')
+  if (!signature) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
+  }
+
+  const rawBody = await request.text()
+  const result = parseVerifiedCreemWebhook(rawBody, signature, secret)
+
+  if (result.kind === 'invalid-signature') {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
+  }
+
+  if (result.kind === 'invalid-payload') {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+  }
+
+  if (result.kind === 'ignored') {
+    return NextResponse.json({ received: true })
+  }
+
+  const { purchase } = result
+  const captured = await captureWebsiteEvent({
+    event: 'purchase_completed',
+    distinctId: purchase.requestId,
+    insertId: `purchase:${purchase.requestId}`,
+    properties: {
+      plan: purchase.plan,
+      locale: purchase.locale,
+      amount_minor: purchase.amountMinor,
+      currency: purchase.currency
+    }
+  })
+
+  if (!captured) {
+    return NextResponse.json({ error: 'Analytics delivery failed' }, { status: 503 })
+  }
+
+  return NextResponse.json({ received: true })
+}

--- a/apps/landing/src/config/pricing.ts
+++ b/apps/landing/src/config/pricing.ts
@@ -4,7 +4,7 @@ export const pricingConfig = {
   discountCodes: {
     '1-device': '',
     '3-devices': ''
-  } as Record<string, string>,
+  },
   plans: {
     free: { price: 0 },
     team: { priceEarlyBird: 18.86, priceRegular: 29, devices: 3 },

--- a/apps/landing/src/lib/analytics/serverPostHog.ts
+++ b/apps/landing/src/lib/analytics/serverPostHog.ts
@@ -1,0 +1,70 @@
+import type { Locale } from '@repo/shared/i18n'
+import { siteConfig } from '@/app/siteConfig'
+import { withGeoIpDisabled } from '@/lib/analytics/posthogConfig'
+import type { PaidPlan } from '@/lib/creem/checkoutMetadata'
+
+const POSTHOG_CAPTURE_URL = 'https://us.i.posthog.com/capture/'
+const POSTHOG_TIMEOUT_MS = 1500
+const WEBSITE_HOST = new URL(siteConfig.url).host
+
+interface CheckoutRedirectedCapture {
+  distinctId: string
+  event: 'checkout_redirected'
+  properties: {
+    locale: Locale
+    plan: PaidPlan
+  }
+}
+
+interface PurchaseCompletedCapture {
+  distinctId: string
+  event: 'purchase_completed'
+  insertId: string
+  properties: {
+    amount_minor: number
+    currency: string
+    locale: Locale
+    plan: PaidPlan
+  }
+}
+
+type WebsiteEventCapture = CheckoutRedirectedCapture | PurchaseCompletedCapture
+
+export async function captureWebsiteEvent(capture: WebsiteEventCapture): Promise<boolean> {
+  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY
+  if (!apiKey) {
+    console.warn('PostHog capture skipped because NEXT_PUBLIC_POSTHOG_KEY is not configured')
+    return false
+  }
+
+  const eventProperties = withGeoIpDisabled({
+    ...capture.properties,
+    distinct_id: capture.distinctId,
+    source: 'website',
+    $host: WEBSITE_HOST,
+    ...(capture.event === 'purchase_completed' ? { $insert_id: capture.insertId } : {})
+  })
+
+  try {
+    const response = await fetch(POSTHOG_CAPTURE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        api_key: apiKey,
+        event: capture.event,
+        properties: eventProperties
+      }),
+      signal: AbortSignal.timeout(POSTHOG_TIMEOUT_MS)
+    })
+
+    if (!response.ok) {
+      console.warn('PostHog capture failed with status:', response.status)
+      return false
+    }
+
+    return true
+  } catch {
+    console.warn('PostHog capture failed before receiving a response')
+    return false
+  }
+}

--- a/apps/landing/src/lib/creem/checkoutMetadata.ts
+++ b/apps/landing/src/lib/creem/checkoutMetadata.ts
@@ -1,0 +1,34 @@
+import { defaultLocale, type Locale } from '@repo/shared/i18n'
+import { pricingConfig } from '@/config/pricing'
+
+export type PaidPlan = '1-device' | '3-devices'
+
+export function parsePaidPlan(value: unknown): PaidPlan | null {
+  if (value === '1-device' || value === '3-devices') {
+    return value
+  }
+
+  return null
+}
+
+export function normalizeLocale(value: unknown): Locale {
+  if (value === 'en' || value === 'zh' || value === 'ja' || value === 'es') {
+    return value
+  }
+
+  return defaultLocale
+}
+
+export function getPaidPlanConfig(plan: PaidPlan) {
+  if (plan === '1-device') {
+    return {
+      productId: process.env.CREEM_PRODUCT_ID_1_DEVICES,
+      discountCode: pricingConfig.discountCodes['1-device']
+    }
+  }
+
+  return {
+    productId: process.env.CREEM_PRODUCT_ID_3_DEVICES,
+    discountCode: pricingConfig.discountCodes['3-devices']
+  }
+}

--- a/apps/landing/src/lib/creem/webhook.test.ts
+++ b/apps/landing/src/lib/creem/webhook.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test'
+import { createHmac } from 'node:crypto'
+
+import { parseVerifiedCreemWebhook } from './webhook'
+
+const WEBHOOK_SECRET = 'creem-test-secret'
+const COMPLETED_CHECKOUT =
+  '{"id":"evt_test_123","eventType":"checkout.completed","created_at":1783877000000,"object":{"id":"ch_private","request_id":"018f3b4c-5d6e-7f80-9123-a456789bcdef","status":"completed","metadata":{"plan":"3-devices","locale":"zh"},"order":{"id":"ord_private","amount":799,"currency":"USD","status":"paid"},"customer":{"id":"cus_private","name":"Private Person","email":"private@example.com","country":"US"}}}'
+const COMPLETED_CHECKOUT_SIGNATURE =
+  '66c939be127361b0181dc23c1f9b3e989f88c69bb9d4f9fe266d6cf744e7b50d'
+
+function sign(body: string) {
+  return createHmac('sha256', WEBHOOK_SECRET).update(body).digest('hex')
+}
+
+describe('Creem webhook verification', () => {
+  test('returns only privacy-safe purchase fields for a literal signed fixture', () => {
+    expect(
+      parseVerifiedCreemWebhook(COMPLETED_CHECKOUT, COMPLETED_CHECKOUT_SIGNATURE, WEBHOOK_SECRET)
+    ).toEqual({
+      kind: 'purchase',
+      purchase: {
+        requestId: '018f3b4c-5d6e-7f80-9123-a456789bcdef',
+        plan: '3-devices',
+        locale: 'zh',
+        amountMinor: 799,
+        currency: 'USD'
+      }
+    })
+  })
+
+  test('rejects an invalid signature before parsing the payload', () => {
+    expect(
+      parseVerifiedCreemWebhook(COMPLETED_CHECKOUT, 'not-a-valid-signature', WEBHOOK_SECRET)
+    ).toEqual({ kind: 'invalid-signature' })
+  })
+
+  test('ignores valid events that do not represent a paid completed checkout', () => {
+    const unpaidCheckout = COMPLETED_CHECKOUT.replace('"status":"paid"', '"status":"pending"')
+    const unrelatedEvent = COMPLETED_CHECKOUT.replace(
+      '"eventType":"checkout.completed"',
+      '"eventType":"subscription.active"'
+    )
+
+    expect(parseVerifiedCreemWebhook(unpaidCheckout, sign(unpaidCheckout), WEBHOOK_SECRET)).toEqual(
+      {
+        kind: 'ignored'
+      }
+    )
+    expect(parseVerifiedCreemWebhook(unrelatedEvent, sign(unrelatedEvent), WEBHOOK_SECRET)).toEqual(
+      {
+        kind: 'ignored'
+      }
+    )
+  })
+
+  test('rejects malformed signed JSON', () => {
+    const malformedBody = '{"eventType":'
+
+    expect(parseVerifiedCreemWebhook(malformedBody, sign(malformedBody), WEBHOOK_SECRET)).toEqual({
+      kind: 'invalid-payload'
+    })
+  })
+
+  test('does not forward an untrusted locale value', () => {
+    const checkoutWithUntrustedLocale = COMPLETED_CHECKOUT.replace(
+      '"locale":"zh"',
+      '"locale":"private@example.com"'
+    )
+
+    expect(
+      parseVerifiedCreemWebhook(
+        checkoutWithUntrustedLocale,
+        sign(checkoutWithUntrustedLocale),
+        WEBHOOK_SECRET
+      )
+    ).toEqual({
+      kind: 'purchase',
+      purchase: {
+        requestId: '018f3b4c-5d6e-7f80-9123-a456789bcdef',
+        plan: '3-devices',
+        locale: 'en',
+        amountMinor: 799,
+        currency: 'USD'
+      }
+    })
+  })
+})

--- a/apps/landing/src/lib/creem/webhook.ts
+++ b/apps/landing/src/lib/creem/webhook.ts
@@ -1,0 +1,112 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+import type { Locale } from '@repo/shared/i18n'
+import { normalizeLocale, type PaidPlan, parsePaidPlan } from '@/lib/creem/checkoutMetadata'
+import { isRecord } from '@/lib/typeGuards'
+
+const CURRENCY_PATTERN = /^[a-z]{3}$/i
+const SIGNATURE_PATTERN = /^[0-9a-f]{64}$/
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+interface PrivacySafePurchase {
+  amountMinor: number
+  currency: string
+  locale: Locale
+  plan: PaidPlan
+  requestId: string
+}
+
+export type VerifiedCreemWebhook =
+  | { kind: 'ignored' }
+  | { kind: 'invalid-payload' }
+  | { kind: 'invalid-signature' }
+  | { kind: 'purchase'; purchase: PrivacySafePurchase }
+
+function isUuid(value: unknown): value is string {
+  return typeof value === 'string' && UUID_PATTERN.test(value)
+}
+
+function hasValidSignature(rawBody: string, signature: string, secret: string) {
+  const normalizedSignature = signature.trim().toLowerCase()
+  if (!SIGNATURE_PATTERN.test(normalizedSignature)) {
+    return false
+  }
+
+  const expected = Buffer.from(createHmac('sha256', secret).update(rawBody).digest('hex'), 'hex')
+  const received = Buffer.from(normalizedSignature, 'hex')
+
+  return expected.length === received.length && timingSafeEqual(expected, received)
+}
+
+export function parseVerifiedCreemWebhook(
+  rawBody: string,
+  signature: string,
+  secret: string
+): VerifiedCreemWebhook {
+  if (!hasValidSignature(rawBody, signature, secret)) {
+    return { kind: 'invalid-signature' }
+  }
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(rawBody)
+  } catch {
+    return { kind: 'invalid-payload' }
+  }
+
+  if (!isRecord(payload) || typeof payload.eventType !== 'string') {
+    return { kind: 'invalid-payload' }
+  }
+
+  if (payload.eventType !== 'checkout.completed') {
+    return { kind: 'ignored' }
+  }
+
+  const checkout = payload.object
+  if (!isRecord(checkout)) {
+    return { kind: 'invalid-payload' }
+  }
+
+  const order = checkout.order
+  if (!isRecord(order)) {
+    return { kind: 'invalid-payload' }
+  }
+
+  if (checkout.status !== 'completed' || order.status !== 'paid') {
+    return { kind: 'ignored' }
+  }
+
+  const metadata = checkout.metadata
+  if (!isRecord(metadata)) {
+    return { kind: 'invalid-payload' }
+  }
+
+  const plan = parsePaidPlan(metadata.plan)
+  const amountMinor = order.amount
+  const currency = order.currency
+
+  if (!(isUuid(checkout.request_id) && plan)) {
+    return { kind: 'invalid-payload' }
+  }
+
+  if (
+    typeof amountMinor !== 'number' ||
+    !Number.isSafeInteger(amountMinor) ||
+    amountMinor < 0 ||
+    typeof currency !== 'string' ||
+    !CURRENCY_PATTERN.test(currency)
+  ) {
+    return { kind: 'invalid-payload' }
+  }
+
+  return {
+    kind: 'purchase',
+    purchase: {
+      requestId: checkout.request_id,
+      plan,
+      locale: normalizeLocale(metadata.locale),
+      amountMinor,
+      currency: currency.toUpperCase()
+    }
+  }
+}

--- a/apps/landing/src/lib/typeGuards.ts
+++ b/apps/landing/src/lib/typeGuards.ts
@@ -1,0 +1,3 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/apps/landing/src/test/parseJsonRequestBody.ts
+++ b/apps/landing/src/test/parseJsonRequestBody.ts
@@ -1,0 +1,14 @@
+import { isRecord } from '@/lib/typeGuards'
+
+export function parseJsonRequestBody(body: BodyInit | null | undefined) {
+  if (typeof body !== 'string') {
+    throw new Error('Expected a JSON string request body')
+  }
+
+  const parsed: unknown = JSON.parse(body)
+  if (!isRecord(parsed)) {
+    throw new Error('Expected a JSON object request body')
+  }
+
+  return parsed
+}

--- a/docs/plans/2026-07-13-posthog-metrics-remediation.md
+++ b/docs/plans/2026-07-13-posthog-metrics-remediation.md
@@ -1,0 +1,208 @@
+# PostHog Metrics Remediation Plan
+
+## Goal
+
+Make the website analytics trustworthy, privacy-safe, and understandable without
+changing the desktop client's PostHog instrumentation or shared project-wide
+collection settings.
+
+## Research baseline
+
+PostHog Web Analytics already provides the standard website metrics we need:
+visitors, page views, sessions, session duration, bounce rate, traffic sources,
+entry and exit paths, and device/browser/OS breakdowns. Custom dashboards should
+therefore focus on Dockerman-specific behavior and conversion instead of
+rebuilding every generic web metric.
+
+PostHog Trends default to total event count. Unique-user metrics must be selected
+explicitly when the question is about people rather than actions.
+
+Creem's successful redirect contains checkout identifiers, but its official
+production guidance recommends webhooks for authoritative payment completion.
+The `checkout.completed` webhook is signed with HMAC-SHA256 using the raw request
+body and the `creem-signature` header. Failed deliveries are retried.
+
+Primary sources:
+
+- [PostHog Web Analytics](https://posthog.com/docs/web-analytics/getting-started)
+- [PostHog Trends aggregations](https://posthog.com/docs/product-analytics/trends/aggregations)
+- [PostHog ecommerce events](https://posthog.com/docs/data/event-spec/ecommerce-events)
+- [Creem webhooks](https://docs.creem.io/code/webhooks)
+
+## Current problems
+
+1. The shared PostHog project contains website and desktop events, while several
+   dashboard insights did not identify the website source consistently.
+2. The conversion dashboard only observes `checkout_redirected`. That is a
+   checkout start, not a purchase, so it cannot report a real conversion rate.
+3. The checkout route sends analytics with an unawaited `fetch`. A serverless
+   invocation may finish before the request is delivered.
+4. Checkout attempts use a timestamp-based request ID. It is not personal data,
+   but an opaque random ID has clearer semantics and safer collision behavior.
+5. The existing analytics design documents describe events that are no longer
+   emitted, which caused stale or empty dashboard tiles.
+6. Dashboard labels do not explain whether a value counts events, visitors, or
+   successful purchases.
+
+## Architecture
+
+### Sources of truth
+
+- Use PostHog Web Analytics for generic traffic statistics.
+- Use custom PostHog dashboards for product-specific behavior and conversion.
+- Use Vercel Speed Insights for Core Web Vitals and runtime performance.
+- Use Creem's signed `checkout.completed` webhook as the source of truth for a
+  completed purchase.
+
+### Website event boundary
+
+Every website-owned server event will include:
+
+```text
+source = website
+$host = dockerman.app
+$geoip_disable = true
+```
+
+These properties allow website dashboards to filter safely without changing any
+desktop event or shared PostHog project setting.
+
+### Conversion correlation
+
+The checkout route will create one opaque UUID and use it as Creem's `request_id`
+and PostHog's `distinct_id` for `checkout_redirected`. Creem checkout metadata
+will carry only the selected plan and locale.
+
+When Creem later sends `checkout.completed`, the verified webhook will capture
+`purchase_completed` with the same request ID as its `distinct_id`. This enables
+an aggregate checkout-start to purchase-complete funnel without browser identity,
+email addresses, names, customer IDs, or device fingerprints.
+
+### Delivery behavior
+
+Checkout creation must never fail because analytics is unavailable. The route
+will await PostHog delivery with a short timeout after Creem has created the
+checkout, log a delivery failure without sensitive payload data, and still
+redirect the customer.
+
+The webhook will verify the signature before parsing or capturing an event. It
+will acknowledge unrelated valid Creem events without analytics side effects.
+PostHog's `$insert_id` will be derived from the opaque request ID so repeated
+Creem deliveries are deduplicated. If PostHog does not accept a purchase event,
+the webhook will return 503 so Creem's documented retry schedule can deliver it
+again without producing a duplicate conversion.
+
+## Privacy contract
+
+Allowed PostHog properties:
+
+| Property | Reason |
+| --- | --- |
+| `plan` | Aggregate product preference and conversion breakdown |
+| `locale` | Aggregate language experience quality |
+| `amount_minor` | Aggregate revenue without transaction identity |
+| `currency` | Required interpretation for monetary values |
+| `source` | Website/desktop isolation |
+| `$host` | Website dashboard filter |
+| `$geoip_disable` | Prevent IP-derived enrichment |
+| `$insert_id` | Retry deduplication using an opaque checkout request ID |
+
+Forbidden PostHog properties:
+
+- Customer name or email
+- Customer, order, checkout, or payment identifiers
+- Billing address or country
+- IP address or user agent added by application code
+- Raw webhook payloads or signatures
+
+The random checkout request ID is used only as a short-lived funnel correlation
+key. It is not linked to the browser's persistent PostHog identity.
+
+## Event definitions
+
+### `checkout_redirected`
+
+Meaning: Creem created a checkout and the website is redirecting the visitor to
+it. Count this as a checkout start, never as a sale.
+
+Properties: `plan`, `locale`, `source`, `$host`, `$geoip_disable`.
+
+### `purchase_completed`
+
+Meaning: Creem delivered a valid signed `checkout.completed` webhook whose order
+status is paid.
+
+Properties: `plan`, `locale`, `amount_minor`, `currency`, `source`, `$host`,
+`$geoip_disable`, `$insert_id`.
+
+### Existing behavior events
+
+- `page_scroll_depth`: one event per reached 25/50/75/100 percent threshold.
+- `page_engaged`: one event after at least 10 seconds plus an interaction.
+- `about_social_clicked`: a social-link click on the About page.
+- `footer_theme_changed`: a footer theme selection.
+
+No new DOM autocapture or form-field capture is required.
+
+## Dashboard remediation
+
+Only the website dashboards will be changed. Shared project settings and desktop
+dashboards are out of scope.
+
+### Traffic
+
+Keep page views, unique visitors, referrers, UTM fields, and device type. Add an
+explanation card that points users to built-in Web Analytics for sessions, bounce
+rate, duration, landing pages, and exit pages. All custom tiles must filter on
+`$host = dockerman.app`.
+
+### Behavior
+
+Keep current emitted events only. Labels must state whether they count actions or
+pages. All custom tiles must filter on `$host = dockerman.app`.
+
+### Conversion
+
+After production begins receiving `purchase_completed`, add:
+
+1. Checkout starts, total and daily trend.
+2. Checkout starts by plan.
+3. Checkout start to purchase completion funnel.
+4. Completed purchases by plan.
+5. Revenue by currency, only when PostHog can aggregate `amount_minor` without
+   mixing currencies.
+
+Conversion server events must filter on `source = website`; they do not depend on
+the browser `$host` property being inferred.
+
+### Performance
+
+Keep the explanatory card directing users to Vercel Speed Insights. Do not
+duplicate Core Web Vitals with custom PostHog events.
+
+## Public test seams
+
+1. **Signed webhook parser**: a valid literal HMAC fixture produces a sanitized
+   purchase event; invalid signatures, malformed bodies, and unpaid orders do not.
+2. **Creem webhook HTTP route**: a valid `checkout.completed` request returns 200
+   and submits only the allowed PostHog fields; an invalid signature returns 401
+   and submits nothing; unrelated signed events return 200 and submit nothing.
+3. **Checkout HTTP route**: Creem receives one opaque UUID plus `plan`/`locale`
+   metadata; PostHog receives the same UUID with the website privacy properties;
+   the route keeps its 303 redirect and remains successful when analytics fails.
+
+Network boundaries may use the repository's existing fetch interception pattern;
+cryptographic verification and payload sanitization are tested with real values,
+not mocked implementations.
+
+## Deployment steps
+
+1. Deploy the website changes with `CREEM_WEBHOOK_SECRET` configured.
+2. Register `https://dockerman.app/api/webhooks/creem` for
+   `checkout.completed` in Creem Developers > Webhooks.
+3. Send a Creem test webhook and confirm one privacy-safe
+   `purchase_completed` event in PostHog Live Events.
+4. Confirm a repeated delivery is deduplicated.
+5. Build the conversion dashboard tiles only after the event schema is observed
+   in production.
+6. Re-check that desktop events and shared PostHog project settings are unchanged.


### PR DESCRIPTION
## Summary

- isolate landing server events with explicit website source, host, and GeoIP-disabled properties
- create Creem checkouts with opaque UUID correlation and privacy-safe plan/locale metadata
- verify signed checkout.completed webhooks and capture authoritative purchase_completed events
- retry failed purchase analytics safely with stable PostHog insert IDs
- document the researched metric and dashboard remediation plan

## Privacy

- never forwards customer names, email addresses, countries, or customer/order/payment identifiers to PostHog
- constrains locale and plan values before sending them to external services
- leaves desktop analytics instrumentation and shared PostHog project settings unchanged

## Validation

- 13 focused Bun tests passed
- targeted Ultracite check passed
- bun run build:landing passed
- independent Standards and Spec reviews passed with no remaining findings

## Deployment

The production CREEM_WEBHOOK_SECRET and checkout.completed webhook have been configured by the project owner. After deployment, send a Creem test webhook, confirm deduplication, and add purchase-based PostHog funnel tiles once the production schema is observed.