### PR TITLE
feat(landing): polish marketing UI and replace teal accent

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -42,24 +42,28 @@ a user needs to read, you're using it wrong.
 
 ### 1.3 Accents
 
-| Token             | Value      | Role                                                       |
-| ----------------- | ---------- | ---------------------------------------------------------- |
-| `dm-accent`       | `#14b8a6`  | Primary accent. Teal. `$` prompt, section eyebrows, links. |
-| `dm-accent-2`     | `#6366f1`  | Secondary accent. Indigo. Focus rings, `NEW` badges.       |
-| `dm-accent-warm`  | `#f97316`  | Warm accent. Orange. Sparingly, for emphasis contrast.     |
+| Token             | Light      | Dark       | Role                                                       |
+| ----------------- | ---------- | ---------- | ---------------------------------------------------------- |
+| `dm-accent`       | `#0c7a73`  | `#2aa89c`  | Primary accent. Mineral teal. `$` prompt, eyebrows, links. |
+| `dm-accent-2`     | `#3d44b8`  | `#8a8ef0`  | Secondary accent. Ink indigo. Focus rings.                 |
+| `dm-accent-warm`  | `#c45e14`  | `#e0893a`  | Warm accent. Used sparingly for contrast.                  |
+| `dm-grad-from`    | `#0a6560`  | same       | CTA / brand-mark gradient start                            |
+| `dm-grad-mid`     | `#1b5f92`  | same       | Azure mid-stop so the blend does not go gray               |
+| `dm-grad-to`      | `#3238ad`  | same       | CTA / brand-mark gradient end                              |
 
-**Pair them, don't collide.** The canonical gradient is
-`linear-gradient(135deg, var(--color-dm-accent), var(--color-dm-accent-2))`
-— teal → indigo, top-left to bottom-right — used on CTAs, brand marks,
-and italic display accents.
+**Pair them, don't collide.** Never hand-type the teal → indigo blend.
+Use `background: var(--dm-grad)` — `135deg in oklab` with the three
+`--color-dm-grad-*` stops. Horizontal fills use `--dm-grad-90`. These
+are the only gradients that carry white type; every stop is ≥ 4.5:1
+against `#fff`.
 
 ### 1.4 Status
 
-| Token     | Value     | Use                              |
-| --------- | --------- | -------------------------------- |
-| `dm-ok`   | `#10b981` | Running, healthy, success dot    |
-| `dm-warn` | `#f59e0b` | Pending, degraded                |
-| `dm-err`  | `#ef4444` | Failed, destructive confirmation |
+| Token     | Light      | Dark       | Use                              |
+| --------- | ---------- | ---------- | -------------------------------- |
+| `dm-ok`   | `#1b8554`  | `#3dba7a`  | Running, healthy, success dot    |
+| `dm-warn` | `#a67c0a`  | `#d4a017`  | Pending, degraded                |
+| `dm-err`  | `#c73636`  | `#ef6b6b`  | Failed, destructive confirmation |
 
 Status tokens carry meaning — don't use `dm-ok` for decoration just
 because you like green.
@@ -131,8 +135,8 @@ critical to comprehension, gate it via `.dm-animated`.
 <Link
   className="inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 font-semibold text-[14px] text-white no-underline transition-all hover:-translate-y-px"
   style={{
-    background: 'linear-gradient(135deg, var(--color-dm-accent), var(--color-dm-accent-2))',
-    boxShadow: '0 10px 30px -10px color-mix(in srgb, var(--color-dm-accent-2) 60%, transparent)',
+    background: 'var(--dm-grad)',
+    boxShadow: '0 10px 30px -10px color-mix(in srgb, var(--color-dm-grad-to) 55%, transparent)',
   }}
 >
   Download Dockerman

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -273,7 +273,7 @@ ones.
 | Overlay / lightbox| `0 30px 60px -20px rgb(0 0 0 / 0.6)`                                                                        |
 | Focus halo        | `0 0 0 3px color-mix(in srgb, var(--color-dm-accent-2) 18%, transparent)`                                  |
 | Live dot halo     | `0 0 0 4px color-mix(in srgb, var(--color-dm-ok) 30%, transparent)`                                        |
-| Brand mark        | `inset 0 0 0 1px rgb(255 255 255 / 0.1), 0 4px 12px -4px var(--color-dm-accent)`                           |
+| Brand mark        | `inset 0 0 0 1px rgb(255 255 255 / 0.12), 0 4px 12px -4px rgb(0 0 0 / 0.35)` on `#0a0a0a`                  |
 
 Notice the pattern: **glows use `color-mix` with the glow's own accent,
 never plain black-on-color**. This keeps the glow chromatically coherent

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -42,28 +42,23 @@ a user needs to read, you're using it wrong.
 
 ### 1.3 Accents
 
-| Token             | Light      | Dark       | Role                                                       |
-| ----------------- | ---------- | ---------- | ---------------------------------------------------------- |
-| `dm-accent`       | `#0c7a73`  | `#2aa89c`  | Primary accent. Mineral teal. `$` prompt, eyebrows, links. |
-| `dm-accent-2`     | `#3d44b8`  | `#8a8ef0`  | Secondary accent. Ink indigo. Focus rings.                 |
-| `dm-accent-warm`  | `#c45e14`  | `#e0893a`  | Warm accent. Used sparingly for contrast.                  |
-| `dm-grad-from`    | `#0a6560`  | same       | CTA / brand-mark gradient start                            |
-| `dm-grad-mid`     | `#1b5f92`  | same       | Azure mid-stop so the blend does not go gray               |
-| `dm-grad-to`      | `#3238ad`  | same       | CTA / brand-mark gradient end                              |
+| Token            | Value     | Role                                                       |
+| ---------------- | --------- | ---------------------------------------------------------- |
+| `dm-accent`      | `#14b8a6` | Primary accent. Teal. `$` prompt, section eyebrows, links. |
+| `dm-accent-2`    | `#6366f1` | Secondary accent. Indigo. Focus rings.                     |
+| `dm-accent-warm` | `#f97316` | Warm accent. Orange. Sparingly, for emphasis contrast.     |
 
-**Pair them, don't collide.** Never hand-type the teal → indigo blend.
-Use `background: var(--dm-grad)` — `135deg in oklab` with the three
-`--color-dm-grad-*` stops. Horizontal fills use `--dm-grad-90`. These
-are the only gradients that carry white type; every stop is ≥ 4.5:1
-against `#fff`.
+**Pair them, don't collide.** The canonical gradient is
+`background: var(--dm-grad)` — teal → indigo, `135deg in oklab`.
+Horizontal fills use `--dm-grad-90`. Do not hand-type the blend.
 
 ### 1.4 Status
 
-| Token     | Light      | Dark       | Use                              |
-| --------- | ---------- | ---------- | -------------------------------- |
-| `dm-ok`   | `#1b8554`  | `#3dba7a`  | Running, healthy, success dot    |
-| `dm-warn` | `#a67c0a`  | `#d4a017`  | Pending, degraded                |
-| `dm-err`  | `#c73636`  | `#ef6b6b`  | Failed, destructive confirmation |
+| Token     | Value     | Use                              |
+| --------- | --------- | -------------------------------- |
+| `dm-ok`   | `#10b981` | Running, healthy, success dot    |
+| `dm-warn` | `#f59e0b` | Pending, degraded                |
+| `dm-err`  | `#ef4444` | Failed, destructive confirmation |
 
 Status tokens carry meaning — don't use `dm-ok` for decoration just
 because you like green.
@@ -136,7 +131,7 @@ critical to comprehension, gate it via `.dm-animated`.
   className="inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 font-semibold text-[14px] text-white no-underline transition-all hover:-translate-y-px"
   style={{
     background: 'var(--dm-grad)',
-    boxShadow: '0 10px 30px -10px color-mix(in srgb, var(--color-dm-grad-to) 55%, transparent)',
+    boxShadow: '0 10px 30px -10px color-mix(in srgb, var(--color-dm-accent-2) 55%, transparent)',
   }}
 >
   Download Dockerman

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -48,9 +48,9 @@ a user needs to read, you're using it wrong.
 | `dm-accent-2`    | `#6366f1` | Secondary accent. Indigo. Focus rings.                     |
 | `dm-accent-warm` | `#f97316` | Warm accent. Orange. Sparingly, for emphasis contrast.     |
 
-**Pair them, don't collide.** The canonical gradient is
-`background: var(--dm-grad)` — teal → indigo, `135deg in oklab`.
-Horizontal fills use `--dm-grad-90`. Do not hand-type the blend.
+**Pair them, don't collide.** Accents are solid fills or solid type —
+never a teal → indigo gradient. Primary actions use `dm-ink` on
+`dm-bg`. Display italics use `dm-accent`.
 
 ### 1.4 Status
 
@@ -75,11 +75,10 @@ because you like green.
 **Display italic is the accent voice.** The site has two kinds of
 headline emphasis:
 
-1. **Gradient word** — `bg-clip-text` with the 135° accent gradient,
-   display italic. Used once per heading for the key verb/noun
-   (`Hero.tsx:87-90`, `CtaFinal.tsx:27-35`).
-2. **Quiet italic** — `dm-display` italic at `dm-ink-2`, no gradient.
-   Used for reflective subclauses (`FeaturesGrid.tsx:33-36`).
+1. **Accent italic** — `dm-display` italic at `dm-accent`. Used once
+   per heading for the key verb/noun (`Hero.tsx`, `CtaFinal.tsx`).
+2. **Quiet italic** — `dm-display` italic at `dm-ink-2`. Used for
+   reflective subclauses (`FeaturesGrid.tsx`).
 
 Never use display italic for more than one phrase per heading; it loses
 its weight.
@@ -128,11 +127,7 @@ critical to comprehension, gate it via `.dm-animated`.
 
 ```tsx
 <Link
-  className="inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 font-semibold text-[14px] text-white no-underline transition-all hover:-translate-y-px"
-  style={{
-    background: 'var(--dm-grad)',
-    boxShadow: '0 10px 30px -10px color-mix(in srgb, var(--color-dm-accent-2) 55%, transparent)',
-  }}
+  className="inline-flex items-center gap-[10px] rounded-[10px] bg-dm-ink px-5 py-3 font-semibold text-[14px] text-dm-bg no-underline transition-transform hover:-translate-y-px"
 >
   Download Dockerman
   <span
@@ -145,10 +140,9 @@ critical to comprehension, gate it via `.dm-animated`.
 ```
 
 Recipe:
-- Gradient fill (135° accent → accent-2)
-- Soft drop shadow in the _same_ indigo with `color-mix`
+- Solid `dm-ink` fill, `dm-bg` label
 - 1px lift on hover (`-translate-y-px`), never a scale
-- Inline meta pill at 18% white fill inside the gradient body
+- Inline meta pill at 18% white fill inside the body
 
 ### 2.2 The secondary button
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -42,15 +42,15 @@ a user needs to read, you're using it wrong.
 
 ### 1.3 Accents
 
-| Token            | Value     | Role                                                       |
-| ---------------- | --------- | ---------------------------------------------------------- |
-| `dm-accent`      | `#14b8a6` | Primary accent. Teal. `$` prompt, section eyebrows, links. |
-| `dm-accent-2`    | `#6366f1` | Secondary accent. Indigo. Focus rings.                     |
-| `dm-accent-warm` | `#f97316` | Warm accent. Orange. Sparingly, for emphasis contrast.     |
+| Token            | Light     | Dark      | Role                                                       |
+| ---------------- | --------- | --------- | ---------------------------------------------------------- |
+| `dm-accent`      | `#4f46e5` | `#818cf8` | Primary accent. Indigo. `$` prompt, eyebrows, italics.     |
+| `dm-accent-2`    | `#6366f1` | same      | Focus rings.                                               |
+| `dm-accent-warm` | `#f97316` | same      | Warm accent. Orange. Sparingly, for emphasis contrast.     |
 
-**Pair them, don't collide.** Accents are solid fills or solid type —
-never a teal → indigo gradient. Primary actions use `dm-ink` on
-`dm-bg`. Display italics use `dm-accent`.
+**Pair them, don't collide.** Accents are solid fills or solid type.
+Primary actions use `dm-ink` on `dm-bg`. Display italics use `dm-accent`.
+Status green (`dm-ok`) is not the brand color.
 
 ### 1.4 Status
 

