### PR TITLE
perf(landing): defer analytics until after first paint

### DIFF
--- a/apps/landing/instrumentation-client.ts
+++ b/apps/landing/instrumentation-client.ts
@@ -1,23 +1,6 @@
-import { createPostHogConfig } from './src/lib/analytics/posthogConfig'
+import { createProductionBrowserPostHogInitializer } from './src/lib/analytics/initBrowserPostHog'
+import { scheduleAfterLoadIdle } from './src/lib/analytics/scheduleAfterLoadIdle'
 
-const initPostHog = async () => {
-  const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY
+const initPostHog = createProductionBrowserPostHogInitializer()
 
-  if (!posthogKey) {
-    return
-  }
-
-  const { default: posthog } = await import('posthog-js')
-
-  posthog.init(
-    posthogKey,
-    createPostHogConfig(
-      process.env.NEXT_PUBLIC_POSTHOG_HOST,
-      process.env.NODE_ENV === 'development'
-    )
-  )
-}
-
-initPostHog().catch(() => {
-  // Analytics failures should not block app initialization.
-})
+scheduleAfterLoadIdle(initPostHog)

--- a/apps/landing/src/app/[locale]/(main)/about/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/about/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { RiGithubFill, RiTwitterXFill } from '@remixicon/react'
+import { captureBrowserEvent } from '@repo/shared/analytics/browserPostHog'
 import { useTranslation } from '@repo/shared/i18n/client'
 import Image from 'next/image'
 import Balancer from 'react-wrap-balancer'