--- a/apps/landing/src/app/[locale]/(main)/about/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/about/page.tsx
@@ -57,7 +57,7 @@ export default function About() {
       <section aria-labelledby="about-overview" className="animate-slide-up-fade">
         <Badge>{t('about.badge')}</Badge>
         <h1
-          className="mt-2 inline-block bg-gradient-to-br from-gray-900 to-gray-800 bg-clip-text py-2 font-bold text-4xl text-transparent tracking-tighter sm:text-6xl md:text-6xl dark:from-gray-50 dark:to-gray-300"
+          className="mt-2 inline-block py-2 font-bold text-4xl text-dm-ink tracking-tighter sm:text-6xl md:text-6xl"
           id="about-overview"
         >
           <Balancer>{t('about.title')}</Balancer>
@@ -154,7 +154,7 @@ export default function About() {
 
       {/* Join Us Section */}
       <section className="mt-24">
-        <div className="rounded-xl bg-gradient-to-br from-indigo-100 to-indigo-50 p-8 dark:from-indigo-900/50 dark:to-indigo-800/50">
+        <div className="rounded-xl border border-dm-line bg-dm-bg-soft p-8">
           <h2 className="font-bold text-2xl text-gray-900 tracking-tight dark:text-gray-100">
             {t('about.connect.title')}
           </h2>

--- a/apps/landing/src/app/[locale]/(main)/layout.tsx
+++ b/apps/landing/src/app/[locale]/(main)/layout.tsx
@@ -19,7 +19,9 @@ export default async function MainLayout({
       <GridBackground />
       <div className="relative z-10">
         <Navbar locale={locale} />
-        {children}
+        <div className="outline-none" id="main" tabIndex={-1}>
+          {children}
+        </div>
         <Footer locale={locale} />
       </div>
     </LenisProvider>

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -76,8 +76,18 @@ export default async function LandingPage({ params }: { params: Promise<{ locale
     <main>
       <JsonLd data={[ORGANIZATION_LD, websiteLd, softwareLd]} />
       <Hero locale={l} />
-      <div className="relative hidden px-5 md:block md:px-8">
-        <LiveDashboard locale={l} />
+      <div className="relative px-5 md:px-8">
+        <div
+          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-10 md:hidden"
+          style={{
+            background: 'linear-gradient(to left, var(--color-dm-bg), transparent)'
+          }}
+        />
+        <div className="overflow-x-auto overscroll-x-contain [-ms-overflow-style:none] [scrollbar-width:none] md:overflow-visible [&::-webkit-scrollbar]:hidden">
+          <div className="min-w-[880px] md:min-w-0">
+            <LiveDashboard locale={l} />
+          </div>
+        </div>
       </div>
       <RuntimeStrip locale={l} />
       <FeaturesGrid locale={l} />

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -243,12 +243,7 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
             />
             <h2 className="relative m-0 font-bold text-[clamp(28px,3.6vw,40px)] text-dm-ink leading-[1.1] tracking-[-0.03em]">
               {t('pricing.finalCta.titleLead')}{' '}
-              <em
-                className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
-                style={{
-                  backgroundImage: 'var(--dm-grad)'
-                }}
-              >
+              <em className="font-[var(--font-dm-display)] font-normal text-dm-accent italic">
                 {t('pricing.finalCta.titleAccent')}
               </em>
             </h2>

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -246,7 +246,7 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
               <em
                 className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
                 style={{
-                  backgroundImage: 'linear-gradient(135deg, var(--color-dm-accent-2), #8b5cf6)'
+                  backgroundImage: 'var(--dm-grad)'
                 }}
               >
                 {t('pricing.finalCta.titleAccent')}

--- a/apps/landing/src/app/[locale]/(main)/pricing/success/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/success/page.tsx
@@ -16,7 +16,7 @@ export default function PricingSuccess() {
           <RiCheckboxCircleFill className="size-16 text-green-500" />
         </div>
 
-        <h1 className="mt-6 bg-gradient-to-br from-gray-900 to-gray-800 bg-clip-text font-bold text-3xl text-transparent tracking-tighter sm:text-4xl dark:from-gray-50 dark:to-gray-300">
+        <h1 className="mt-6 font-bold text-3xl text-dm-ink tracking-tighter sm:text-4xl">
           {t('pricing.success.title')}
         </h1>
 

--- a/apps/landing/src/app/api/og/docs/route.tsx
+++ b/apps/landing/src/app/api/og/docs/route.tsx
@@ -51,7 +51,7 @@ export function GET(request: NextRequest) {
             width: 44,
             height: 44,
             borderRadius: 10,
-            background: 'linear-gradient(135deg, #14b8a6, #6366f1)'
+            background: '#14b8a6'
           }}
         />
         <div style={{ fontSize: 28, fontWeight: 600, letterSpacing: '-0.02em' }}>

--- a/apps/landing/src/app/api/og/docs/route.tsx
+++ b/apps/landing/src/app/api/og/docs/route.tsx
@@ -51,9 +51,26 @@ export function GET(request: NextRequest) {
             width: 44,
             height: 44,
             borderRadius: 10,
-            background: '#4f46e5'
+            background: '#0a0a0a',
+            border: '1px solid rgba(255,255,255,0.14)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#fafaf9'
           }}
-        />
+        >
+          <svg
+            fill="currentColor"
+            height="26"
+            viewBox="0 0 32 32"
+            width="26"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M28,12H20V4h8Zm-6-2h4V6H22Z" />
+            <path d="M17,15V9H9V23H23V15Zm-6-4h4v4H11Zm4,10H11V17h4Zm6,0H17V17h4Z" />
+            <path d="M26,28H6a2,2,0,0,1-2-2V6A2,2,0,0,1,6,4H16V6H6V26H26V16h2V26A2,2,0,0,1,26,28Z" />
+          </svg>
+        </div>
         <div style={{ fontSize: 28, fontWeight: 600, letterSpacing: '-0.02em' }}>
           Dockerman Docs
         </div>

--- a/apps/landing/src/app/api/og/docs/route.tsx
+++ b/apps/landing/src/app/api/og/docs/route.tsx
@@ -51,7 +51,7 @@ export function GET(request: NextRequest) {
             width: 44,
             height: 44,
             borderRadius: 10,
-            background: '#14b8a6'
+            background: '#4f46e5'
           }}
         />
         <div style={{ fontSize: 28, fontWeight: 600, letterSpacing: '-0.02em' }}>

--- a/apps/landing/src/app/api/og/docs/route.tsx
+++ b/apps/landing/src/app/api/og/docs/route.tsx
@@ -51,7 +51,7 @@ export function GET(request: NextRequest) {
             width: 44,
             height: 44,
             borderRadius: 10,
-            background: 'linear-gradient(135deg, #6366f1, #8b5cf6)'
+            background: 'linear-gradient(135deg, #0a6560, #1b5f92, #3238ad)'
           }}
         />
         <div style={{ fontSize: 28, fontWeight: 600, letterSpacing: '-0.02em' }}>

--- a/apps/landing/src/app/api/og/docs/route.tsx
+++ b/apps/landing/src/app/api/og/docs/route.tsx
@@ -51,7 +51,7 @@ export function GET(request: NextRequest) {
             width: 44,
             height: 44,
             borderRadius: 10,
-            background: 'linear-gradient(135deg, #0a6560, #1b5f92, #3238ad)'
+            background: 'linear-gradient(135deg, #14b8a6, #6366f1)'
           }}
         />
         <div style={{ fontSize: 28, fontWeight: 600, letterSpacing: '-0.02em' }}>

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -5,6 +5,7 @@
 @source "../node_modules/fumadocs-ui/dist/**/*.js";
 
 @custom-variant dark (&:where(.dark, .dark *));
+@custom-variant fine-hover (@media (hover: hover));
 
 @plugin "@tailwindcss/forms";
 
@@ -150,6 +151,42 @@
 
   --radius-dm: 12px;
   --radius-dm-sm: 8px;
+}
+
+@layer components {
+  .dm-focus-ring {
+    outline: none;
+  }
+
+  .dm-focus-ring:focus-visible {
+    outline: 2px solid var(--color-dm-accent-2);
+    outline-offset: 2px;
+    box-shadow: 0 0 0 3px
+      color-mix(in srgb, var(--color-dm-accent-2) 18%, transparent);
+  }
+
+  .dm-skip-link {
+    position: absolute;
+    inset-inline-start: 16px;
+    top: 16px;
+    z-index: 100;
+    transform: translateY(-200%);
+    border-radius: 10px;
+    background: var(--color-dm-bg-elev);
+    padding: 10px 14px;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-dm-ink);
+    text-decoration: none;
+    box-shadow: 0 0 0 3px
+      color-mix(in srgb, var(--color-dm-accent-2) 18%, transparent);
+  }
+
+  .dm-skip-link:focus {
+    transform: translateY(0);
+    outline: 2px solid var(--color-dm-accent-2);
+    outline-offset: 2px;
+  }
 }
 
 @layer base {

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -137,12 +137,15 @@
   --color-dm-ink-2: #3a3a3a;
   --color-dm-ink-3: #6a6a6a;
   --color-dm-ink-4: #9a9a98;
-  --color-dm-accent: #14b8a6;
-  --color-dm-accent-2: #6366f1;
-  --color-dm-accent-warm: #f97316;
-  --color-dm-ok: #10b981;
-  --color-dm-warn: #f59e0b;
-  --color-dm-err: #ef4444;
+  --color-dm-accent: #0c7a73;
+  --color-dm-accent-2: #3d44b8;
+  --color-dm-accent-warm: #c45e14;
+  --color-dm-ok: #1b8554;
+  --color-dm-warn: #a67c0a;
+  --color-dm-err: #c73636;
+  --color-dm-grad-from: #0a6560;
+  --color-dm-grad-mid: #1b5f92;
+  --color-dm-grad-to: #3238ad;
   --color-dm-grid: rgb(0 0 0 / 0.05);
 
   --font-dm-mono:
@@ -151,6 +154,23 @@
 
   --radius-dm: 12px;
   --radius-dm-sm: 8px;
+}
+
+@layer base {
+  :root {
+    --dm-grad: linear-gradient(
+      135deg in oklab,
+      var(--color-dm-grad-from),
+      var(--color-dm-grad-mid),
+      var(--color-dm-grad-to)
+    );
+    --dm-grad-90: linear-gradient(
+      90deg in oklab,
+      var(--color-dm-grad-from),
+      var(--color-dm-grad-mid),
+      var(--color-dm-grad-to)
+    );
+  }
 }
 
 @layer components {
@@ -227,6 +247,12 @@
     --color-dm-ink-3: #8c8c8a;
     --color-dm-ink-4: #5c5c5a;
     --color-dm-grid: rgb(255 255 255 / 0.04);
+    --color-dm-accent: #2aa89c;
+    --color-dm-accent-2: #8a8ef0;
+    --color-dm-accent-warm: #e0893a;
+    --color-dm-ok: #3dba7a;
+    --color-dm-warn: #d4a017;
+    --color-dm-err: #ef6b6b;
   }
 
   @keyframes dm-pulse {

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -137,7 +137,7 @@
   --color-dm-ink-2: #3a3a3a;
   --color-dm-ink-3: #6a6a6a;
   --color-dm-ink-4: #9a9a98;
-  --color-dm-accent: #14b8a6;
+  --color-dm-accent: #4f46e5;
   --color-dm-accent-2: #6366f1;
   --color-dm-accent-warm: #f97316;
   --color-dm-ok: #10b981;
@@ -227,6 +227,7 @@
     --color-dm-ink-3: #8c8c8a;
     --color-dm-ink-4: #5c5c5a;
     --color-dm-grid: rgb(255 255 255 / 0.04);
+    --color-dm-accent: #818cf8;
   }
 
   @keyframes dm-pulse {

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -137,15 +137,12 @@
   --color-dm-ink-2: #3a3a3a;
   --color-dm-ink-3: #6a6a6a;
   --color-dm-ink-4: #9a9a98;
-  --color-dm-accent: #0c7a73;
-  --color-dm-accent-2: #3d44b8;
-  --color-dm-accent-warm: #c45e14;
-  --color-dm-ok: #1b8554;
-  --color-dm-warn: #a67c0a;
-  --color-dm-err: #c73636;
-  --color-dm-grad-from: #0a6560;
-  --color-dm-grad-mid: #1b5f92;
-  --color-dm-grad-to: #3238ad;
+  --color-dm-accent: #14b8a6;
+  --color-dm-accent-2: #6366f1;
+  --color-dm-accent-warm: #f97316;
+  --color-dm-ok: #10b981;
+  --color-dm-warn: #f59e0b;
+  --color-dm-err: #ef4444;
   --color-dm-grid: rgb(0 0 0 / 0.05);
 
   --font-dm-mono:
@@ -160,15 +157,13 @@
   :root {
     --dm-grad: linear-gradient(
       135deg in oklab,
-      var(--color-dm-grad-from),
-      var(--color-dm-grad-mid),
-      var(--color-dm-grad-to)
+      var(--color-dm-accent),
+      var(--color-dm-accent-2)
     );
     --dm-grad-90: linear-gradient(
       90deg in oklab,
-      var(--color-dm-grad-from),
-      var(--color-dm-grad-mid),
-      var(--color-dm-grad-to)
+      var(--color-dm-accent),
+      var(--color-dm-accent-2)
     );
   }
 }
@@ -247,12 +242,6 @@
     --color-dm-ink-3: #8c8c8a;
     --color-dm-ink-4: #5c5c5a;
     --color-dm-grid: rgb(255 255 255 / 0.04);
-    --color-dm-accent: #2aa89c;
-    --color-dm-accent-2: #8a8ef0;
-    --color-dm-accent-warm: #e0893a;
-    --color-dm-ok: #3dba7a;
-    --color-dm-warn: #d4a017;
-    --color-dm-err: #ef6b6b;
   }
 
   @keyframes dm-pulse {

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -153,21 +153,6 @@
   --radius-dm-sm: 8px;
 }
 