@@ -22,13 +23,7 @@ type SocialPlatform = 'github' | 'twitter'
 type SocialSection = 'team_member' | 'join_us'
 
 function captureSocialClick(platform: SocialPlatform, section: SocialSection, url: string) {
-  import('posthog-js')
-    .then(({ default: posthog }) => {
-      posthog.capture('about_social_clicked', { platform, section, url })
-    })
-    .catch(() => {
-      // Analytics failures should never interfere with navigation.
-    })
+  captureBrowserEvent('about_social_clicked', { platform, section, url })
 }
 
 export default function About() {

--- a/apps/landing/src/app/performance-contracts.test.ts
+++ b/apps/landing/src/app/performance-contracts.test.ts
@@ -37,6 +37,22 @@ describe('landing performance contracts', () => {
     expect(posthogImport).toBeGreaterThan(posthogKeyGuard)
   })
 
+  test('browser PostHog capture callers share the deferred queue instead of importing posthog-js', () => {
+    const callers = [
+      'src/components/ThemeSwitch.tsx',
+      'src/app/[locale]/(main)/about/page.tsx',
+      '../../packages/shared/src/hooks/usePageEngaged.ts',
+      '../../packages/shared/src/hooks/useScrollDepth.ts'
+    ]
+
+    for (const path of callers) {
+      const source = readAppFile(path)
+      expect(source).not.toContain("import('posthog-js')")
+      expect(source).not.toContain("from 'posthog-js'")
+      expect(source).toContain('captureBrowserEvent')
+    }
+  })
+
   test('Google Ads library is not preloaded on the first-paint path', () => {
     const tag = readAppFile('src/components/GoogleAdsTag.tsx')
     const layout = readAppFile('src/app/layout.tsx')

--- a/apps/landing/src/app/performance-contracts.test.ts
+++ b/apps/landing/src/app/performance-contracts.test.ts
@@ -23,13 +23,28 @@ describe('landing performance contracts', () => {
   })
 
   test('browser instrumentation defers PostHog out of the initial module graph', () => {
-    const source = readAppFile('instrumentation-client.ts')
-    const posthogKeyGuard = source.indexOf('if (!posthogKey)')
-    const posthogImport = source.indexOf("import('posthog-js')")
+    const instrumentation = readAppFile('instrumentation-client.ts')
+    const initializer = readAppFile('src/lib/analytics/initBrowserPostHog.ts')
+    const posthogKeyGuard = initializer.indexOf('if (!posthogKey)')
+    const posthogImport = initializer.indexOf("import('posthog-js')")
 
-    expect(source).not.toContain("import posthog from 'posthog-js'")
+    expect(instrumentation).not.toContain("import posthog from 'posthog-js'")
+    expect(instrumentation).not.toContain("import('posthog-js')")
+    expect(instrumentation).toContain('scheduleAfterLoadIdle(initPostHog)')
+    expect(initializer).not.toContain("import posthog from 'posthog-js'")
     expect(posthogKeyGuard).toBeGreaterThan(-1)
+    expect(initializer.indexOf('dependencies.importPostHog()')).toBeGreaterThan(posthogKeyGuard)
     expect(posthogImport).toBeGreaterThan(posthogKeyGuard)
+  })
+
+  test('Google Ads library is not preloaded on the first-paint path', () => {
+    const tag = readAppFile('src/components/GoogleAdsTag.tsx')
+    const layout = readAppFile('src/app/layout.tsx')
+
+    expect(tag).toContain('www.googletagmanager.com/gtag/js')
+    expect(tag).toContain('strategy="afterInteractive"')
+    expect(tag).toContain('strategy="lazyOnload"')
+    expect(layout).toContain("process.env.NODE_ENV === 'production' ? <GoogleAdsTag /> : null")
   })
 
   test('production builds upload PostHog source maps when credentials are available', () => {

--- a/apps/landing/src/components/GoogleAdsTag.test.tsx
+++ b/apps/landing/src/components/GoogleAdsTag.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+import { Children, isValidElement, type ReactElement } from 'react'
+import { GOOGLE_ADS_ID } from '@/lib/analytics/googleAds'
+import { GoogleAdsTag } from './GoogleAdsTag'
+
+interface ScriptProps {
+  id?: string
+  src?: string
+  strategy?: string
+  children?: string
+}
+
+function googleAdsScripts() {
+  const tree = GoogleAdsTag() as ReactElement<{ children?: unknown }>
+  return Children.toArray(tree.props.children).filter(isValidElement) as ReactElement<ScriptProps>[]
+}
+
+describe('GoogleAdsTag', () => {
+  test('bootstraps the gtag queue before loading the Ads library on idle', () => {
+    const [queue, library] = googleAdsScripts()
+
+    expect(queue?.props.id).toBe('google-ads-tag')
+    expect(queue?.props.strategy).toBe('afterInteractive')
+    expect(queue?.props.src).toBeUndefined()
+    expect(queue?.props.children).toContain('window.dataLayer = window.dataLayer || []')
+    expect(queue?.props.children).toContain('window.gtag = window.gtag || gtag')
+    expect(queue?.props.children).toContain(`gtag('config', '${GOOGLE_ADS_ID}')`)
+
+    expect(library?.props.src).toBe(`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ADS_ID}`)
+    expect(library?.props.strategy).toBe('lazyOnload')
+  })
+})

--- a/apps/landing/src/components/GoogleAdsTag.tsx
+++ b/apps/landing/src/components/GoogleAdsTag.tsx
@@ -13,7 +13,7 @@ gtag('config', '${GOOGLE_ADS_ID}');`}
       </Script>
       <Script
         src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ADS_ID}`}
-        strategy="afterInteractive"
+        strategy="lazyOnload"
       />
     </>
   )

--- a/apps/landing/src/components/ThemeSwitch.tsx
+++ b/apps/landing/src/components/ThemeSwitch.tsx
@@ -2,6 +2,7 @@
 
 import * as RadioGroupPrimitives from '@radix-ui/react-radio-group'
 import { RiMoonLine, RiSunLine } from '@remixicon/react'
+import { captureBrowserEvent } from '@repo/shared/analytics/browserPostHog'
 import { useTheme } from 'next-themes'
 import { useSyncExternalStore } from 'react'
 import { applyThemeWithTransition } from '@/lib/theme-transition'
@@ -46,17 +47,11 @@ function ThemeSwitch() {
 
     applyThemeWithTransition(() => setTheme(value))
 
-    import('posthog-js')
-      .then(({ default: posthog }) => {
-        posthog.capture('footer_theme_changed', {
-          from_theme: fromTheme,
-          to_theme: value,
-          location: 'navbar'
-        })
-      })
-      .catch(() => {
-        /* analytics failures shouldn't block theme changes */
-      })
+    captureBrowserEvent('footer_theme_changed', {
+      from_theme: fromTheme,
+      to_theme: value,
+      location: 'navbar'
+    })
   }
 
   return (

--- a/apps/landing/src/lib/analytics/initBrowserPostHog.test.ts
+++ b/apps/landing/src/lib/analytics/initBrowserPostHog.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { createBrowserPostHogInitializer } from './initBrowserPostHog'
+
+function createDependencies(overrides?: {
+  key?: string | undefined
+  host?: string
+  debug?: boolean
+}) {
+  const posthog = { init: mock(() => undefined) }
+  const importPostHog = mock(() => Promise.resolve({ default: posthog }))
+
+  return {
+    posthog,
+    importPostHog,
+    dependencies: {
+      getKey: () => overrides?.key,
+      getHost: () => overrides?.host,
+      isDebug: () => overrides?.debug ?? false,
+      importPostHog
+    }
+  }
+}
+
+describe('createBrowserPostHogInitializer', () => {
+  test('does not import PostHog until init runs', () => {
+    const { importPostHog, dependencies } = createDependencies({ key: 'phc_test' })
+    createBrowserPostHogInitializer(dependencies)
+
+    expect(importPostHog).not.toHaveBeenCalled()
+  })
+
+  test('skips the dynamic import when no key is configured', async () => {
+    const { importPostHog, posthog, dependencies } = createDependencies({ key: undefined })
+    const init = createBrowserPostHogInitializer(dependencies)
+
+    await init()
+
+    expect(importPostHog).not.toHaveBeenCalled()
+    expect(posthog.init).not.toHaveBeenCalled()
+  })
+
+  test('imports and initializes PostHog exactly once', async () => {
+    const { importPostHog, posthog, dependencies } = createDependencies({
+      key: 'phc_test',
+      host: 'https://us.i.posthog.com',
+      debug: false
+    })
+    const init = createBrowserPostHogInitializer(dependencies)
+
+    await Promise.all([init(), init()])
+    await init()
+
+    expect(importPostHog).toHaveBeenCalledTimes(1)
+    expect(posthog.init).toHaveBeenCalledTimes(1)
+    expect(posthog.init.mock.calls[0]?.[0]).toBe('phc_test')
+    expect(posthog.init.mock.calls[0]?.[1]).toMatchObject({
+      api_host: '/ingest',
+      ui_host: 'https://us.i.posthog.com',
+      capture_exceptions: true,
+      capture_performance: false,
+      debug: false
+    })
+  })
+
+  test('does not retry after a failed dynamic import', async () => {
+    const importPostHog = mock(() => Promise.reject(new Error('offline')))
+    const init = createBrowserPostHogInitializer({
+      getKey: () => 'phc_test',
+      getHost: () => undefined,
+      isDebug: () => false,
+      importPostHog
+    })
+
+    await expect(init()).rejects.toThrow('offline')
+    await expect(init()).resolves.toBeUndefined()
+    expect(importPostHog).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/landing/src/lib/analytics/initBrowserPostHog.test.ts
+++ b/apps/landing/src/lib/analytics/initBrowserPostHog.test.ts
@@ -1,22 +1,65 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { createBrowserPostHogCapture } from '@repo/shared/analytics/browserPostHog'
 import { createBrowserPostHogInitializer } from './initBrowserPostHog'
+import { type AfterLoadIdleHost, scheduleAfterLoadIdle } from './scheduleAfterLoadIdle'
 
 function createDependencies(overrides?: {
   key?: string | undefined
   host?: string
   debug?: boolean
 }) {
-  const posthog = { init: mock(() => undefined) }
+  const posthog = {
+    init: mock(() => undefined),
+    capture: mock(() => undefined)
+  }
   const importPostHog = mock(() => Promise.resolve({ default: posthog }))
+  const captureSeam = createBrowserPostHogCapture()
 
   return {
     posthog,
     importPostHog,
+    captureSeam,
     dependencies: {
       getKey: () => overrides?.key,
       getHost: () => overrides?.host,
       isDebug: () => overrides?.debug ?? false,
-      importPostHog
+      importPostHog,
+      captureSeam
+    }
+  }
+}
+
+function createLoadIdleHost(readyState: DocumentReadyState) {
+  const loadListeners: Array<() => void> = []
+  const idleCallbacks: Array<() => void> = []
+
+  const host: AfterLoadIdleHost = {
+    document: { readyState },
+    addLoadListener(listener) {
+      loadListeners.push(listener)
+    },
+    requestIdleCallback(callback) {
+      idleCallbacks.push(callback)
+      return 0
+    },
+    setTimeout(callback) {
+      idleCallbacks.push(callback)
+      return 0
+    }
+  }
+
+  return {
+    host,
+    fireLoad() {
+      for (const listener of loadListeners) {
+        listener()
+      }
+    },
+    fireIdle() {
+      const callbacks = idleCallbacks.splice(0)
+      for (const callback of callbacks) {
+        callback()
+      }
     }
   }
 }
@@ -30,13 +73,18 @@ describe('createBrowserPostHogInitializer', () => {
   })
 
   test('skips the dynamic import when no key is configured', async () => {
-    const { importPostHog, posthog, dependencies } = createDependencies({ key: undefined })
+    const { importPostHog, posthog, captureSeam, dependencies } = createDependencies({
+      key: undefined
+    })
     const init = createBrowserPostHogInitializer(dependencies)
 
+    captureSeam.capture('page_engaged', { page_path: '/en' })
     await init()
+    captureSeam.capture('page_scroll_depth', { depth: 25 })
 
     expect(importPostHog).not.toHaveBeenCalled()
     expect(posthog.init).not.toHaveBeenCalled()
+    expect(posthog.capture).not.toHaveBeenCalled()
   })
 
   test('imports and initializes PostHog exactly once', async () => {
@@ -64,15 +112,58 @@ describe('createBrowserPostHogInitializer', () => {
 
   test('does not retry after a failed dynamic import', async () => {
     const importPostHog = mock(() => Promise.reject(new Error('offline')))
+    const posthog = {
+      init: mock(() => undefined),
+      capture: mock(() => undefined)
+    }
+    const captureSeam = createBrowserPostHogCapture()
     const init = createBrowserPostHogInitializer({
       getKey: () => 'phc_test',
       getHost: () => undefined,
       isDebug: () => false,
-      importPostHog
+      importPostHog,
+      captureSeam
     })
 
-    await expect(init()).rejects.toThrow('offline')
+    captureSeam.capture('about_social_clicked', { platform: 'github' })
     await expect(init()).resolves.toBeUndefined()
+    await expect(init()).resolves.toBeUndefined()
+    captureSeam.capture('page_engaged', { page_path: '/en' })
+
     expect(importPostHog).toHaveBeenCalledTimes(1)
+    expect(posthog.capture).not.toHaveBeenCalled()
+  })
+
+  test('delivers captures queued before the load/idle boundary exactly once after init', async () => {
+    const { importPostHog, posthog, captureSeam, dependencies } = createDependencies({
+      key: 'phc_test'
+    })
+    const init = createBrowserPostHogInitializer(dependencies)
+    const env = createLoadIdleHost('loading')
+    let inFlight: Promise<void> | undefined
+
+    scheduleAfterLoadIdle(() => {
+      inFlight = init()
+    }, env.host)
+
+    captureSeam.capture('footer_theme_changed', { location: 'navbar' })
+    captureSeam.capture('page_scroll_depth', { depth: 25, page_path: '/en' })
+
+    expect(importPostHog).not.toHaveBeenCalled()
+    expect(posthog.capture).not.toHaveBeenCalled()
+
+    env.fireLoad()
+    env.fireIdle()
+    await inFlight
+
+    expect(importPostHog).toHaveBeenCalledTimes(1)
+    expect(posthog.init).toHaveBeenCalledTimes(1)
+    expect(posthog.capture.mock.calls).toEqual([
+      ['footer_theme_changed', { location: 'navbar' }],
+      ['page_scroll_depth', { depth: 25, page_path: '/en' }]
+    ])
+
+    captureSeam.capture('page_engaged', { page_path: '/en', duration_seconds: 10 })
+    expect(posthog.capture).toHaveBeenCalledTimes(3)
   })
 })

--- a/apps/landing/src/lib/analytics/initBrowserPostHog.ts
+++ b/apps/landing/src/lib/analytics/initBrowserPostHog.ts
@@ -1,0 +1,41 @@
+import { createPostHogConfig } from './posthogConfig'
+
+interface PostHogClient {
+  init: (apiKey: string, config: ReturnType<typeof createPostHogConfig>) => void
+}
+
+export interface BrowserPostHogDependencies {
+  getKey: () => string | undefined
+  getHost: () => string | undefined
+  isDebug: () => boolean
+  importPostHog: () => Promise<{ default: PostHogClient }>
+}
+
+export function createBrowserPostHogInitializer(dependencies: BrowserPostHogDependencies) {
+  let started = false
+
+  return async function initBrowserPostHog() {
+    if (started) {
+      return
+    }
+
+    const posthogKey = dependencies.getKey()
+    if (!posthogKey) {
+      return
+    }
+
+    started = true
+
+    const { default: posthog } = await dependencies.importPostHog()
+    posthog.init(posthogKey, createPostHogConfig(dependencies.getHost(), dependencies.isDebug()))
+  }
+}
+
+export function createProductionBrowserPostHogInitializer() {
+  return createBrowserPostHogInitializer({
+    getKey: () => process.env.NEXT_PUBLIC_POSTHOG_KEY,
+    getHost: () => process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    isDebug: () => process.env.NODE_ENV === 'development',
+    importPostHog: () => import('posthog-js')
+  })
+}

--- a/apps/landing/src/lib/analytics/initBrowserPostHog.ts
+++ b/apps/landing/src/lib/analytics/initBrowserPostHog.ts
@@ -1,7 +1,14 @@
+import {
+  type BrowserEventProperties,
+  type BrowserPostHogCaptureSeam,
+  markBrowserPostHogFailed,
+  markBrowserPostHogReady
+} from '@repo/shared/analytics/browserPostHog'
 import { createPostHogConfig } from './posthogConfig'
 
 interface PostHogClient {
   init: (apiKey: string, config: ReturnType<typeof createPostHogConfig>) => void
+  capture: (event: string, properties?: BrowserEventProperties) => unknown
 }
 
 export interface BrowserPostHogDependencies {
@@ -9,10 +16,17 @@ export interface BrowserPostHogDependencies {
   getHost: () => string | undefined
   isDebug: () => boolean
   importPostHog: () => Promise<{ default: PostHogClient }>
+  captureSeam?: BrowserPostHogCaptureSeam
+}
+
+const defaultCaptureSeam: BrowserPostHogCaptureSeam = {
+  markReady: markBrowserPostHogReady,
+  markFailed: markBrowserPostHogFailed
 }
 
 export function createBrowserPostHogInitializer(dependencies: BrowserPostHogDependencies) {
   let started = false
+  const captureSeam = dependencies.captureSeam ?? defaultCaptureSeam
 
   return async function initBrowserPostHog() {
     if (started) {
@@ -21,13 +35,20 @@ export function createBrowserPostHogInitializer(dependencies: BrowserPostHogDepe
 
     const posthogKey = dependencies.getKey()
     if (!posthogKey) {
+      started = true
+      captureSeam.markFailed()
       return
     }
 
     started = true
 
-    const { default: posthog } = await dependencies.importPostHog()
-    posthog.init(posthogKey, createPostHogConfig(dependencies.getHost(), dependencies.isDebug()))
+    try {
+      const { default: posthog } = await dependencies.importPostHog()
+      posthog.init(posthogKey, createPostHogConfig(dependencies.getHost(), dependencies.isDebug()))
+      captureSeam.markReady(posthog)
+    } catch {
+      captureSeam.markFailed()
+    }
   }
 }
 

--- a/apps/landing/src/lib/analytics/scheduleAfterLoadIdle.test.ts
+++ b/apps/landing/src/lib/analytics/scheduleAfterLoadIdle.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  type AfterLoadIdleHost,
+  ANALYTICS_IDLE_TIMEOUT_MS,
+  scheduleAfterLoadIdle
+} from './scheduleAfterLoadIdle'
+
+function createHost(readyState: DocumentReadyState, withIdleCallback = true) {
+  const loadListeners: Array<() => void> = []
+  const idleCallbacks: Array<() => void> = []
+  const timeouts: Array<() => void> = []
+  const idleOptions: Array<{ timeout?: number } | undefined> = []
+
+  const host: AfterLoadIdleHost = {
+    document: { readyState },
+    addLoadListener(listener) {
+      loadListeners.push(listener)
+    },
+    setTimeout(callback) {
+      timeouts.push(callback)
+      return 0
+    }
+  }
+
+  if (withIdleCallback) {
+    host.requestIdleCallback = (callback, options) => {
+      idleCallbacks.push(callback)
+      idleOptions.push(options)
+      return 0
+    }
+  }
+
+  return {
+    host,
+    idleOptions,
+    fireLoad() {
+      for (const listener of loadListeners) {
+        listener()
+      }
+    },
+    fireIdle() {
+      const callbacks = idleCallbacks.splice(0)
+      for (const callback of callbacks) {
+        callback()
+      }
+    },
+    fireTimeout() {
+      const callbacks = timeouts.splice(0)
+      for (const callback of callbacks) {
+        callback()
+      }
+    },
+    loadCount: () => loadListeners.length,
+    idleCount: () => idleCallbacks.length,
+    timeoutCount: () => timeouts.length
+  }
+}
+
+describe('scheduleAfterLoadIdle', () => {
+  test('waits for window load and idle time before running', () => {
+    const calls: string[] = []
+    const env = createHost('loading')
+
+    scheduleAfterLoadIdle(() => {
+      calls.push('ran')
+    }, env.host)
+
+    expect(calls).toEqual([])
+    expect(env.loadCount()).toBe(1)
+    expect(env.idleCount()).toBe(0)
+
+    env.fireLoad()
+    expect(calls).toEqual([])
+    expect(env.idleCount()).toBe(1)
+
+    env.fireIdle()
+    expect(calls).toEqual(['ran'])
+  })
+
+  test('schedules idle work immediately when the module loads after window.load', () => {
+    const calls: string[] = []
+    const env = createHost('complete')
+
+    scheduleAfterLoadIdle(() => {
+      calls.push('ran')
+    }, env.host)
+
+    expect(env.loadCount()).toBe(0)
+    expect(env.idleCount()).toBe(1)
+    expect(calls).toEqual([])
+
+    env.fireIdle()
+    expect(calls).toEqual(['ran'])
+  })
+
+  test('falls back to setTimeout when requestIdleCallback is missing', () => {
+    const calls: string[] = []
+    const env = createHost('complete', false)
+
+    scheduleAfterLoadIdle(() => {
+      calls.push('ran')
+    }, env.host)
+
+    expect(env.idleCount()).toBe(0)
+    expect(env.timeoutCount()).toBe(1)
+    expect(calls).toEqual([])
+
+    env.fireTimeout()
+    expect(calls).toEqual(['ran'])
+  })
+
+  test('falls back after load when requestIdleCallback is missing before load', () => {
+    const calls: string[] = []
+    const env = createHost('interactive', false)
+
+    scheduleAfterLoadIdle(() => {
+      calls.push('ran')
+    }, env.host)
+
+    env.fireLoad()
+    expect(calls).toEqual([])
+    expect(env.timeoutCount()).toBe(1)
+
+    env.fireTimeout()
+    expect(calls).toEqual(['ran'])
+  })
+
+  test('runs the task exactly once if load and idle are delivered twice', () => {
+    const calls: string[] = []
+    const env = createHost('loading')
+
+    scheduleAfterLoadIdle(() => {
+      calls.push('ran')
+    }, env.host)
+
+    env.fireLoad()
+    env.fireLoad()
+    env.fireIdle()
+    env.fireIdle()
+
+    expect(calls).toEqual(['ran'])
+  })
+
+  test('swallows sync and async task failures', async () => {
+    const env = createHost('complete')
+
+    expect(() => {
+      scheduleAfterLoadIdle(() => {
+        throw new Error('sync analytics failure')
+      }, env.host)
+      env.fireIdle()
+    }).not.toThrow()
+
+    let rejected = false
+    scheduleAfterLoadIdle(() => {
+      rejected = true
+      return Promise.reject(new Error('async analytics failure'))
+    }, env.host)
+    env.fireIdle()
+
+    await Promise.resolve()
+    expect(rejected).toBe(true)
+  })
+
+  test('asks for idle time with a timeout so analytics is not starved', () => {
+    const env = createHost('complete')
+
+    scheduleAfterLoadIdle(() => undefined, env.host)
+
+    expect(env.idleOptions).toEqual([{ timeout: ANALYTICS_IDLE_TIMEOUT_MS }])
+  })
+})

--- a/apps/landing/src/lib/analytics/scheduleAfterLoadIdle.ts
+++ b/apps/landing/src/lib/analytics/scheduleAfterLoadIdle.ts
@@ -1,0 +1,64 @@
+export const ANALYTICS_IDLE_TIMEOUT_MS = 2000
+const IDLE_FALLBACK_DELAY_MS = 1
+
+export interface AfterLoadIdleHost {
+  document: Pick<Document, 'readyState'>
+  addLoadListener: (listener: () => void) => void
+  requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => unknown
+  setTimeout: (callback: () => void, delay: number) => unknown
+}
+
+function createBrowserAfterLoadIdleHost(): AfterLoadIdleHost {
+  return {
+    document,
+    addLoadListener(listener) {
+      window.addEventListener('load', listener, { once: true })
+    },
+    requestIdleCallback:
+      typeof window.requestIdleCallback === 'function'
+        ? (callback, options) => window.requestIdleCallback(callback, options)
+        : undefined,
+    setTimeout: (callback, delay) => {
+      window.setTimeout(callback, delay)
+    }
+  }
+}
+
+export function scheduleAfterLoadIdle(task: () => unknown, host?: AfterLoadIdleHost) {
+  const runtime = host ?? createBrowserAfterLoadIdleHost()
+  let started = false
+
+  const run = () => {
+    if (started) {
+      return
+    }
+
+    started = true
+
+    try {
+      const result = task()
+      if (result instanceof Promise) {
+        result.catch(() => undefined)
+      }
+    } catch {
+      // Analytics failures should not throw into the page.
+    }
+  }
+
+  const runWhenIdle = () => {
+    if (runtime.requestIdleCallback) {
+      runtime.requestIdleCallback(run, { timeout: ANALYTICS_IDLE_TIMEOUT_MS })
+      return
+    }
+
+    runtime.setTimeout(run, IDLE_FALLBACK_DELAY_MS)
+  }
+
+  if (runtime.document.readyState === 'complete') {
+    // Client modules can evaluate after window.load; still idle-init in that case.
+    runWhenIdle()
+    return
+  }
+
+  runtime.addLoadListener(runWhenIdle)
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,6 +8,7 @@
     "./i18n/server": "./src/i18n/server.ts",
     "./i18n/settings": "./src/i18n/settings.ts",
     "./utils": "./src/utils.ts",
+    "./analytics/browserPostHog": "./src/analytics/browserPostHog.ts",
     "./components/I18nProvider": "./src/components/I18nProvider.tsx",
     "./components/LenisProvider": "./src/components/LenisProvider.tsx",
     "./components/AnalyticsTracker": "./src/components/AnalyticsTracker.tsx",

--- a/packages/shared/src/analytics/browserPostHog.test.ts
+++ b/packages/shared/src/analytics/browserPostHog.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+import { createBrowserPostHogCapture } from './browserPostHog'
+
+describe('browser PostHog capture queue', () => {
+  test('queues captures until ready and flushes them once in order', () => {
+    const capture = mock(() => undefined)
+    const queue = createBrowserPostHogCapture()
+
+    queue.capture('footer_theme_changed', { location: 'navbar' })
+    queue.capture('page_scroll_depth', { depth: 25, page_path: '/en' })
+
+    expect(capture).not.toHaveBeenCalled()
+
+    queue.markReady({ capture })
+    queue.markReady({ capture })
+
+    expect(capture.mock.calls).toEqual([
+      ['footer_theme_changed', { location: 'navbar' }],
+      ['page_scroll_depth', { depth: 25, page_path: '/en' }]
+    ])
+
+    queue.capture('page_engaged', { page_path: '/en', duration_seconds: 10 })
+
+    expect(capture.mock.calls).toEqual([
+      ['footer_theme_changed', { location: 'navbar' }],
+      ['page_scroll_depth', { depth: 25, page_path: '/en' }],
+      ['page_engaged', { page_path: '/en', duration_seconds: 10 }]
+    ])
+  })
+
+  test('drops queued and later captures after initialization failure', () => {
+    const capture = mock(() => undefined)
+    const queue = createBrowserPostHogCapture()
+
+    queue.capture('about_social_clicked', { platform: 'github' })
+    queue.markFailed()
+    queue.markReady({ capture })
+    queue.capture('page_engaged', { page_path: '/en' })
+
+    expect(capture).not.toHaveBeenCalled()
+  })
+
+  test('does not deliver duplicates when markFailed is repeated after ready', () => {
+    const capture = mock(() => undefined)
+    const queue = createBrowserPostHogCapture()
+
+    queue.capture('page_engaged', { duration_seconds: 10 })
+    queue.markReady({ capture })
+    queue.markFailed()
+    queue.markFailed()
+
+    expect(capture).toHaveBeenCalledTimes(1)
+  })
+
+  test('keeps flushing remaining events when one capture throws', () => {
+    const capture = mock((event: string) => {
+      if (event === 'footer_theme_changed') {
+        throw new Error('capture failed')
+      }
+    })
+    const queue = createBrowserPostHogCapture()
+
+    queue.capture('footer_theme_changed', { location: 'navbar' })
+    queue.capture('page_scroll_depth', { depth: 50 })
+
+    expect(() => queue.markReady({ capture })).not.toThrow()
+    expect(capture.mock.calls.map((call) => call[0])).toEqual([
+      'footer_theme_changed',
+      'page_scroll_depth'
+    ])
+  })
+})

--- a/packages/shared/src/analytics/browserPostHog.ts
+++ b/packages/shared/src/analytics/browserPostHog.ts
@@ -1,0 +1,90 @@
+export type BrowserCaptureEvent =
+  | 'about_social_clicked'
+  | 'footer_theme_changed'
+  | 'page_engaged'
+  | 'page_scroll_depth'
+
+export type BrowserEventPropertyValue = string | number | boolean | null | undefined
+
+export type BrowserEventProperties = Record<string, BrowserEventPropertyValue>
+
+export interface PostHogCaptureClient {
+  capture: (event: string, properties?: BrowserEventProperties) => unknown
+}
+
+export interface BrowserPostHogCaptureSeam {
+  markReady: (client: PostHogCaptureClient) => void
+  markFailed: () => void
+}
+
+interface QueuedCapture {
+  event: string
+  properties?: BrowserEventProperties
+}
+
+type CaptureState =
+  | { kind: 'pending'; queue: QueuedCapture[] }
+  | { kind: 'ready'; client: PostHogCaptureClient }
+  | { kind: 'failed' }
+
+function deliver(client: PostHogCaptureClient, event: string, properties?: BrowserEventProperties) {
+  try {
+    client.capture(event, properties)
+  } catch {
+    // Analytics failures should never break the page.
+  }
+}
+
+// posthog-js 1.336.4 does not queue capture() before init.
+export function createBrowserPostHogCapture() {
+  let state: CaptureState = { kind: 'pending', queue: [] }
+
+  return {
+    capture(event: string, properties?: BrowserEventProperties) {
+      if (state.kind === 'ready') {
+        deliver(state.client, event, properties)
+        return
+      }
+
+      if (state.kind === 'pending') {
+        state.queue.push({ event, properties })
+      }
+    },
+    markReady(client: PostHogCaptureClient) {
+      if (state.kind !== 'pending') {
+        return
+      }
+
+      const queued = state.queue.splice(0)
+      state = { kind: 'ready', client }
+
+      for (const item of queued) {
+        deliver(client, item.event, item.properties)
+      }
+    },
+    markFailed() {
+      if (state.kind !== 'pending') {
+        return
+      }
+
+      state = { kind: 'failed' }
+    }
+  }
+}
+
+const browserPostHogCapture = createBrowserPostHogCapture()
+
+export function captureBrowserEvent(
+  event: BrowserCaptureEvent,
+  properties?: BrowserEventProperties
+) {
+  browserPostHogCapture.capture(event, properties)
+}
+
+export function markBrowserPostHogReady(client: PostHogCaptureClient) {
+  browserPostHogCapture.markReady(client)
+}
+
+export function markBrowserPostHogFailed() {
+  browserPostHogCapture.markFailed()
+}

--- a/packages/shared/src/hooks/usePageEngaged.ts
+++ b/packages/shared/src/hooks/usePageEngaged.ts
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 
+import { captureBrowserEvent } from '../analytics/browserPostHog'
 import { createPageEngagementTracker, ENGAGE_THRESHOLD_MS } from '../analytics/pageTracking'
 
 export function usePageEngaged(pagePath: string) {
@@ -10,11 +11,9 @@ export function usePageEngaged(pagePath: string) {
       pagePath,
       Date.now(),
       (duration, trackedPagePath) => {
-        import('posthog-js').then(({ default: posthog }) => {
-          posthog.capture('page_engaged', {
-            page_path: trackedPagePath,
-            duration_seconds: duration
-          })
+        captureBrowserEvent('page_engaged', {
+          page_path: trackedPagePath,
+          duration_seconds: duration
         })
       }
     )

--- a/packages/shared/src/hooks/useScrollDepth.ts
+++ b/packages/shared/src/hooks/useScrollDepth.ts
@@ -2,16 +2,15 @@
 
 import { useEffect } from 'react'
 
+import { captureBrowserEvent } from '../analytics/browserPostHog'
 import { createScrollDepthTracker } from '../analytics/pageTracking'
 
 export function useScrollDepth(pagePath: string) {
   useEffect(() => {
     const tracker = createScrollDepthTracker(pagePath, (depth, trackedPagePath) => {
-      import('posthog-js').then(({ default: posthog }) => {
-        posthog.capture('page_scroll_depth', {
-          depth,
-          page_path: trackedPagePath
-        })
+      captureBrowserEvent('page_scroll_depth', {
+        depth,
+        page_path: trackedPagePath
       })
     })
 


### PR DESCRIPTION
## Summary

- defer PostHog init until after `window.load` plus idle time so `posthog-js` stays out of the first-paint module graph
- load the Google Ads library with `lazyOnload` so Next.js does not preload `gtag/js`
- queue browser capture events until PostHog is ready, then flush them once in order
- route ThemeSwitch, About social clicks, page engagement, and scroll depth through one shared capture seam

## Validation

- 24 focused Bun tests passed (`performance-contracts`, Google Ads tag, PostHog init, idle scheduler, capture queue)