-@layer base {
-  :root {
-    --dm-grad: linear-gradient(
-      135deg in oklab,
-      var(--color-dm-accent),
-      var(--color-dm-accent-2)
-    );
-    --dm-grad-90: linear-gradient(
-      90deg in oklab,
-      var(--color-dm-accent),
-      var(--color-dm-accent-2)
-    );
-  }
-}
-
 @layer components {
   .dm-focus-ring {
     outline: none;

--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -119,7 +119,7 @@ export default function RootLayout({
         )}
       </head>
       <body
-        className={`${inter.variable} min-h-screen scroll-auto antialiased selection:bg-indigo-100 selection:text-indigo-700 dark:bg-gray-950`}
+        className={`${inter.variable} min-h-screen scroll-auto bg-dm-bg antialiased selection:bg-[color-mix(in_srgb,var(--color-dm-accent-2)_22%,transparent)] selection:text-dm-ink`}
       >
         {children}
         {process.env.NODE_ENV === 'development' ? <AgentationClient /> : null}

--- a/apps/landing/src/components/Badge.tsx
+++ b/apps/landing/src/components/Badge.tsx
@@ -15,9 +15,7 @@ function Badge({ children, className, ref, ...props }: BadgeProps) {
       ref={ref}
       {...props}
     >
-      <span className="bg-gradient-to-b from-indigo-500 to-indigo-600 bg-clip-text text-transparent dark:from-indigo-200 dark:to-indigo-400">
-        {children}
-      </span>
+      <span className="text-dm-accent">{children}</span>
     </span>
   )
 }

--- a/apps/landing/src/components/ThemeSwitch.tsx
+++ b/apps/landing/src/components/ThemeSwitch.tsx
@@ -62,14 +62,14 @@ function ThemeSwitch() {
   return (
     <RadioGroupPrimitives.Root
       aria-label="Toggle color theme"
-      className="inline-flex h-8 items-center gap-[2px] rounded-full border border-dm-line bg-dm-bg-elev p-[2px]"
+      className="inline-flex h-9 items-center gap-[2px] rounded-full border border-dm-line bg-dm-bg-elev p-[2px]"
       onValueChange={onChange}
       value={active}
     >
       {OPTIONS.map(({ value, label, Icon }) => (
         <RadioGroupPrimitives.Item
           aria-label={`Switch to ${label} mode`}
-          className="dm-focus-ring group relative grid h-[26px] w-[26px] cursor-pointer place-items-center rounded-full text-dm-ink-3 outline-none transition-[color,background-color,border-color,transform] fine-hover:hover:text-dm-ink active:scale-[0.96] data-[state=checked]:text-dm-ink"
+          className="dm-focus-ring group relative grid aspect-square h-full cursor-pointer place-items-center rounded-full text-dm-ink-3 outline-none transition-[color,background-color,border-color,transform] fine-hover:hover:text-dm-ink active:scale-[0.96] data-[state=checked]:text-dm-ink"
           key={value}
           value={value}
         >

--- a/apps/landing/src/components/ThemeSwitch.tsx
+++ b/apps/landing/src/components/ThemeSwitch.tsx
@@ -69,7 +69,7 @@ function ThemeSwitch() {
       {OPTIONS.map(({ value, label, Icon }) => (
         <RadioGroupPrimitives.Item
           aria-label={`Switch to ${label} mode`}
-          className="group relative grid h-[26px] w-[26px] cursor-pointer place-items-center rounded-full text-dm-ink-3 outline-none transition-[color,background-color,border-color,transform] hover:text-dm-ink focus-visible:ring-2 focus-visible:ring-[var(--color-dm-accent-2)]/60 active:scale-[0.97] data-[state=checked]:text-dm-ink"
+          className="dm-focus-ring group relative grid h-[26px] w-[26px] cursor-pointer place-items-center rounded-full text-dm-ink-3 outline-none transition-[color,background-color,border-color,transform] fine-hover:hover:text-dm-ink active:scale-[0.96] data-[state=checked]:text-dm-ink"
           key={value}
           value={value}
         >

--- a/apps/landing/src/components/changelog/ChangelogPageContent.tsx
+++ b/apps/landing/src/components/changelog/ChangelogPageContent.tsx
@@ -92,13 +92,7 @@ function TitleWithAccent({ title }: { title: string }) {
   return (
     <>
       {head}{' '}
-      <em
-        className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
-        style={{
-          backgroundImage: 'var(--dm-grad)',
-          letterSpacing: '-0.02em'
-        }}
-      >
+      <em className="font-[var(--font-dm-display)] font-normal text-dm-accent italic tracking-[-0.02em]">
         {tail}
       </em>
     </>

--- a/apps/landing/src/components/changelog/ChangelogPageContent.tsx
+++ b/apps/landing/src/components/changelog/ChangelogPageContent.tsx
@@ -95,7 +95,7 @@ function TitleWithAccent({ title }: { title: string }) {
       <em
         className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
         style={{
-          backgroundImage: 'linear-gradient(135deg, var(--color-dm-accent-2), #8b5cf6)',
+          backgroundImage: 'var(--dm-grad)',
           letterSpacing: '-0.02em'
         }}
       >

--- a/apps/landing/src/components/changelog/ChangelogTimeline.tsx
+++ b/apps/landing/src/components/changelog/ChangelogTimeline.tsx
@@ -112,7 +112,7 @@ function VersionPill({
         style={
           highlighted
             ? {
-                background: 'var(--dm-grad)',
+                background: 'var(--color-dm-accent)',
                 boxShadow:
                   '0 4px 10px -3px color-mix(in srgb, var(--color-dm-accent-2) 50%, transparent)'
               }
@@ -183,7 +183,7 @@ function SectionBlock({ section }: { section: ChangelogSection }) {
           aria-hidden="true"
           className="inline-block h-[18px] w-[4px] rounded-[2px]"
           style={{
-            background: 'var(--dm-grad)'
+            background: 'var(--color-dm-accent)'
           }}
         />
         {section.title}

--- a/apps/landing/src/components/changelog/ChangelogTimeline.tsx
+++ b/apps/landing/src/components/changelog/ChangelogTimeline.tsx
@@ -112,7 +112,7 @@ function VersionPill({
         style={
           highlighted
             ? {
-                background: 'linear-gradient(135deg, var(--color-dm-accent-2), #8b5cf6)',
+                background: 'var(--dm-grad)',
                 boxShadow:
                   '0 4px 10px -3px color-mix(in srgb, var(--color-dm-accent-2) 50%, transparent)'
               }
@@ -183,7 +183,7 @@ function SectionBlock({ section }: { section: ChangelogSection }) {
           aria-hidden="true"
           className="inline-block h-[18px] w-[4px] rounded-[2px]"
           style={{
-            background: 'linear-gradient(180deg, var(--color-dm-accent-2), #8b5cf6)'
+            background: 'var(--dm-grad)'
           }}
         />
         {section.title}

--- a/apps/landing/src/components/download/DownloadHero.tsx
+++ b/apps/landing/src/components/download/DownloadHero.tsx
@@ -44,7 +44,7 @@ export async function DownloadHero({ locale }: { locale: Locale }) {
           <em
             className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
             style={{
-              backgroundImage: 'linear-gradient(135deg, var(--color-dm-accent-2), #8b5cf6)',
+              backgroundImage: 'var(--dm-grad)',
               letterSpacing: '-0.02em'
             }}
           >

--- a/apps/landing/src/components/download/DownloadHero.tsx
+++ b/apps/landing/src/components/download/DownloadHero.tsx
@@ -41,13 +41,7 @@ export async function DownloadHero({ locale }: { locale: Locale }) {
         >
           {t('download.hero.titleLead')}
           {locale === 'zh' || locale === 'ja' ? <br /> : ' '}
-          <em
-            className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
-            style={{
-              backgroundImage: 'var(--dm-grad)',
-              letterSpacing: '-0.02em'
-            }}
-          >
+          <em className="font-[var(--font-dm-display)] font-normal text-dm-accent italic tracking-[-0.02em]">
             {t('download.hero.titleAccent')}
           </em>
         </h1>

--- a/apps/landing/src/components/landing/CtaFinal.tsx
+++ b/apps/landing/src/components/landing/CtaFinal.tsx
@@ -45,7 +45,7 @@ export async function CtaFinal({ locale }: { locale: Locale }) {
               style={{
                 background: 'var(--dm-grad)',
                 boxShadow:
-                  '0 10px 30px -10px color-mix(in srgb, var(--color-dm-grad-to) 55%, transparent)'
+                  '0 10px 30px -10px color-mix(in srgb, var(--color-dm-accent-2) 55%, transparent)'
               }}
             >
               <svg

--- a/apps/landing/src/components/landing/CtaFinal.tsx
+++ b/apps/landing/src/components/landing/CtaFinal.tsx
@@ -41,7 +41,7 @@ export async function CtaFinal({ locale }: { locale: Locale }) {
           </p>
           <div className="relative flex flex-wrap justify-center gap-3">
             <Link
-              className="dm-focus-ring inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
+              className="dm-focus-ring inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 font-semibold text-[14px] text-white no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
               href={`/${locale}/download`}
               style={{
                 background:

--- a/apps/landing/src/components/landing/CtaFinal.tsx
+++ b/apps/landing/src/components/landing/CtaFinal.tsx
@@ -26,12 +26,7 @@ export async function CtaFinal({ locale }: { locale: Locale }) {
           />
           <h2 className="relative m-0 text-balance font-bold text-[clamp(36px,5vw,64px)] text-dm-ink leading-[1.02] tracking-[-0.04em]">
             {t('cta.titleLead')}{' '}
-            <em
-              className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
-              style={{
-                backgroundImage: 'var(--dm-grad)'
-              }}
-            >
+            <em className="font-[var(--font-dm-display)] font-normal text-dm-accent italic">
               {t('cta.titleAccent')}
             </em>
           </h2>
@@ -40,13 +35,8 @@ export async function CtaFinal({ locale }: { locale: Locale }) {
           </p>
           <div className="relative flex flex-wrap justify-center gap-3">
             <Link
-              className="dm-focus-ring inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 font-semibold text-[14px] text-white no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
+              className="dm-focus-ring inline-flex items-center gap-[10px] rounded-[10px] bg-dm-ink px-5 py-3 font-semibold text-[14px] text-dm-bg no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
               href={`/${locale}/download`}
-              style={{
-                background: 'var(--dm-grad)',
-                boxShadow:
-                  '0 10px 30px -10px color-mix(in srgb, var(--color-dm-accent-2) 55%, transparent)'
-              }}
             >
               <svg
                 aria-hidden="true"

--- a/apps/landing/src/components/landing/CtaFinal.tsx
+++ b/apps/landing/src/components/landing/CtaFinal.tsx
@@ -29,8 +29,7 @@ export async function CtaFinal({ locale }: { locale: Locale }) {
             <em
               className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
               style={{
-                backgroundImage:
-                  'linear-gradient(135deg, var(--color-dm-accent), var(--color-dm-accent-2))'
+                backgroundImage: 'var(--dm-grad)'
               }}
             >
               {t('cta.titleAccent')}
@@ -44,10 +43,9 @@ export async function CtaFinal({ locale }: { locale: Locale }) {
               className="dm-focus-ring inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 font-semibold text-[14px] text-white no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
               href={`/${locale}/download`}
               style={{
-                background:
-                  'linear-gradient(135deg, var(--color-dm-accent), var(--color-dm-accent-2))',
+                background: 'var(--dm-grad)',
                 boxShadow:
-                  '0 10px 30px -10px color-mix(in srgb, var(--color-dm-accent-2) 60%, transparent)'
+                  '0 10px 30px -10px color-mix(in srgb, var(--color-dm-grad-to) 55%, transparent)'
               }}
             >
               <svg

--- a/apps/landing/src/components/landing/CtaFinal.tsx
+++ b/apps/landing/src/components/landing/CtaFinal.tsx
@@ -24,7 +24,7 @@ export async function CtaFinal({ locale }: { locale: Locale }) {
               backgroundSize: '40px 40px'
             }}
           />
-          <h2 className="relative m-0 font-bold text-[clamp(36px,5vw,64px)] text-dm-ink leading-[1.02] tracking-[-0.04em]">
+          <h2 className="relative m-0 text-balance font-bold text-[clamp(36px,5vw,64px)] text-dm-ink leading-[1.02] tracking-[-0.04em]">
             {t('cta.titleLead')}{' '}
             <em
               className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
@@ -36,12 +36,12 @@ export async function CtaFinal({ locale }: { locale: Locale }) {
               {t('cta.titleAccent')}
             </em>
           </h2>
-          <p className="relative mx-auto mt-[18px] mb-8 max-w-[68ch] text-[17px] text-dm-ink-3">
+          <p className="relative mx-auto mt-[18px] mb-8 max-w-[68ch] text-pretty text-[17px] text-dm-ink-3">
             {t('cta.description')}
           </p>
           <div className="relative flex flex-wrap justify-center gap-3">
             <Link
-              className="inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-transform hover:-translate-y-px active:translate-y-0 active:scale-[0.97]"
+              className="dm-focus-ring inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
               href={`/${locale}/download`}
               style={{
                 background:
@@ -71,7 +71,7 @@ export async function CtaFinal({ locale }: { locale: Locale }) {
               </span>
             </Link>
             <a
-              className="inline-flex items-center gap-2 rounded-[10px] border border-dm-line-strong bg-transparent px-[18px] py-3 font-medium text-[14px] text-dm-ink-2 transition-[color,background-color,border-color,transform] hover:bg-dm-bg-soft hover:text-dm-ink active:scale-[0.97]"
+              className="dm-focus-ring inline-flex items-center gap-2 rounded-[10px] border border-dm-line-strong bg-transparent px-[18px] py-3 font-medium text-[14px] text-dm-ink-2 transition-[color,background-color,border-color,transform] fine-hover:hover:bg-dm-bg-soft fine-hover:hover:text-dm-ink active:scale-[0.96]"
               href="https://github.com/ZingerLittleBee/dockerman.app/issues/new"
               rel="noopener noreferrer"
               target="_blank"

--- a/apps/landing/src/components/landing/FeaturesGrid.tsx
+++ b/apps/landing/src/components/landing/FeaturesGrid.tsx
@@ -5,7 +5,7 @@ import { PaletteViz } from './PaletteViz'
 export async function FeaturesGrid({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
   return (
-    <section className="px-5 py-16 sm:px-8 sm:py-24" id="features">
+    <section className="scroll-mt-24 px-5 py-16 sm:px-8 sm:py-24" id="features">
       <div className="mx-auto max-w-[1240px]">
         <SectionHead t={t} />
         <div className="grid grid-cols-1 gap-4 md:auto-rows-[minmax(200px,auto)] md:grid-cols-6">
@@ -33,15 +33,15 @@ function SectionHead({ t }: { t: TFn }) {
         style={{ color: 'var(--color-dm-accent)' }}
       >
         <span aria-hidden="true" className="text-dm-ink-4 before:content-['//_']" />
-        features
+        {t('featuresSection.kicker')}
       </div>
-      <h2 className="m-0 font-bold text-[clamp(32px,4.5vw,56px)] text-dm-ink leading-[1.02] tracking-[-0.035em]">
+      <h2 className="m-0 text-balance font-bold text-[clamp(32px,4.5vw,56px)] text-dm-ink leading-[1.02] tracking-[-0.035em]">
         {t('featuresSection.titleLead')}{' '}
         <em className="font-[var(--font-dm-display)] font-normal text-dm-ink-2 italic">
           {t('featuresSection.titleAccent')}
         </em>
       </h2>
-      <p className="m-0 max-w-[52ch] text-[17px] text-dm-ink-3 leading-[1.5]">
+      <p className="m-0 max-w-[52ch] text-pretty text-[17px] text-dm-ink-3 leading-[1.5]">
         {t('featuresSection.description')}
       </p>
     </div>
@@ -100,7 +100,7 @@ function FeatCard({
 }) {
   return (
     <article
-      className={`relative flex flex-col overflow-hidden rounded-[14px] border border-dm-line bg-dm-bg-elev p-5 transition-[transform,border-color] hover:-translate-y-px hover:border-dm-line-strong sm:p-6 ${SHAPE_CLASSES[shape]}`}
+      className={`relative flex flex-col overflow-hidden rounded-[14px] border border-dm-line bg-dm-bg-elev p-5 transition-[transform,border-color] fine-hover:hover:-translate-y-px fine-hover:hover:border-dm-line-strong sm:p-6 ${SHAPE_CLASSES[shape]}`}
     >
       <div
         className="mb-[14px] grid h-8 w-8 place-items-center rounded-[8px]"
@@ -111,9 +111,17 @@ function FeatCard({
       >
         {icon}
       </div>
-      <h3 className="mb-2 font-semibold text-[18px] text-dm-ink tracking-[-0.015em]">{title}</h3>
-      <p className="m-0 text-[13.5px] text-dm-ink-3 leading-[1.5]">{children}</p>
-      {visual ? <div className="relative mt-auto min-h-[140px] pt-[18px]">{visual}</div> : null}
+      <h3 className="mb-2 text-balance font-semibold text-[18px] text-dm-ink tracking-[-0.015em]">
+        {title}
+      </h3>
+      <p className="m-0 text-pretty text-[13.5px] text-dm-ink-3 leading-[1.5]">{children}</p>
+      {visual ? (
+        <div
+          className={`relative mt-auto pt-[18px] ${shape === 'large' || shape === 'tall' ? 'min-h-[140px]' : ''}`}
+        >
+          {visual}
+        </div>
+      ) : null}
     </article>
   )
 }
@@ -124,6 +132,7 @@ function PaletteCard({ t }: { t: TFn }) {
     <FeatCard
       icon={
         <svg
+          aria-hidden="true"
           fill="none"
           height="16"
           stroke="currentColor"
@@ -151,6 +160,7 @@ function ImageUpgradeCard({ t }: { t: TFn }) {
     <FeatCard
       icon={
         <svg
+          aria-hidden="true"
           fill="none"
           height="16"
           stroke="currentColor"
@@ -164,6 +174,23 @@ function ImageUpgradeCard({ t }: { t: TFn }) {
       }
       shape="med"
       title={t('featuresSection.cards.imageUpgrade.title')}
+      visual={
+        <div aria-hidden="true" className="flex flex-col gap-[6px]">
+          <span className="inline-flex items-center gap-2 font-[var(--font-dm-mono)] text-[11px] text-dm-ink-2">
+            <span className="text-dm-ink-3">redis:7.2</span>
+            <span style={{ color: 'var(--color-dm-accent)' }}>→</span>
+            <span className="text-dm-ink">redis:7.4</span>
+          </span>
+          <span className="inline-flex items-center gap-[6px] font-[var(--font-dm-mono)] text-[10.5px] text-dm-ink-3">
+            <span className="rounded border border-dm-line bg-dm-bg-soft px-[6px] py-[2px]">
+              sha256:a1f3…
+            </span>
+            <span className="rounded border border-dm-line bg-dm-bg-soft px-[6px] py-[2px]">
+              backup ready
+            </span>
+          </span>
+        </div>
+      }
     >
       {t('featuresSection.cards.imageUpgrade.body')}
     </FeatCard>
@@ -176,6 +203,7 @@ function PodmanCard({ t }: { t: TFn }) {
     <FeatCard
       icon={
         <svg
+          aria-hidden="true"
           fill="none"
           height="16"
           stroke="currentColor"
@@ -191,6 +219,18 @@ function PodmanCard({ t }: { t: TFn }) {
       iconColor="accent-warm"
       shape="med"
       title={t('featuresSection.cards.podman.title')}
+      visual={
+        <div aria-hidden="true" className="flex flex-wrap gap-[6px]">
+          <span className="inline-flex items-center gap-[6px] rounded-md border border-dm-line bg-dm-bg-soft px-2 py-[4px] font-[var(--font-dm-mono)] text-[10.5px] text-dm-ink-2">
+            docker.sock
+            <span className="text-dm-ink-3">detected</span>
+          </span>
+          <span className="inline-flex items-center gap-[6px] rounded-md border border-dm-line bg-dm-bg-soft px-2 py-[4px] font-[var(--font-dm-mono)] text-[10.5px] text-dm-ink-2">
+            podman.sock
+            <span className="text-dm-ink-3">rootless</span>
+          </span>
+        </div>
+      }
     >
       {t('featuresSection.cards.podman.body')}
     </FeatCard>
@@ -203,6 +243,7 @@ function KubernetesCard({ t }: { t: TFn }) {
     <FeatCard
       icon={
         <svg
+          aria-hidden="true"
           fill="none"
           height="16"
           stroke="currentColor"
@@ -219,7 +260,7 @@ function KubernetesCard({ t }: { t: TFn }) {
       shape="tall"
       title={t('featuresSection.cards.kubernetes.title')}
       visual={
-        <div className="flex flex-col gap-[6px]">
+        <div aria-hidden="true" className="flex flex-col gap-[6px]">
           <VizBadge state="running">deployment/web · 3/3 ready</VizBadge>
           <VizBadge state="running">service/api · forwarded :8080</VizBadge>
           <VizBadge state="running">pod/worker-7d4f · 2d 14h</VizBadge>
@@ -252,15 +293,26 @@ function VizBadge({
       style={{ opacity }}
     >
       <span
-        className="inline-block h-2 w-2 rounded-full"
-        style={{
-          background: VIZ_BADGE_BACKGROUND_BY_STATE[state],
-          boxShadow:
-            state === 'running'
-              ? '0 0 8px color-mix(in srgb, var(--color-dm-ok) 60%, transparent)'
+        aria-hidden="true"
+        className={
+          state === 'stopped'
+            ? 'inline-block h-2 w-2 rounded-full border border-dm-ink-3 bg-transparent'
+            : state === 'paused'
+              ? 'inline-block h-2 w-2 rounded-[1px] bg-dm-warn'
+              : 'inline-block h-2 w-2 rounded-full'
+        }
+        style={
+          state === 'running'
+            ? {
+                background: VIZ_BADGE_BACKGROUND_BY_STATE[state],
+                boxShadow: '0 0 8px color-mix(in srgb, var(--color-dm-ok) 60%, transparent)'
+              }
+            : state === 'paused'
+              ? { background: VIZ_BADGE_BACKGROUND_BY_STATE[state] }
               : undefined
-        }}
+        }
       />
+      <span className="sr-only">{state} </span>
       {children}
     </span>
   )
@@ -272,6 +324,7 @@ function EventsCard({ t }: { t: TFn }) {
     <FeatCard
       icon={
         <svg
+          aria-hidden="true"
           fill="none"
           height="16"
           stroke="currentColor"
@@ -287,6 +340,27 @@ function EventsCard({ t }: { t: TFn }) {
       iconColor="err"
       shape="wide"
       title={t('featuresSection.cards.events.title')}
+      visual={
+        <div
+          aria-hidden="true"
+          className="flex flex-col gap-[6px] font-[var(--font-dm-mono)] text-[10.5px]"
+        >
+          <span className="inline-flex items-center gap-2 text-dm-ink-2">
+            <span className="rounded-sm bg-[color-mix(in_srgb,var(--color-dm-err)_16%,transparent)] px-[6px] py-[2px] text-dm-err">
+              exit 137
+            </span>
+            worker
+            <span className="ml-auto text-dm-ink-3">2s</span>
+          </span>
+          <span className="inline-flex items-center gap-2 text-dm-ink-2">
+            <span className="rounded-sm bg-[color-mix(in_srgb,var(--color-dm-warn)_16%,transparent)] px-[6px] py-[2px] text-dm-warn">
+              OOM
+            </span>
+            plex
+            <span className="ml-auto text-dm-ink-3">14s</span>
+          </span>
+        </div>
+      }
     >
       {t('featuresSection.cards.events.body')}
     </FeatCard>
@@ -299,6 +373,7 @@ function CloudflaredCard({ t }: { t: TFn }) {
     <FeatCard
       icon={
         <svg
+          aria-hidden="true"
           fill="none"
           height="16"
           stroke="currentColor"
@@ -311,6 +386,16 @@ function CloudflaredCard({ t }: { t: TFn }) {
       }
       shape="wide"
       title={t('featuresSection.cards.cloudflared.title')}
+      visual={
+        <div
+          aria-hidden="true"
+          className="inline-flex max-w-full items-center gap-2 overflow-hidden rounded-md border border-dm-line bg-dm-bg-soft px-2 py-[5px] font-[var(--font-dm-mono)] text-[10.5px] text-dm-ink-2"
+        >
+          <span className="shrink-0 text-dm-ink-3">:8080</span>
+          <span style={{ color: 'var(--color-dm-accent)' }}>→</span>
+          <span className="truncate">trycloudflare.com</span>
+        </div>
+      }
     >
       {t('featuresSection.cards.cloudflared.body')}
     </FeatCard>
@@ -323,6 +408,7 @@ function LogsCard({ t }: { t: TFn }) {
     <FeatCard
       icon={
         <svg
+          aria-hidden="true"
           fill="none"
           height="16"
           stroke="currentColor"
@@ -336,6 +422,21 @@ function LogsCard({ t }: { t: TFn }) {
       }
       shape="wide"
       title={t('featuresSection.cards.logs.title')}
+      visual={
+        <div
+          aria-hidden="true"
+          className="flex flex-col gap-[4px] font-[var(--font-dm-mono)] text-[10.5px] text-dm-ink-3"
+        >
+          <span>
+            <span className="text-dm-ink-4">14:02:11</span> <span className="text-dm-ok">GET</span>{' '}
+            /health 200
+          </span>
+          <span>
+            <span className="text-dm-ink-4">14:02:12</span>{' '}
+            <span className="text-dm-warn">WARN</span> retry redis
+          </span>
+        </div>
+      }
     >
       {t('featuresSection.cards.logs.bodyPre')}
       <code className="rounded bg-dm-bg-soft px-[5px] py-[1px] font-[var(--font-dm-mono)] text-[11px]">
@@ -356,6 +457,7 @@ function SecurityCard({ t }: { t: TFn }) {
     <FeatCard
       icon={
         <svg
+          aria-hidden="true"
           fill="none"
           height="16"
           stroke="currentColor"
@@ -371,6 +473,22 @@ function SecurityCard({ t }: { t: TFn }) {
       iconColor="ok"
       shape="wide"
       title={t('featuresSection.cards.security.title')}
+      visual={
+        <div
+          aria-hidden="true"
+          className="flex flex-wrap gap-[6px] font-[var(--font-dm-mono)] text-[10.5px]"
+        >
+          <span className="rounded-md bg-[color-mix(in_srgb,var(--color-dm-err)_14%,transparent)] px-2 py-[3px] text-dm-err">
+            CRITICAL 2
+          </span>
+          <span className="rounded-md bg-[color-mix(in_srgb,var(--color-dm-warn)_14%,transparent)] px-2 py-[3px] text-dm-warn">
+            HIGH 6
+          </span>
+          <span className="rounded-md border border-dm-line bg-dm-bg-soft px-2 py-[3px] text-dm-ink-3">
+            MEDIUM 11
+          </span>
+        </div>
+      }
     >
       {t('featuresSection.cards.security.body')}
     </FeatCard>

--- a/apps/landing/src/components/landing/Hero.tsx
+++ b/apps/landing/src/components/landing/Hero.tsx
@@ -91,22 +91,31 @@ export function Hero({ locale }: { locale: Locale }) {
       <div className="relative mx-auto max-w-[1240px]">
         <HeroStage locale={locale} />
         {/* Eyebrow: pulsing dot + version note + NEW tag */}
-        <span className="inline-flex max-w-full items-start gap-[10px] rounded-[20px] border border-dm-line-strong bg-dm-bg-elev px-[10px] py-[5px] font-[var(--font-dm-mono)] text-[11px] text-dm-ink-2 sm:items-center sm:rounded-full sm:text-[12px]">
-          <span
-            className="dm-animated mt-[6px] h-[6px] w-[6px] shrink-0 rounded-full sm:mt-0"
-            style={{
-              background: 'var(--color-dm-ok)',
-              boxShadow: '0 0 0 4px color-mix(in srgb, var(--color-dm-ok) 30%, transparent)',
-              animation: 'dm-pulse 900ms ease-in-out infinite'
-            }}
-          />
-          <span className="min-w-0 flex-1 text-pretty leading-snug">
-            {t('hero.eyebrow', { version: siteConfig.latestVersion })}
+        <div className="flex w-full max-w-[52ch] flex-col gap-1.5 rounded-[14px] border border-dm-line-strong bg-dm-bg-elev px-3 py-2.5 font-[var(--font-dm-mono)] text-[12px] text-dm-ink-2 sm:inline-flex sm:w-auto sm:max-w-none sm:flex-row sm:items-center sm:gap-[10px] sm:rounded-full sm:px-[10px] sm:py-[5px]">
+          <div className="flex items-center gap-[10px]">
+            <span
+              className="dm-animated h-[6px] w-[6px] shrink-0 rounded-full"
+              style={{
+                background: 'var(--color-dm-ok)',
+                boxShadow: '0 0 0 4px color-mix(in srgb, var(--color-dm-ok) 30%, transparent)',
+                animation: 'dm-pulse 900ms ease-in-out infinite'
+              }}
+            />
+            <span className="font-medium text-dm-ink">v{siteConfig.latestVersion}</span>
+            <span className="ml-auto shrink-0 rounded-full bg-dm-ink px-2 py-[2px] font-semibold text-[10px] text-dm-bg tracking-[0.04em] sm:hidden">
+              {t('hero.eyebrowTag')}
+            </span>
+          </div>
+          <span className="min-w-0 text-pretty break-words leading-[1.45] sm:flex-1">
+            <span aria-hidden="true" className="hidden text-dm-ink-4 sm:inline">
+              —{' '}
+            </span>
+            {t('hero.eyebrow')}
           </span>
-          <span className="shrink-0 self-center rounded-full bg-dm-ink px-2 py-[2px] font-semibold text-[10px] text-dm-bg tracking-[0.04em]">
+          <span className="hidden shrink-0 rounded-full bg-dm-ink px-2 py-[2px] font-semibold text-[10px] text-dm-bg tracking-[0.04em] sm:inline-flex">
             {t('hero.eyebrowTag')}
           </span>
-        </span>
+        </div>
 
         {/* Two-line headline with accent on the final word of each line */}
         <h1 className="mt-[22px] max-w-[14ch] text-balance font-bold text-[clamp(44px,7.2vw,96px)] text-dm-ink leading-[0.95] tracking-[-0.045em]">

--- a/apps/landing/src/components/landing/Hero.tsx
+++ b/apps/landing/src/components/landing/Hero.tsx
@@ -130,7 +130,7 @@ export function Hero({ locale }: { locale: Locale }) {
         <div className="mt-7 flex flex-wrap items-center gap-3">
           {/* Gradient download button */}
           <Link
-            className="dm-focus-ring inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 font-semibold text-[14px] text-white no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
+            className="dm-focus-ring inline-flex h-12 items-center gap-[10px] rounded-[10px] px-5 font-semibold text-[14px] text-white no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
             href={`/${locale}/download`}
             style={{
               background:
@@ -158,7 +158,7 @@ export function Hero({ locale }: { locale: Locale }) {
           <button
             aria-label={copied ? t('hero.copied') : t('hero.copyAria', { cmd: INSTALL_CMD })}
             aria-live="polite"
-            className="dm-focus-ring inline-flex max-w-full cursor-pointer items-center gap-[10px] rounded-[10px] border border-dm-line bg-dm-bg-elev px-[12px] py-[10px] pr-3 font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-2 transition-[color,background-color,border-color,transform] fine-hover:hover:border-dm-line-strong active:scale-[0.96] sm:px-[14px] sm:text-[13px]"
+            className="dm-focus-ring inline-flex h-12 max-w-full cursor-pointer items-center gap-[10px] rounded-[10px] border border-dm-line bg-dm-bg-elev px-[12px] pr-3 font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-2 transition-[color,background-color,border-color,transform] fine-hover:hover:border-dm-line-strong active:scale-[0.96] sm:px-[14px] sm:text-[13px]"
             onClick={copyInstall}
             type="button"
           >

--- a/apps/landing/src/components/landing/Hero.tsx
+++ b/apps/landing/src/components/landing/Hero.tsx
@@ -128,15 +128,9 @@ export function Hero({ locale }: { locale: Locale }) {
         </p>
 
         <div className="mt-7 flex flex-wrap items-center gap-3">
-          {/* Gradient download button */}
           <Link
-            className="dm-focus-ring inline-flex h-12 items-center gap-[10px] rounded-[10px] px-5 font-semibold text-[14px] text-white no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
+            className="dm-focus-ring inline-flex h-12 items-center gap-[10px] rounded-[10px] bg-dm-ink px-5 font-semibold text-[14px] text-dm-bg no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
             href={`/${locale}/download`}
-            style={{
-              background: 'var(--dm-grad)',
-              boxShadow:
-                '0 10px 30px -10px color-mix(in srgb, var(--color-dm-accent-2) 55%, transparent)'
-            }}
           >
             <svg aria-hidden="true" fill="currentColor" height="14" viewBox="0 0 24 24" width="14">
               <path d="M12 16l-5-5h3V4h4v7h3l-5 5zm-7 4v-2h14v2H5z" />
@@ -345,7 +339,7 @@ function TerminalCard({ locale }: { locale: Locale }) {
                 className="absolute inset-y-0 left-0 block rounded-full"
                 style={{
                   width: '0',
-                  background: 'var(--dm-grad-90)',
+                  background: 'var(--color-dm-accent)',
                   animation: 'dm-progress 900ms var(--ease-out-strong) forwards',
                   animationDelay: `${STAGE_STEPS.progress}ms`,
                   ['--dm-progress' as string]: '100%'
@@ -469,7 +463,7 @@ function MiniBars({ delayMs }: { delayMs: number }) {
 
 function Accent({ children }: { children: React.ReactNode }) {
   return (
-    <span className="-me-[0.18em] -mb-[0.18em] bg-clip-text pe-[0.18em] pb-[0.18em] font-[var(--font-dm-display)] font-normal text-transparent italic tracking-[-0.02em] [background-image:var(--dm-grad)]">
+    <span className="font-[var(--font-dm-display)] font-normal text-dm-accent italic tracking-[-0.02em]">
       {children}
     </span>
   )

--- a/apps/landing/src/components/landing/Hero.tsx
+++ b/apps/landing/src/components/landing/Hero.tsx
@@ -135,7 +135,7 @@ export function Hero({ locale }: { locale: Locale }) {
             style={{
               background: 'var(--dm-grad)',
               boxShadow:
-                '0 10px 30px -10px color-mix(in srgb, var(--color-dm-grad-to) 55%, transparent)'
+                '0 10px 30px -10px color-mix(in srgb, var(--color-dm-accent-2) 55%, transparent)'
             }}
           >
             <svg aria-hidden="true" fill="currentColor" height="14" viewBox="0 0 24 24" width="14">

--- a/apps/landing/src/components/landing/Hero.tsx
+++ b/apps/landing/src/components/landing/Hero.tsx
@@ -133,10 +133,9 @@ export function Hero({ locale }: { locale: Locale }) {
             className="dm-focus-ring inline-flex h-12 items-center gap-[10px] rounded-[10px] px-5 font-semibold text-[14px] text-white no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
             href={`/${locale}/download`}
             style={{
-              background:
-                'linear-gradient(135deg, var(--color-dm-accent), var(--color-dm-accent-2))',
+              background: 'var(--dm-grad)',
               boxShadow:
-                '0 10px 30px -10px color-mix(in srgb, var(--color-dm-accent-2) 60%, transparent)'
+                '0 10px 30px -10px color-mix(in srgb, var(--color-dm-grad-to) 55%, transparent)'
             }}
           >
             <svg aria-hidden="true" fill="currentColor" height="14" viewBox="0 0 24 24" width="14">
@@ -346,8 +345,7 @@ function TerminalCard({ locale }: { locale: Locale }) {
                 className="absolute inset-y-0 left-0 block rounded-full"
                 style={{
                   width: '0',
-                  background:
-                    'linear-gradient(90deg, var(--color-dm-accent), var(--color-dm-accent-2))',
+                  background: 'var(--dm-grad-90)',
                   animation: 'dm-progress 900ms var(--ease-out-strong) forwards',
                   animationDelay: `${STAGE_STEPS.progress}ms`,
                   ['--dm-progress' as string]: '100%'
@@ -471,7 +469,7 @@ function MiniBars({ delayMs }: { delayMs: number }) {
 
 function Accent({ children }: { children: React.ReactNode }) {
   return (
-    <span className="-me-[0.18em] -mb-[0.18em] bg-[linear-gradient(135deg,var(--color-dm-accent)_0%,var(--color-dm-accent-2)_100%)] bg-clip-text pe-[0.18em] pb-[0.18em] font-[var(--font-dm-display)] font-normal text-transparent italic tracking-[-0.02em]">
+    <span className="-me-[0.18em] -mb-[0.18em] bg-clip-text pe-[0.18em] pb-[0.18em] font-[var(--font-dm-display)] font-normal text-transparent italic tracking-[-0.02em] [background-image:var(--dm-grad)]">
       {children}
     </span>
   )

--- a/apps/landing/src/components/landing/Hero.tsx
+++ b/apps/landing/src/components/landing/Hero.tsx
@@ -130,7 +130,7 @@ export function Hero({ locale }: { locale: Locale }) {
         <div className="mt-7 flex flex-wrap items-center gap-3">
           {/* Gradient download button */}
           <Link
-            className="dm-focus-ring inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
+            className="dm-focus-ring inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 font-semibold text-[14px] text-white no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
             href={`/${locale}/download`}
             style={{
               background:

--- a/apps/landing/src/components/landing/Hero.tsx
+++ b/apps/landing/src/components/landing/Hero.tsx
@@ -91,35 +91,37 @@ export function Hero({ locale }: { locale: Locale }) {
       <div className="relative mx-auto max-w-[1240px]">
         <HeroStage locale={locale} />
         {/* Eyebrow: pulsing dot + version note + NEW tag */}
-        <span className="inline-flex items-center gap-[10px] rounded-full border border-dm-line-strong bg-dm-bg-elev px-[10px] py-[5px] font-[var(--font-dm-mono)] text-[12px] text-dm-ink-2">
+        <span className="inline-flex max-w-full items-start gap-[10px] rounded-[20px] border border-dm-line-strong bg-dm-bg-elev px-[10px] py-[5px] font-[var(--font-dm-mono)] text-[11px] text-dm-ink-2 sm:items-center sm:rounded-full sm:text-[12px]">
           <span
-            className="dm-animated h-[6px] w-[6px] rounded-full"
+            className="dm-animated mt-[6px] h-[6px] w-[6px] shrink-0 rounded-full sm:mt-0"
             style={{
               background: 'var(--color-dm-ok)',
               boxShadow: '0 0 0 4px color-mix(in srgb, var(--color-dm-ok) 30%, transparent)',
               animation: 'dm-pulse 900ms ease-in-out infinite'
             }}
           />
-          <span>{t('hero.eyebrow', { version: siteConfig.latestVersion })}</span>
-          <span className="rounded-full bg-dm-ink px-2 py-[2px] font-semibold text-[10px] text-dm-bg tracking-[0.04em]">
+          <span className="min-w-0 flex-1 text-pretty leading-snug">
+            {t('hero.eyebrow', { version: siteConfig.latestVersion })}
+          </span>
+          <span className="shrink-0 self-center rounded-full bg-dm-ink px-2 py-[2px] font-semibold text-[10px] text-dm-bg tracking-[0.04em]">
             {t('hero.eyebrowTag')}
           </span>
         </span>
 
         {/* Two-line headline with accent on the final word of each line */}
-        <h1 className="mt-[22px] max-w-[14ch] font-bold text-[clamp(44px,7.2vw,96px)] text-dm-ink leading-[0.95] tracking-[-0.045em]">
+        <h1 className="mt-[22px] max-w-[14ch] text-balance font-bold text-[clamp(44px,7.2vw,96px)] text-dm-ink leading-[0.95] tracking-[-0.045em]">
           {t('hero.headline1Lead')} <Accent>{t('hero.headline1Accent')}</Accent>.<br />
           {t('hero.headline2Lead')} <Accent>{t('hero.headline2Accent')}</Accent>.
         </h1>
 
-        <p className="mt-6 max-w-[52ch] text-[18px] text-dm-ink-3 leading-[1.5]">
+        <p className="mt-6 max-w-[52ch] text-pretty text-[18px] text-dm-ink-3 leading-[1.5]">
           {t('hero.description')}
         </p>
 
         <div className="mt-7 flex flex-wrap items-center gap-3">
           {/* Gradient download button */}
           <Link
-            className="inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-transform hover:-translate-y-px active:translate-y-0 active:scale-[0.97]"
+            className="dm-focus-ring inline-flex items-center gap-[10px] rounded-[10px] px-5 py-3 pr-[6px] font-semibold text-[14px] text-white no-underline transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96]"
             href={`/${locale}/download`}
             style={{
               background:
@@ -146,7 +148,8 @@ export function Hero({ locale }: { locale: Locale }) {
           {/* Inline copy install command */}
           <button
             aria-label={copied ? t('hero.copied') : t('hero.copyAria', { cmd: INSTALL_CMD })}
-            className="inline-flex max-w-full cursor-pointer items-center gap-[10px] rounded-[10px] border border-dm-line bg-dm-bg-elev px-[12px] py-[10px] pr-3 font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-2 transition-[color,background-color,border-color,transform] hover:border-dm-line-strong active:scale-[0.97] sm:px-[14px] sm:text-[13px]"
+            aria-live="polite"
+            className="dm-focus-ring inline-flex max-w-full cursor-pointer items-center gap-[10px] rounded-[10px] border border-dm-line bg-dm-bg-elev px-[12px] py-[10px] pr-3 font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-2 transition-[color,background-color,border-color,transform] fine-hover:hover:border-dm-line-strong active:scale-[0.96] sm:px-[14px] sm:text-[13px]"
             onClick={copyInstall}
             type="button"
           >

--- a/apps/landing/src/components/landing/LiveDashboard.tsx
+++ b/apps/landing/src/components/landing/LiveDashboard.tsx
@@ -32,7 +32,10 @@ const MOCK_CONTAINERS = [
 export function LiveDashboard({ locale }: { locale: Locale }) {
   const { t } = useTranslation(locale)
   return (
-    <div className="mx-auto mt-10 max-w-[1240px] overflow-hidden rounded-[14px] border border-dm-line-strong bg-dm-bg-elev shadow-[0_20px_60px_-20px_rgb(0_0_0_/_0.3)]">
+    <div
+      aria-hidden="true"
+      className="mx-auto mt-10 max-w-[1240px] overflow-hidden rounded-[14px] border border-dm-line-strong bg-dm-bg-elev shadow-[0_20px_60px_-20px_rgb(0_0_0_/_0.3)]"
+    >
       <Titlebar />
       <div className="grid grid-cols-[220px_1fr]">
         <Sidebar t={t} />
@@ -90,6 +93,7 @@ function Sidebar({ t }: { t: TFn }) {
           img={c.img}
           key={c.name}
           name={c.name}
+          runningLabel={t('liveDashboard.sidebar.running')}
           state={c.state}
         />
       ))}
@@ -208,30 +212,39 @@ function ContainerRow({
   name,
   img,
   state,
-  idleLabel
+  idleLabel,
+  runningLabel
 }: {
   name: string
   img?: string
   state: 'running' | 'stopped'
   idleLabel: string
+  runningLabel: string
 }) {
   return (
     <div className="flex items-center gap-2 rounded-md px-2 py-[6px] font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-2">
       <span
-        className="h-[6px] w-[6px] rounded-full"
-        style={{
-          background: state === 'running' ? 'var(--color-dm-ok)' : 'var(--color-dm-ink-4)',
-          boxShadow:
-            state === 'running'
-              ? '0 0 8px color-mix(in srgb, var(--color-dm-ok) 60%, transparent)'
-              : undefined
-        }}
+        className={
+          state === 'running'
+            ? 'h-[6px] w-[6px] shrink-0 rounded-full'
+            : 'h-[6px] w-[6px] shrink-0 rounded-full border border-dm-ink-3 bg-transparent'
+        }
+        style={
+          state === 'running'
+            ? {
+                background: 'var(--color-dm-ok)',
+                boxShadow: '0 0 8px color-mix(in srgb, var(--color-dm-ok) 60%, transparent)'
+              }
+            : undefined
+        }
       />
       <span className="flex flex-1 flex-col overflow-hidden leading-tight">
         <span className="truncate text-dm-ink">{name}</span>
-        {img ? <span className="truncate text-[10px] text-dm-ink-4">{img}</span> : null}
+        {img ? <span className="truncate text-[10px] text-dm-ink-3">{img}</span> : null}
       </span>
-      {state === 'stopped' ? <span className="text-[10px] text-dm-ink-4">{idleLabel}</span> : null}
+      <span className="text-[10px] text-dm-ink-3">
+        {state === 'stopped' ? idleLabel : runningLabel}
+      </span>
     </div>
   )
 }
@@ -347,30 +360,31 @@ function ChartRow({ t }: { t: TFn }) {
   return (
     <div className="mt-3 grid grid-cols-2 gap-3">
       <ChartCard
-        stroke="#6366f1"
+        stroke="var(--color-dm-accent-2)"
         title={t('liveDashboard.main.charts.cpu')}
         value={`${Math.round(cpu.at(-1) ?? 0)}%`}
       >
         <Sparkline
           className="block h-[120px] w-full"
           data={cpu}
+          fill="color-mix(in srgb, var(--color-dm-accent-2) 12%, transparent)"
           height={120}
-          stroke="#6366f1"
+          stroke="var(--color-dm-accent-2)"
           strokeWidth={1.75}
           width={500}
         />
       </ChartCard>
       <ChartCard
-        stroke="#10b981"
+        stroke="var(--color-dm-ok)"
         title={t('liveDashboard.main.charts.memory')}
         value={`${Math.round(mem.at(-1) ?? 0)}%`}
       >
         <Sparkline
           className="block h-[120px] w-full"
           data={mem}
-          fill="#10b98122"
+          fill="color-mix(in srgb, var(--color-dm-ok) 12%, transparent)"
           height={120}
-          stroke="#10b981"
+          stroke="var(--color-dm-ok)"
           strokeWidth={1.75}
           width={500}
         />
@@ -393,11 +407,15 @@ function ChartCard({
   return (
     <div className="rounded-[12px] border border-dm-line bg-dm-bg-elev p-4">
       <div className="flex items-baseline justify-between">
-        <span className="text-[12px] text-dm-ink-3">{title}</span>
-        <span
-          className="font-[var(--font-dm-mono)] font-semibold text-[20px]"
-          style={{ color: stroke }}
-        >
+        <span className="inline-flex items-center gap-[6px] text-[12px] text-dm-ink-3">
+          <span
+            aria-hidden="true"
+            className="h-[6px] w-[6px] rounded-full"
+            style={{ background: stroke }}
+          />
+          {title}
+        </span>
+        <span className="font-[var(--font-dm-mono)] font-semibold text-[20px] text-dm-ink tabular-nums">
           {value}
         </span>
       </div>
@@ -424,31 +442,31 @@ function IoRow({ t }: { t: TFn }) {
   return (
     <div className="mt-3 grid grid-cols-2 gap-3">
       <ChartCard
-        stroke="#a855f7"
+        stroke="var(--color-dm-accent)"
         title={t('liveDashboard.main.charts.networkIo')}
         value={`${(net.at(-1) ?? 0).toFixed(1)} MB/s`}
       >
         <Sparkline
           className="block h-[100px] w-full"
           data={net}
-          fill="#a855f722"
+          fill="color-mix(in srgb, var(--color-dm-accent) 12%, transparent)"
           height={100}
-          stroke="#a855f7"
+          stroke="var(--color-dm-accent)"
           strokeWidth={1.5}
           width={500}
         />
       </ChartCard>
       <ChartCard
-        stroke="#ec4899"
+        stroke="var(--color-dm-accent-warm)"
         title={t('liveDashboard.main.charts.diskIo')}
         value={`${(disk.at(-1) ?? 0).toFixed(1)} MB/s`}
       >
         <Sparkline
           className="block h-[100px] w-full"
           data={disk}
-          fill="#ec489922"
+          fill="color-mix(in srgb, var(--color-dm-accent-warm) 12%, transparent)"
           height={100}
-          stroke="#ec4899"
+          stroke="var(--color-dm-accent-warm)"
           strokeWidth={1.5}
           width={500}
         />

--- a/apps/landing/src/components/landing/ModulesSection.tsx
+++ b/apps/landing/src/components/landing/ModulesSection.tsx
@@ -14,7 +14,7 @@ export async function ModulesSection({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
 
   return (
-    <section className="px-5 py-16 sm:px-8 sm:py-24" id="modules">
+    <section className="scroll-mt-24 px-5 py-16 sm:px-8 sm:py-24" id="modules">
       <div className="mx-auto max-w-[1240px]">
         <div className="mb-10 flex max-w-[780px] flex-col gap-[14px] sm:mb-12">
           <div
@@ -22,16 +22,16 @@ export async function ModulesSection({ locale }: { locale: Locale }) {
             style={{ color: 'var(--color-dm-accent)' }}
           >
             <span aria-hidden="true" className="text-dm-ink-4 before:content-['//_']" />
-            modules
+            {t('modulesSection.kicker')}
           </div>
-          <h2 className="m-0 font-bold text-[clamp(32px,4.5vw,56px)] text-dm-ink leading-[1.02] tracking-[-0.035em]">
+          <h2 className="m-0 text-balance font-bold text-[clamp(32px,4.5vw,56px)] text-dm-ink leading-[1.02] tracking-[-0.035em]">
             {t('modulesSection.titleLead')}{' '}
             <em className="font-[var(--font-dm-display)] font-normal text-dm-ink-2 italic">
               {t('modulesSection.titleAccent')}
             </em>{' '}
             {t('modulesSection.titleTrail')}
           </h2>
-          <p className="m-0 max-w-[52ch] text-[17px] text-dm-ink-3 leading-[1.5]">
+          <p className="m-0 max-w-[52ch] text-pretty text-[17px] text-dm-ink-3 leading-[1.5]">
             {t('modulesSection.descriptionPre')}
             <code className="rounded bg-dm-bg-soft px-[6px] py-[1px] font-[var(--font-dm-mono)] text-[14px]">
               docker
@@ -59,7 +59,7 @@ export async function ModulesSection({ locale }: { locale: Locale }) {
                     {t(`modulesSection.modules.${key}.chip`)}
                   </span>
                 </div>
-                <h3 className="mb-[10px] font-semibold text-[24px] text-dm-ink tracking-[-0.02em]">
+                <h3 className="mb-[10px] text-balance font-semibold text-[24px] text-dm-ink tracking-[-0.02em]">
                   {t(`modulesSection.modules.${key}.title`)}
                   <em className="font-[var(--font-dm-display)] font-normal text-dm-ink-2 italic">
                     {t(`modulesSection.modules.${key}.titleEm`)}

--- a/apps/landing/src/components/landing/PaletteViz.tsx
+++ b/apps/landing/src/components/landing/PaletteViz.tsx
@@ -162,7 +162,10 @@ export function PaletteViz() {
   const showResults = text.length > 0
 
   return (
-    <div className="overflow-hidden rounded-[10px] border border-dm-line-strong bg-dm-bg shadow-[0_20px_40px_-20px_rgb(0_0_0_/_0.35)]">
+    <div
+      aria-hidden="true"
+      className="overflow-hidden rounded-[10px] border border-dm-line-strong bg-dm-bg shadow-[0_20px_40px_-20px_rgb(0_0_0_/_0.35)]"
+    >
       <div className="flex items-center gap-[10px] border-dm-line border-b bg-dm-bg-soft px-[14px] py-3">
         <svg
           aria-hidden="true"
@@ -188,7 +191,7 @@ export function PaletteViz() {
             }}
           />
         </div>
-        <span className="ml-auto rounded border border-dm-line px-[5px] py-[1px] font-[var(--font-dm-mono)] text-[10px] text-dm-ink-4">
+        <span className="ml-auto rounded border border-dm-line px-[5px] py-[1px] font-[var(--font-dm-mono)] text-[10px] text-dm-ink-3">
           ⌘;
         </span>
       </div>
@@ -224,7 +227,7 @@ export function PaletteViz() {
                 >
                   {r.n}
                 </span>
-                <span className="ml-auto font-[var(--font-dm-mono)] text-[10.5px] text-dm-ink-4">
+                <span className="ml-auto font-[var(--font-dm-mono)] text-[10.5px] text-dm-ink-3">
                   {r.t} · {r.s}
                 </span>
               </div>

--- a/apps/landing/src/components/landing/RuntimeStrip.tsx
+++ b/apps/landing/src/components/landing/RuntimeStrip.tsx
@@ -7,7 +7,7 @@ export async function RuntimeStrip({ locale }: { locale: Locale }) {
   const { t } = await getTranslation(locale)
   return (
     <section className="border-dm-line border-y bg-dm-bg-elev/50">
-      <div className="mx-auto flex max-w-[1240px] flex-wrap items-center justify-between gap-x-6 gap-y-3 px-5 py-5 text-[12px] text-dm-ink-3 sm:px-8 sm:py-6">
+      <div className="mx-auto flex max-w-[1240px] flex-wrap items-center justify-center gap-x-5 gap-y-2 px-5 py-5 text-[12px] text-dm-ink-3 sm:justify-between sm:gap-x-6 sm:px-8 sm:py-6">
         <span className="font-[var(--font-dm-mono)] uppercase tracking-wider">
           {t('runtimeStrip.label')}
         </span>

--- a/apps/landing/src/components/policy/PolicyShell.tsx
+++ b/apps/landing/src/components/policy/PolicyShell.tsx
@@ -34,14 +34,7 @@ export function PolicyHero({
 
         <h1 className="mt-3 font-bold text-[clamp(40px,6vw,68px)] text-dm-ink leading-[1.02] tracking-[-0.035em]">
           {titleLead}{' '}
-          <em
-            className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
-            style={{
-              backgroundImage:
-                'var(--dm-grad)',
-              letterSpacing: '-0.02em'
-            }}
-          >
+          <em className="font-[var(--font-dm-display)] font-normal text-dm-accent italic tracking-[-0.02em]">
             {titleAccent}
           </em>
         </h1>

--- a/apps/landing/src/components/policy/PolicyShell.tsx
+++ b/apps/landing/src/components/policy/PolicyShell.tsx
@@ -38,7 +38,7 @@ export function PolicyHero({
             className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
             style={{
               backgroundImage:
-                'linear-gradient(135deg, var(--color-dm-accent), var(--color-dm-accent-2))',
+                'var(--dm-grad)',
               letterSpacing: '-0.02em'
             }}
           >

--- a/apps/landing/src/components/pricing/PlanCard.tsx
+++ b/apps/landing/src/components/pricing/PlanCard.tsx
@@ -112,7 +112,7 @@ export function PlanCard(p: PlanCardProps) {
         <span
           className="absolute top-[18px] right-[18px] rounded-full px-[10px] py-1 font-[var(--font-dm-mono)] font-bold text-[10.5px] text-white uppercase tracking-[0.04em]"
           style={{
-            background: 'linear-gradient(135deg, var(--color-dm-accent-2), #8b5cf6)',
+            background: 'var(--dm-grad)',
             boxShadow:
               '0 8px 20px -6px color-mix(in srgb, var(--color-dm-accent-2) 50%, transparent)'
           }}

--- a/apps/landing/src/components/pricing/PlanCard.tsx
+++ b/apps/landing/src/components/pricing/PlanCard.tsx
@@ -51,7 +51,7 @@ export function PlanCard(p: PlanCardProps) {
 
   const ctaClassName = `mt-auto inline-flex cursor-pointer items-center justify-center gap-2 rounded-[10px] px-[18px] py-[13px] font-semibold text-[14px] no-underline transition-[transform,background-color,border-color,color] active:scale-[0.97] ${
     ctaVariant === 'primary'
-      ? 'text-white hover:-translate-y-px active:translate-y-0'
+      ? 'text-dm-bg hover:-translate-y-px active:translate-y-0'
       : ctaVariant === 'disabled'
         ? 'cursor-not-allowed border border-dm-line bg-dm-bg-soft text-dm-ink-3'
         : 'border border-dm-line-strong bg-transparent text-dm-ink hover:bg-dm-bg-soft'
@@ -59,11 +59,9 @@ export function PlanCard(p: PlanCardProps) {
   const ctaStyle =
     ctaVariant === 'primary'
       ? {
-          background:
-            'linear-gradient(180deg, var(--color-dm-accent-2), color-mix(in srgb, var(--color-dm-accent-2) 80%, black))',
-          borderColor: 'transparent',
-          boxShadow:
-            '0 10px 24px -8px color-mix(in srgb, var(--color-dm-accent-2) 55%, transparent)'
+          background: 'var(--color-dm-ink)',
+          color: 'var(--color-dm-bg)',
+          borderColor: 'transparent'
         }
       : undefined
   const ctaContent = (
@@ -112,7 +110,7 @@ export function PlanCard(p: PlanCardProps) {
         <span
           className="absolute top-[18px] right-[18px] rounded-full px-[10px] py-1 font-[var(--font-dm-mono)] font-bold text-[10.5px] text-white uppercase tracking-[0.04em]"
           style={{
-            background: 'var(--dm-grad)',
+            background: 'var(--color-dm-accent)',
             boxShadow:
               '0 8px 20px -6px color-mix(in srgb, var(--color-dm-accent-2) 50%, transparent)'
           }}

--- a/apps/landing/src/components/pricing/PricingHero.tsx
+++ b/apps/landing/src/components/pricing/PricingHero.tsx
@@ -48,7 +48,7 @@ export async function PricingHero({
           <em
             className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
             style={{
-              backgroundImage: 'linear-gradient(135deg, var(--color-dm-accent-2), #8b5cf6)',
+              backgroundImage: 'var(--dm-grad)',
               letterSpacing: '-0.02em'
             }}
           >

--- a/apps/landing/src/components/pricing/PricingHero.tsx
+++ b/apps/landing/src/components/pricing/PricingHero.tsx
@@ -45,13 +45,7 @@ export async function PricingHero({
           style={{ maxWidth: locale === 'zh' || locale === 'ja' ? 'none' : '16ch' }}
         >
           {t('pricing.hero.titleLead')}{' '}
-          <em
-            className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic"
-            style={{
-              backgroundImage: 'var(--dm-grad)',
-              letterSpacing: '-0.02em'
-            }}
-          >
+          <em className="font-[var(--font-dm-display)] font-normal text-dm-accent italic tracking-[-0.02em]">
             {t('pricing.hero.titleAccent')}
           </em>
         </h1>

--- a/apps/landing/src/components/shell/Footer.tsx
+++ b/apps/landing/src/components/shell/Footer.tsx
@@ -147,7 +147,7 @@ function BrandMark() {
       className="relative grid h-[26px] w-[26px] place-items-center overflow-hidden rounded-[7px] text-white"
       style={{
         background: 'var(--dm-grad)',
-        boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.1), 0 4px 12px -4px var(--color-dm-grad-from)'
+        boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.1), 0 4px 12px -4px var(--color-dm-accent)'
       }}
     >
       <svg

--- a/apps/landing/src/components/shell/Footer.tsx
+++ b/apps/landing/src/components/shell/Footer.tsx
@@ -146,8 +146,8 @@ function BrandMark() {
     <span
       className="relative grid h-[26px] w-[26px] place-items-center overflow-hidden rounded-[7px] text-white"
       style={{
-        background: 'linear-gradient(135deg, var(--color-dm-accent), var(--color-dm-accent-2))',
-        boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.1), 0 4px 12px -4px var(--color-dm-accent)'
+        background: 'var(--dm-grad)',
+        boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.1), 0 4px 12px -4px var(--color-dm-grad-from)'
       }}
     >
       <svg

--- a/apps/landing/src/components/shell/Footer.tsx
+++ b/apps/landing/src/components/shell/Footer.tsx
@@ -13,7 +13,10 @@ export async function Footer({ locale }: { locale: Locale }) {
         <div className="flex flex-wrap items-start justify-between gap-10">
           {/* Brand column */}
           <div className="flex max-w-[300px] flex-col gap-[10px]">
-            <Link className="flex items-center gap-[10px]" href={prefix('/')}>
+            <Link
+              className="dm-focus-ring flex items-center gap-[10px] rounded-md"
+              href={prefix('/')}
+            >
               <BrandMark />
               <span className="font-bold text-[15px] text-dm-ink tracking-[-0.01em]">
                 Dockerman
@@ -24,32 +27,56 @@ export async function Footer({ locale }: { locale: Locale }) {
 
           {/* Product */}
           <FooterCol heading={t('footer.columns.product')}>
-            <Link className="hover:text-dm-ink" href={prefix('/download')}>
+            <Link
+              className="dm-focus-ring rounded-sm fine-hover:hover:text-dm-ink"
+              href={prefix('/download')}
+            >
               {t('footer.links.download')}
             </Link>
-            <Link className="hover:text-dm-ink" href={prefix('/#features')}>
+            <Link
+              className="dm-focus-ring rounded-sm fine-hover:hover:text-dm-ink"
+              href={prefix('/#features')}
+            >
               {t('footer.links.features')}
             </Link>
-            <Link className="hover:text-dm-ink" href={prefix('/changelog')}>
+            <Link
+              className="dm-focus-ring rounded-sm fine-hover:hover:text-dm-ink"
+              href={prefix('/changelog')}
+            >
               {t('footer.links.changelog')}
             </Link>
-            <Link className="hover:text-dm-ink" href={prefix('/pricing')}>
+            <Link
+              className="dm-focus-ring rounded-sm fine-hover:hover:text-dm-ink"
+              href={prefix('/pricing')}
+            >
               {t('footer.links.pricing')}
             </Link>
           </FooterCol>
 
           {/* Docs */}
           <FooterCol heading={t('footer.columns.docs')}>
-            <Link className="hover:text-dm-ink" href={prefix('/docs/getting-started')}>
+            <Link
+              className="dm-focus-ring rounded-sm fine-hover:hover:text-dm-ink"
+              href={prefix('/docs/getting-started')}
+            >
               {t('footer.links.gettingStarted')}
             </Link>
-            <Link className="hover:text-dm-ink" href={prefix('/docs/kubernetes/overview')}>
+            <Link
+              className="dm-focus-ring rounded-sm fine-hover:hover:text-dm-ink"
+              href={prefix('/docs/kubernetes/overview')}
+            >
               {t('footer.links.kubernetes')}
             </Link>
-            <Link className="hover:text-dm-ink" href={prefix('/docs/homelab')}>
+            <Link
+              className="dm-focus-ring rounded-sm fine-hover:hover:text-dm-ink"
+              href={prefix('/docs/homelab')}
+            >
               {t('footer.links.homelab')}
             </Link>
-            <Link className="hover:text-dm-ink" href={prefix('/docs/reference/troubleshooting')}>
+            <Link
+              className="dm-focus-ring rounded-sm fine-hover:hover:text-dm-ink"
+              href={prefix('/docs/reference/troubleshooting')}
+            >
               {t('footer.links.troubleshooting')}
             </Link>
           </FooterCol>
@@ -57,7 +84,7 @@ export async function Footer({ locale }: { locale: Locale }) {
           {/* Community */}
           <FooterCol heading={t('footer.columns.community')}>
             <a
-              className="hover:text-dm-ink"
+              className="dm-focus-ring rounded-sm fine-hover:hover:text-dm-ink"
               href="https://github.com/ZingerLittleBee/dockerman.app"
               rel="noopener noreferrer"
               target="_blank"
@@ -65,7 +92,7 @@ export async function Footer({ locale }: { locale: Locale }) {
               {t('footer.links.github')}
             </a>
             <a
-              className="font-[var(--font-dm-mono)] text-[12.5px] hover:text-dm-ink"
+              className="dm-focus-ring rounded-sm font-[var(--font-dm-mono)] text-[12.5px] fine-hover:hover:text-dm-ink"
               href="mailto:support@dockerman.app"
             >
               support@dockerman.app
@@ -74,20 +101,29 @@ export async function Footer({ locale }: { locale: Locale }) {
 
           {/* Legal */}
           <FooterCol heading={t('footer.columns.legal')}>
-            <Link className="hover:text-dm-ink" href={prefix('/privacy')}>
+            <Link
+              className="dm-focus-ring rounded-sm fine-hover:hover:text-dm-ink"
+              href={prefix('/privacy')}
+            >
               {t('footer.links.privacy')}
             </Link>
-            <Link className="hover:text-dm-ink" href={prefix('/terms')}>
+            <Link
+              className="dm-focus-ring rounded-sm fine-hover:hover:text-dm-ink"
+              href={prefix('/terms')}
+            >
               {t('footer.links.terms')}
             </Link>
-            <Link className="hover:text-dm-ink" href={prefix('/dpa')}>
+            <Link
+              className="dm-focus-ring rounded-sm fine-hover:hover:text-dm-ink"
+              href={prefix('/dpa')}
+            >
               {t('footer.links.dpa')}
             </Link>
           </FooterCol>
         </div>
 
         {/* Foot note: copyright + tagline */}
-        <div className="mt-10 flex flex-wrap items-center justify-between gap-4 border-dm-line border-t pt-5 font-[var(--font-dm-mono)] text-[12px] text-dm-ink-4">
+        <div className="mt-10 flex flex-wrap items-center justify-between gap-4 border-dm-line border-t pt-5 font-[var(--font-dm-mono)] text-[12px] text-dm-ink-3">
           <span>© {copyrightYear} Dockerman</span>
           <span>{t('footer.note')}</span>
         </div>

--- a/apps/landing/src/components/shell/Footer.tsx
+++ b/apps/landing/src/components/shell/Footer.tsx
@@ -146,7 +146,7 @@ function BrandMark() {
     <span
       className="relative grid h-[26px] w-[26px] place-items-center overflow-hidden rounded-[7px] text-white"
       style={{
-        background: 'var(--dm-grad)',
+        background: 'var(--color-dm-accent)',
         boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.1), 0 4px 12px -4px var(--color-dm-accent)'
       }}
     >

--- a/apps/landing/src/components/shell/Footer.tsx
+++ b/apps/landing/src/components/shell/Footer.tsx
@@ -144,10 +144,9 @@ function FooterCol({ heading, children }: { heading: string; children: React.Rea
 function BrandMark() {
   return (
     <span
-      className="relative grid h-[26px] w-[26px] place-items-center overflow-hidden rounded-[7px] text-white"
+      className="relative grid h-[26px] w-[26px] place-items-center overflow-hidden rounded-[7px] bg-[#0a0a0a] text-[#fafaf9]"
       style={{
-        background: 'var(--color-dm-accent)',
-        boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.1), 0 4px 12px -4px var(--color-dm-accent)'
+        boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.12), 0 4px 12px -4px rgb(0 0 0 / 0.35)'
       }}
     >
       <svg

--- a/apps/landing/src/components/shell/LocaleSwitch.tsx
+++ b/apps/landing/src/components/shell/LocaleSwitch.tsx
@@ -3,7 +3,7 @@
 import { cookieName, type Locale, localeConfig, locales } from '@repo/shared/i18n'
 import { useTranslation } from '@repo/shared/i18n/client'
 import { usePathname, useRouter } from 'next/navigation'
-import { type KeyboardEvent, useEffect, useRef, useState } from 'react'
+import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState } from 'react'
 
 export function LocaleSwitch({ locale }: { locale: Locale }) {
   const [open, setOpen] = useState(false)
@@ -34,7 +34,7 @@ export function LocaleSwitch({ locale }: { locale: Locale }) {
     }
   }, [open])
 
-  const onMenuKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+  const onMenuKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
     const buttons = Array.from(
       e.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')
     )

--- a/apps/landing/src/components/shell/LocaleSwitch.tsx
+++ b/apps/landing/src/components/shell/LocaleSwitch.tsx
@@ -3,7 +3,7 @@
 import { cookieName, type Locale, localeConfig, locales } from '@repo/shared/i18n'
 import { useTranslation } from '@repo/shared/i18n/client'
 import { usePathname, useRouter } from 'next/navigation'
-import { useEffect, useRef, useState } from 'react'
+import { type KeyboardEvent, useEffect, useRef, useState } from 'react'
 
 export function LocaleSwitch({ locale }: { locale: Locale }) {
   const [open, setOpen] = useState(false)
@@ -34,6 +34,26 @@ export function LocaleSwitch({ locale }: { locale: Locale }) {
     }
   }, [open])
 
+  const onMenuKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    const buttons = Array.from(
+      e.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')
+    )
+    const current = buttons.indexOf(document.activeElement as HTMLButtonElement)
+    if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+      e.preventDefault()
+      buttons[(current + 1 + buttons.length) % buttons.length]?.focus()
+    } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+      e.preventDefault()
+      buttons[(current - 1 + buttons.length) % buttons.length]?.focus()
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      buttons[0]?.focus()
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      buttons.at(-1)?.focus()
+    }
+  }
+
   const switchTo = (next: Locale) => {
     setOpen(false)
     if (next === locale) {
@@ -49,10 +69,11 @@ export function LocaleSwitch({ locale }: { locale: Locale }) {
   return (
     <div className="relative" ref={ref}>
       <button
+        aria-controls="dm-locale-menu"
         aria-expanded={open}
         aria-haspopup="menu"
         aria-label={t('nav.changeLanguage')}
-        className="grid h-8 w-8 cursor-pointer place-items-center rounded-md text-dm-ink-2 transition-[color,background-color,border-color,transform] hover:bg-dm-bg-soft hover:text-dm-ink active:scale-[0.97]"
+        className="dm-focus-ring grid h-8 w-8 cursor-pointer place-items-center rounded-md text-dm-ink-2 transition-[color,background-color,border-color,transform] fine-hover:hover:bg-dm-bg-soft fine-hover:hover:text-dm-ink active:scale-[0.96]"
         onClick={() => setOpen((o) => !o)}
         type="button"
       >
@@ -76,6 +97,8 @@ export function LocaleSwitch({ locale }: { locale: Locale }) {
       {open ? (
         <div
           className="absolute top-[40px] right-0 z-50 w-[168px] overflow-hidden rounded-[10px] border border-dm-line-strong bg-dm-bg-elev p-1"
+          id="dm-locale-menu"
+          onKeyDown={onMenuKeyDown}
           role="menu"
           style={{ boxShadow: '0 20px 40px -20px rgb(0 0 0 / 0.35)' }}
         >
@@ -84,8 +107,10 @@ export function LocaleSwitch({ locale }: { locale: Locale }) {
             return (
               <button
                 aria-current={isActive ? 'true' : undefined}
-                className={`flex w-full cursor-pointer items-center justify-between gap-2 rounded-md px-[10px] py-[7px] text-left text-[13px] transition-[color,background-color,border-color,transform] active:scale-[0.97] ${
-                  isActive ? 'text-dm-ink' : 'text-dm-ink-2 hover:bg-dm-bg-soft hover:text-dm-ink'
+                className={`dm-focus-ring flex w-full cursor-pointer items-center justify-between gap-2 rounded-md px-[10px] py-[7px] text-left text-[13px] transition-[color,background-color,border-color,transform] active:scale-[0.96] ${
+                  isActive
+                    ? 'text-dm-ink'
+                    : 'text-dm-ink-2 fine-hover:hover:bg-dm-bg-soft fine-hover:hover:text-dm-ink'
                 }`}
                 key={code}
                 onClick={() => switchTo(code)}

--- a/apps/landing/src/components/shell/LocaleSwitch.tsx
+++ b/apps/landing/src/components/shell/LocaleSwitch.tsx
@@ -73,7 +73,7 @@ export function LocaleSwitch({ locale }: { locale: Locale }) {
         aria-expanded={open}
         aria-haspopup="menu"
         aria-label={t('nav.changeLanguage')}
-        className="dm-focus-ring grid h-8 w-8 cursor-pointer place-items-center rounded-md text-dm-ink-2 transition-[color,background-color,border-color,transform] fine-hover:hover:bg-dm-bg-soft fine-hover:hover:text-dm-ink active:scale-[0.96]"
+        className="dm-focus-ring grid h-9 w-9 cursor-pointer place-items-center rounded-md text-dm-ink-2 transition-[color,background-color,border-color,transform] fine-hover:hover:bg-dm-bg-soft fine-hover:hover:text-dm-ink active:scale-[0.96]"
         onClick={() => setOpen((o) => !o)}
         type="button"
       >
@@ -96,7 +96,7 @@ export function LocaleSwitch({ locale }: { locale: Locale }) {
 
       {open ? (
         <div
-          className="absolute top-[40px] right-0 z-50 w-[168px] overflow-hidden rounded-[10px] border border-dm-line-strong bg-dm-bg-elev p-1"
+          className="absolute top-full right-0 z-50 mt-2 w-[168px] overflow-hidden rounded-[10px] border border-dm-line-strong bg-dm-bg-elev p-1"
           id="dm-locale-menu"
           onKeyDown={onMenuKeyDown}
           role="menu"

--- a/apps/landing/src/components/shell/Navbar.tsx
+++ b/apps/landing/src/components/shell/Navbar.tsx
@@ -215,7 +215,7 @@ function BrandMark() {
       className="relative grid h-[26px] w-[26px] place-items-center overflow-hidden rounded-[7px] text-white"
       style={{
         background: 'var(--dm-grad)',
-        boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.1), 0 4px 12px -4px var(--color-dm-grad-from)'
+        boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.1), 0 4px 12px -4px var(--color-dm-accent)'
       }}
     >
       <svg

--- a/apps/landing/src/components/shell/Navbar.tsx
+++ b/apps/landing/src/components/shell/Navbar.tsx
@@ -214,8 +214,8 @@ function BrandMark() {
     <span
       className="relative grid h-[26px] w-[26px] place-items-center overflow-hidden rounded-[7px] text-white"
       style={{
-        background: 'linear-gradient(135deg, var(--color-dm-accent), var(--color-dm-accent-2))',
-        boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.1), 0 4px 12px -4px var(--color-dm-accent)'
+        background: 'var(--dm-grad)',
+        boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.1), 0 4px 12px -4px var(--color-dm-grad-from)'
       }}
     >
       <svg

--- a/apps/landing/src/components/shell/Navbar.tsx
+++ b/apps/landing/src/components/shell/Navbar.tsx
@@ -40,10 +40,17 @@ export function Navbar({ locale }: { locale: Locale }) {
     if (!menuOpen) return
     const prev = document.body.style.overflow
     document.body.style.overflow = 'hidden'
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setMenu({ open: false, pathname })
+      }
+    }
+    document.addEventListener('keydown', onEsc)
     return () => {
       document.body.style.overflow = prev
+      document.removeEventListener('keydown', onEsc)
     }
-  }, [menuOpen])
+  }, [menuOpen, pathname])
 
   return (
     <nav
@@ -52,13 +59,17 @@ export function Navbar({ locale }: { locale: Locale }) {
         background: 'color-mix(in srgb, var(--color-dm-bg) 80%, transparent)'
       }}
     >
-      <div className="mx-auto flex max-w-[1240px] items-center justify-between gap-2 px-4 py-[14px] sm:px-6 md:px-8">
+      <a className="dm-skip-link" href="#main">
+        {t('nav.skipToContent')}
+      </a>
+      <div className="mx-auto flex max-w-[1240px] items-center justify-between gap-1.5 px-3 py-[14px] sm:gap-2 sm:px-6 md:px-8">
         <Link
-          className="flex min-w-0 items-center gap-[10px] font-bold text-[15px] text-dm-ink tracking-[-0.01em]"
+          aria-label="Dockerman"
+          className="dm-focus-ring flex min-w-0 items-center gap-2 rounded-md font-bold text-[15px] text-dm-ink tracking-[-0.01em] sm:gap-[10px]"
           href={hrefFor('/')}
         >
           <BrandMark />
-          <span>Dockerman</span>
+          <span className="max-[360px]:hidden">Dockerman</span>
           <span className="ml-[2px] hidden rounded-full bg-dm-ink px-2 py-[2px] font-semibold text-[10px] text-dm-bg tracking-[0.04em] sm:inline">
             v{siteConfig.latestVersion}
           </span>
@@ -67,7 +78,7 @@ export function Navbar({ locale }: { locale: Locale }) {
         <div className="hidden items-center gap-1 text-[13px] text-dm-ink-2 md:flex">
           {LINKS.map((l) => (
             <Link
-              className={`rounded-md px-3 py-[6px] transition-colors hover:bg-dm-bg-soft hover:text-dm-ink ${
+              className={`dm-focus-ring rounded-md px-3 py-[6px] transition-colors fine-hover:hover:bg-dm-bg-soft fine-hover:hover:text-dm-ink ${
                 isActive(l.href, l.anchor) ? 'text-dm-ink' : ''
               }`}
               href={hrefFor(l.href)}
@@ -78,12 +89,12 @@ export function Navbar({ locale }: { locale: Locale }) {
           ))}
         </div>
 
-        <div className="flex items-center gap-1 sm:gap-2">
+        <div className="flex shrink-0 items-center gap-0.5 sm:gap-2">
           <LocaleSwitch locale={locale} />
           <ThemeSwitch />
           <a
             aria-label={t('nav.github')}
-            className="hidden h-8 w-8 place-items-center rounded-md text-dm-ink-2 hover:bg-dm-bg-soft hover:text-dm-ink sm:grid"
+            className="dm-focus-ring hidden h-8 w-8 place-items-center rounded-md text-dm-ink-2 fine-hover:hover:bg-dm-bg-soft fine-hover:hover:text-dm-ink sm:grid"
             href="https://github.com/ZingerLittleBee/dockerman.app"
             rel="noopener noreferrer"
             target="_blank"
@@ -91,7 +102,7 @@ export function Navbar({ locale }: { locale: Locale }) {
             <RiGithubFill className="h-4 w-4" />
           </a>
           <Link
-            className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg border border-dm-ink bg-dm-ink px-[12px] py-[7px] font-medium text-[12.5px] text-dm-bg transition-transform hover:-translate-y-px active:translate-y-0 active:scale-[0.97] sm:px-[14px] sm:py-2 sm:text-[13px]"
+            className="dm-focus-ring inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg border border-dm-ink bg-dm-ink px-[12px] py-[7px] font-medium text-[12.5px] text-dm-bg transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96] sm:px-[14px] sm:py-2 sm:text-[13px]"
             href={hrefFor('/download')}
           >
             {t('nav.download')}
@@ -100,7 +111,7 @@ export function Navbar({ locale }: { locale: Locale }) {
             aria-controls="dm-mobile-menu"
             aria-expanded={menuOpen}
             aria-label={menuOpen ? t('nav.closeMenu') : t('nav.openMenu')}
-            className="grid h-8 w-8 cursor-pointer place-items-center rounded-md border border-dm-line bg-dm-bg-elev text-dm-ink-2 transition-[color,background-color,border-color,transform] hover:border-dm-line-strong hover:text-dm-ink active:scale-[0.97] md:hidden"
+            className="dm-focus-ring grid h-8 w-8 cursor-pointer place-items-center rounded-md border border-dm-line bg-dm-bg-elev text-dm-ink-2 transition-[color,background-color,border-color,transform] fine-hover:hover:border-dm-line-strong fine-hover:hover:text-dm-ink active:scale-[0.96] md:hidden"
             onClick={() =>
               setMenu((current) => ({
                 open: current.pathname === pathname ? !current.open : true,
@@ -127,8 +138,8 @@ export function Navbar({ locale }: { locale: Locale }) {
 
       {/* Mobile menu drawer */}
       <div
-        aria-hidden={!menuOpen}
         className={`md:hidden ${menuOpen ? 'pointer-events-auto' : 'pointer-events-none'}`}
+        inert={menuOpen ? undefined : true}
       >
         {/* Backdrop */}
         <button
@@ -155,10 +166,10 @@ export function Navbar({ locale }: { locale: Locale }) {
               return (
                 <li key={l.href}>
                   <Link
-                    className={`flex items-center justify-between rounded-md px-3 py-3 text-[15px] transition-colors ${
+                    className={`dm-focus-ring flex items-center justify-between rounded-md px-3 py-3 text-[15px] transition-colors ${
                       active
                         ? 'bg-dm-bg-soft text-dm-ink'
-                        : 'text-dm-ink-2 hover:bg-dm-bg-soft hover:text-dm-ink'
+                        : 'text-dm-ink-2 fine-hover:hover:bg-dm-bg-soft fine-hover:hover:text-dm-ink'
                     }`}
                     href={hrefFor(l.href)}
                     onClick={() => setMenu({ open: false, pathname })}
@@ -181,7 +192,7 @@ export function Navbar({ locale }: { locale: Locale }) {
             })}
             <li className="mt-2 border-dm-line border-t pt-3">
               <a
-                className="flex items-center gap-3 rounded-md px-3 py-3 text-[14px] text-dm-ink-2 hover:bg-dm-bg-soft hover:text-dm-ink"
+                className="dm-focus-ring flex items-center gap-3 rounded-md px-3 py-3 text-[14px] text-dm-ink-2 fine-hover:hover:bg-dm-bg-soft fine-hover:hover:text-dm-ink"
                 href="https://github.com/ZingerLittleBee/dockerman.app"
                 onClick={() => setMenu({ open: false, pathname })}
                 rel="noopener noreferrer"

--- a/apps/landing/src/components/shell/Navbar.tsx
+++ b/apps/landing/src/components/shell/Navbar.tsx
@@ -212,10 +212,9 @@ export function Navbar({ locale }: { locale: Locale }) {
 function BrandMark() {
   return (
     <span
-      className="relative grid h-[26px] w-[26px] place-items-center overflow-hidden rounded-[7px] text-white"
+      className="relative grid h-[26px] w-[26px] place-items-center overflow-hidden rounded-[7px] bg-[#0a0a0a] text-[#fafaf9]"
       style={{
-        background: 'var(--color-dm-accent)',
-        boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.1), 0 4px 12px -4px var(--color-dm-accent)'
+        boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.12), 0 4px 12px -4px rgb(0 0 0 / 0.35)'
       }}
     >
       <svg

--- a/apps/landing/src/components/shell/Navbar.tsx
+++ b/apps/landing/src/components/shell/Navbar.tsx
@@ -214,7 +214,7 @@ function BrandMark() {
     <span
       className="relative grid h-[26px] w-[26px] place-items-center overflow-hidden rounded-[7px] text-white"
       style={{
-        background: 'var(--dm-grad)',
+        background: 'var(--color-dm-accent)',
         boxShadow: 'inset 0 0 0 1px rgb(255 255 255 / 0.1), 0 4px 12px -4px var(--color-dm-accent)'
       }}
     >

--- a/apps/landing/src/components/shell/Navbar.tsx
+++ b/apps/landing/src/components/shell/Navbar.tsx
@@ -94,7 +94,7 @@ export function Navbar({ locale }: { locale: Locale }) {
           <ThemeSwitch />
           <a
             aria-label={t('nav.github')}
-            className="dm-focus-ring hidden h-8 w-8 place-items-center rounded-md text-dm-ink-2 fine-hover:hover:bg-dm-bg-soft fine-hover:hover:text-dm-ink sm:grid"
+            className="dm-focus-ring hidden h-9 w-9 place-items-center rounded-md text-dm-ink-2 fine-hover:hover:bg-dm-bg-soft fine-hover:hover:text-dm-ink sm:grid"
             href="https://github.com/ZingerLittleBee/dockerman.app"
             rel="noopener noreferrer"
             target="_blank"
@@ -102,7 +102,7 @@ export function Navbar({ locale }: { locale: Locale }) {
             <RiGithubFill className="h-4 w-4" />
           </a>
           <Link
-            className="dm-focus-ring inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg border border-dm-ink bg-dm-ink px-[12px] py-[7px] font-medium text-[12.5px] text-dm-bg transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96] sm:px-[14px] sm:py-2 sm:text-[13px]"
+            className="dm-focus-ring inline-flex h-9 shrink-0 items-center gap-2 whitespace-nowrap rounded-lg border border-dm-ink bg-dm-ink px-[12px] font-medium text-[12.5px] text-dm-bg transition-transform fine-hover:hover:-translate-y-px active:translate-y-0 active:scale-[0.96] sm:px-[14px] sm:text-[13px]"
             href={hrefFor('/download')}
           >
             {t('nav.download')}
@@ -111,7 +111,7 @@ export function Navbar({ locale }: { locale: Locale }) {
             aria-controls="dm-mobile-menu"
             aria-expanded={menuOpen}
             aria-label={menuOpen ? t('nav.closeMenu') : t('nav.openMenu')}
-            className="dm-focus-ring grid h-8 w-8 cursor-pointer place-items-center rounded-md border border-dm-line bg-dm-bg-elev text-dm-ink-2 transition-[color,background-color,border-color,transform] fine-hover:hover:border-dm-line-strong fine-hover:hover:text-dm-ink active:scale-[0.96] md:hidden"
+            className="dm-focus-ring grid h-9 w-9 cursor-pointer place-items-center rounded-md border border-dm-line bg-dm-bg-elev text-dm-ink-2 transition-[color,background-color,border-color,transform] fine-hover:hover:border-dm-line-strong fine-hover:hover:text-dm-ink active:scale-[0.96] md:hidden"
             onClick={() =>
               setMenu((current) => ({
                 open: current.pathname === pathname ? !current.open : true,
@@ -144,7 +144,7 @@ export function Navbar({ locale }: { locale: Locale }) {
         {/* Backdrop */}
         <button
           aria-label={t('nav.closeMenu')}
-          className={`fixed inset-x-0 top-[57px] bottom-0 z-40 cursor-default bg-dm-bg/60 backdrop-blur-[2px] transition-opacity duration-200 ${
+          className={`absolute inset-x-0 top-full z-40 h-[100dvh] cursor-default bg-dm-bg/60 backdrop-blur-[2px] transition-opacity duration-200 ${
             menuOpen ? 'opacity-100' : 'opacity-0'
           }`}
           onClick={() => setMenu({ open: false, pathname })}

--- a/apps/landing/src/components/snapshot/SnapshotHero.tsx
+++ b/apps/landing/src/components/snapshot/SnapshotHero.tsx
@@ -18,31 +18,13 @@ export async function SnapshotHero({ locale }: { locale: Locale }) {
       />
       <div className="mx-auto max-w-[1320px]">
         <span className="inline-flex items-center gap-[10px] rounded-full border border-dm-line-strong bg-dm-bg-elev py-[5px] pr-[11px] pl-[11px] font-[var(--font-dm-mono)] text-[11.5px] text-dm-ink-2 tracking-[0.02em]">
-          <span
-            className="bg-clip-text px-[5px] font-bold text-transparent"
-            style={{
-              backgroundImage: 'var(--dm-grad)'
-            }}
-          >
-            {count}
-          </span>
+          <span className="px-[5px] font-bold text-dm-accent">{count}</span>
           <span>{t('snapshot.hero.kickerLabel')}</span>
         </span>
 
         <h1 className="mt-[18px] max-w-[16ch] font-bold text-[clamp(44px,6.2vw,84px)] text-dm-ink leading-[0.98] tracking-[-0.04em]">
           {t('snapshot.hero.titleLead')}{' '}
-          <em
-            className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic tracking-[-0.02em]"
-            style={{
-              backgroundImage: 'var(--dm-grad)',
-              paddingInline: '0.18em',
-              marginInline: '-0.18em',
-              paddingBlock: '0.18em',
-              marginBlock: '-0.18em',
-              WebkitBoxDecorationBreak: 'clone',
-              boxDecorationBreak: 'clone'
-            }}
-          >
+          <em className="font-[var(--font-dm-display)] font-normal text-dm-accent italic tracking-[-0.02em]">
             {t('snapshot.hero.titleAccent')}
           </em>
         </h1>

--- a/apps/landing/src/components/snapshot/SnapshotHero.tsx
+++ b/apps/landing/src/components/snapshot/SnapshotHero.tsx
@@ -21,8 +21,7 @@ export async function SnapshotHero({ locale }: { locale: Locale }) {
           <span
             className="bg-clip-text px-[5px] font-bold text-transparent"
             style={{
-              backgroundImage:
-                'linear-gradient(135deg, var(--color-dm-accent), var(--color-dm-accent-2))'
+              backgroundImage: 'var(--dm-grad)'
             }}
           >
             {count}
@@ -35,8 +34,7 @@ export async function SnapshotHero({ locale }: { locale: Locale }) {
           <em
             className="bg-clip-text font-[var(--font-dm-display)] font-normal text-transparent italic tracking-[-0.02em]"
             style={{
-              backgroundImage:
-                'linear-gradient(135deg, var(--color-dm-accent), var(--color-dm-accent-2))',
+              backgroundImage: 'var(--dm-grad)',
               paddingInline: '0.18em',
               marginInline: '-0.18em',
               paddingBlock: '0.18em',

--- a/apps/landing/src/components/snapshot/SnapshotShowcase.tsx
+++ b/apps/landing/src/components/snapshot/SnapshotShowcase.tsx
@@ -378,7 +378,7 @@ function RailItem({
           active
             ? {
                 background:
-                  'linear-gradient(135deg, var(--color-dm-accent), var(--color-dm-accent-2))',
+                  'var(--dm-grad)',
                 boxShadow:
                   '0 3px 10px -3px color-mix(in srgb, var(--color-dm-accent) 55%, transparent)'
               }

--- a/apps/landing/src/components/snapshot/SnapshotShowcase.tsx
+++ b/apps/landing/src/components/snapshot/SnapshotShowcase.tsx
@@ -377,8 +377,7 @@ function RailItem({
         style={
           active
             ? {
-                background:
-                  'var(--dm-grad)',
+                background: 'var(--color-dm-accent)',
                 boxShadow:
                   '0 3px 10px -3px color-mix(in srgb, var(--color-dm-accent) 55%, transparent)'
               }

--- a/apps/landing/src/components/ui/StatCard.tsx
+++ b/apps/landing/src/components/ui/StatCard.tsx
@@ -17,8 +17,10 @@ export function StatCard({
         <span>{title}</span>
         {icon}
       </div>
-      <div className="mt-2 font-bold text-[28px] text-dm-ink tracking-[-0.02em]">{value}</div>
-      {subtitle && <div className="mt-1 text-[12px] text-dm-ink-4">{subtitle}</div>}
+      <div className="mt-2 font-bold text-[28px] text-dm-ink tabular-nums tracking-[-0.02em]">
+        {value}
+      </div>
+      {subtitle ? <div className="mt-1 text-[12px] text-dm-ink-3">{subtitle}</div> : null}
     </div>
   )
 }

--- a/packages/shared/src/locales/en.json
+++ b/packages/shared/src/locales/en.json
@@ -13,7 +13,7 @@
     "skipToContent": "Skip to content"
   },
   "hero": {
-    "eyebrow": "v{{version}} — Memorable *.dockerman.localhost addresses, guided Local Domains setup, domains that survive recreation",
+    "eyebrow": "Memorable *.dockerman.localhost addresses, guided Local Domains setup, domains that survive recreation",
     "eyebrowTag": "NEW",
     "headline1Lead": "Docker that feels",
     "headline1Accent": "local",

--- a/packages/shared/src/locales/en.json
+++ b/packages/shared/src/locales/en.json
@@ -9,7 +9,8 @@
     "github": "GitHub",
     "changeLanguage": "Change language",
     "openMenu": "Open menu",
-    "closeMenu": "Close menu"
+    "closeMenu": "Close menu",
+    "skipToContent": "Skip to content"
   },
   "hero": {
     "eyebrow": "v{{version}} — Memorable *.dockerman.localhost addresses, guided Local Domains setup, domains that survive recreation",
@@ -107,6 +108,7 @@
     "download": "Download"
   },
   "featuresSection": {
+    "kicker": "features",
     "titleLead": "Every object you care about,",
     "titleAccent": "one keystroke away.",
     "description": "Containers, images, volumes, networks, compose projects, Kubernetes workloads, Cloudflared tunnels — all surfaced in a single, low-latency interface.",
@@ -148,6 +150,7 @@
     }
   },
   "modulesSection": {
+    "kicker": "modules",
     "titleLead": "Built for the things you",
     "titleAccent": "actually",
     "titleTrail": "do every day.",
@@ -229,6 +232,7 @@
         "file": "File"
       },
       "containersHeader": "Containers",
+      "running": "running",
       "idle": "idle"
     },
     "main": {

--- a/packages/shared/src/locales/es.json
+++ b/packages/shared/src/locales/es.json
@@ -9,7 +9,8 @@
     "github": "GitHub",
     "changeLanguage": "Cambiar idioma",
     "openMenu": "Abrir menú",
-    "closeMenu": "Cerrar menú"
+    "closeMenu": "Cerrar menú",
+    "skipToContent": "Saltar al contenido"
   },
   "hero": {
     "eyebrow": "v{{version}} — Direcciones *.dockerman.localhost memorables, configuración guiada de Local Domains, dominios que sobreviven a la recreación",
@@ -107,6 +108,7 @@
     "download": "Descargar"
   },
   "featuresSection": {
+    "kicker": "funciones",
     "titleLead": "Todo lo que te importa,",
     "titleAccent": "a una tecla de distancia.",
     "description": "Contenedores, imágenes, volúmenes, redes, proyectos Compose, cargas de Kubernetes, túneles Cloudflared — todo en una sola interfaz de baja latencia.",
@@ -148,6 +150,7 @@
     }
   },
   "modulesSection": {
+    "kicker": "módulos",
     "titleLead": "Construido para lo que",
     "titleAccent": "realmente",
     "titleTrail": "haces cada día.",
@@ -229,6 +232,7 @@
         "file": "Archivos"
       },
       "containersHeader": "Contenedores",
+      "running": "en ejecución",
       "idle": "inactivo"
     },
     "main": {

--- a/packages/shared/src/locales/es.json
+++ b/packages/shared/src/locales/es.json
@@ -13,7 +13,7 @@
     "skipToContent": "Saltar al contenido"
   },
   "hero": {
-    "eyebrow": "v{{version}} — Direcciones *.dockerman.localhost memorables, configuración guiada de Local Domains, dominios que sobreviven a la recreación",
+    "eyebrow": "Direcciones *.dockerman.localhost memorables, configuración guiada de Local Domains, dominios que sobreviven a la recreación",
     "eyebrowTag": "NUEVO",
     "headline1Lead": "Docker que se siente",
     "headline1Accent": "local",

--- a/packages/shared/src/locales/ja.json
+++ b/packages/shared/src/locales/ja.json
@@ -13,7 +13,7 @@
     "skipToContent": "コンテンツへスキップ"
   },
   "hero": {
-    "eyebrow": "v{{version}} — 覚えやすい *.dockerman.localhost アドレス、ガイド付き Local Domains セットアップ、再作成後も残るドメイン",
+    "eyebrow": "覚えやすい *.dockerman.localhost アドレス、ガイド付き Local Domains セットアップ、再作成後も残るドメイン",
     "eyebrowTag": "NEW",
     "headline1Lead": "Docker を",
     "headline1Accent": "ローカルに",

--- a/packages/shared/src/locales/ja.json
+++ b/packages/shared/src/locales/ja.json
@@ -9,7 +9,8 @@
     "github": "GitHub",
     "changeLanguage": "言語を変更",
     "openMenu": "メニューを開く",
-    "closeMenu": "メニューを閉じる"
+    "closeMenu": "メニューを閉じる",
+    "skipToContent": "コンテンツへスキップ"
   },
   "hero": {
     "eyebrow": "v{{version}} — 覚えやすい *.dockerman.localhost アドレス、ガイド付き Local Domains セットアップ、再作成後も残るドメイン",
@@ -107,6 +108,7 @@
     "download": "ダウンロード"
   },
   "featuresSection": {
+    "kicker": "機能",
     "titleLead": "気にかけるあらゆるもの、",
     "titleAccent": "キー一打で。",
     "description": "コンテナ、イメージ、ボリューム、ネットワーク、Compose プロジェクト、Kubernetes ワークロード、Cloudflared トンネル — すべてを低遅延の単一 UI に。",
@@ -148,6 +150,7 @@
     }
   },
   "modulesSection": {
+    "kicker": "モジュール",
     "titleLead": "あなたが",
     "titleAccent": "実際に",
     "titleTrail": "毎日やっていることのために。",
@@ -229,6 +232,7 @@
         "file": "ファイル"
       },
       "containersHeader": "コンテナ",
+      "running": "稼働中",
       "idle": "待機"
     },
     "main": {

--- a/packages/shared/src/locales/zh.json
+++ b/packages/shared/src/locales/zh.json
@@ -9,7 +9,8 @@
     "github": "GitHub",
     "changeLanguage": "切换语言",
     "openMenu": "打开菜单",
-    "closeMenu": "关闭菜单"
+    "closeMenu": "关闭菜单",
+    "skipToContent": "跳到正文"
   },
   "hero": {
     "eyebrow": "v{{version}} — 好记的 *.dockerman.localhost 地址、引导式本地域名设置、域名在容器重建后仍可用",
@@ -107,6 +108,7 @@
     "download": "下载"
   },
   "featuresSection": {
+    "kicker": "特性",
     "titleLead": "你关心的每一个对象，",
     "titleAccent": "只差一次击键。",
     "description": "容器、镜像、卷、网络、Compose 项目、Kubernetes 工作负载、Cloudflared 隧道 —— 全部汇聚于单一的低延迟界面。",
@@ -148,6 +150,7 @@
     }
   },
   "modulesSection": {
+    "kicker": "模块",
     "titleLead": "为你每天",
     "titleAccent": "真正",
     "titleTrail": "在做的事打造。",
@@ -229,6 +232,7 @@
         "file": "文件"
       },
       "containersHeader": "容器",
+      "running": "运行中",
       "idle": "空闲"
     },
     "main": {

--- a/packages/shared/src/locales/zh.json
+++ b/packages/shared/src/locales/zh.json
@@ -13,7 +13,7 @@
     "skipToContent": "跳到正文"
   },
   "hero": {
-    "eyebrow": "v{{version}} — 好记的 *.dockerman.localhost 地址、引导式本地域名设置、域名在容器重建后仍可用",
+    "eyebrow": "好记的 *.dockerman.localhost 地址、引导式本地域名设置、域名在容器重建后仍可用",
     "eyebrowTag": "新",
     "headline1Lead": "Docker，用起来像",
     "headline1Accent": "本地",


### PR DESCRIPTION
## Summary

- tighten landing chrome: hero eyebrow on small screens, download button padding and heights, and a 36px navbar control cluster aligned to Download
- drop brand gradients for solid fills; keep ink CTAs and switch the theme accent from teal to indigo
- use a black brand mark (navbar, footer, docs OG) so the logo matches the solid buttons
- update `DESIGN.md` tokens and the four locale files for the new kickers and skip-link copy

## Validation

- measured navbar controls at 36px on desktop (1440) and mobile (390); locale menu and mobile drawer still open
- checked home, download, and pricing in light and dark; status green stays on running/success dots only
- no remaining teal brand fills in `apps/landing` source

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-site styling, accessibility, and copy only—no auth, payments logic, or backend behavior changes beyond OG image rendering.
> 
> **Overview**
> Rebrands the landing site around **solid ink CTAs and indigo accents**, retiring teal and gradient headline/CTA treatments across marketing pages, pricing, changelog, docs OG, and `DESIGN.md`.
> 
> **Visual system:** `dm-accent` moves from teal to indigo (with a lighter dark-mode token); primary buttons and plan CTAs use `dm-ink` on `dm-bg` instead of accent gradients. Display emphasis shifts from gradient clip-text to **`text-dm-accent` italic**. Brand marks (navbar, footer, OG) become black tiles with the dock icon. Body/selection styling and sparkline colors align with design tokens.
> 
> **Chrome & UX:** Adds shared **`dm-focus-ring`**, **`dm-skip-link`**, and **`fine-hover`** so focus and hover behave consistently; navbar gets skip-to-`#main`, a focusable main wrapper, taller controls, mobile menu `inert`/Escape handling, and locale menu keyboard navigation. Hero eyebrow is reworked for small screens; **Live Dashboard** is shown on mobile with horizontal scroll and a fade edge.
> 
> **Content & polish:** Feature cards gain decorative visuals and a11y tweaks; section kickers and hero copy are i18n’d (four locales); muted text contrast is bumped in several spots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304e3da0098ab839f6e9d19605b489a7da5f18d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->